### PR TITLE
Fix URL construction on Windows platforms

### DIFF
--- a/packages/http/src/router.ts
+++ b/packages/http/src/router.ts
@@ -24,13 +24,13 @@ import {
 // @ts-ignore
 import formidable from 'formidable';
 import { IncomingMessage } from 'http';
-import { join } from 'path';
 import querystring from 'querystring';
 import { httpClass } from './decorator';
 import { HttpRequest, HttpRequestQuery, HttpRequestResolvedParameters } from './model';
 import { BasicInjector, injectable, NormalizedProvider, Tag, TagProvider, TagRegistry } from '@deepkit/injector';
 import { Logger } from '@deepkit/logger';
 import { HttpControllers } from './controllers';
+import { resolveUrl } from './utils';
 
 export type RouteParameterResolverForInjector = ((injector: BasicInjector) => any[] | Promise<any[]>);
 type ResolvedController = { parameters: RouteParameterResolverForInjector, routeConfig: RouteConfig, uploadedFiles: { [name: string]: UploadedFile } };
@@ -134,7 +134,7 @@ export class RouteConfig {
     }
 
     getFullPath(): string {
-        let path = this.baseUrl ? join(this.baseUrl, this.path) : this.path;
+        let path = this.baseUrl ? resolveUrl(this.baseUrl, this.path) : this.path;
         if (!path.startsWith('/')) path = '/' + path;
         return path;
     }

--- a/packages/http/src/utils.ts
+++ b/packages/http/src/utils.ts
@@ -5,3 +5,12 @@ export function normalizeDirectory(path: string): string {
     if (path[path.length - 1] !== '/') path = path + '/';
     return path;
 }
+
+export function resolveUrl(from: string, to: string) {
+    const resolvedUrl = new URL(to, new URL(from, 'resolve://'));
+    if (resolvedUrl.protocol === 'resolve:') {
+      const { pathname, search, hash } = resolvedUrl;
+      return pathname + search + hash;
+    }
+    return resolvedUrl.toString();
+  }

--- a/packages/http/src/utils.ts
+++ b/packages/http/src/utils.ts
@@ -9,8 +9,8 @@ export function normalizeDirectory(path: string): string {
 export function resolveUrl(from: string, to: string) {
     const resolvedUrl = new URL(to, new URL(from, 'resolve://'));
     if (resolvedUrl.protocol === 'resolve:') {
-      const { pathname, search, hash } = resolvedUrl;
-      return pathname + search + hash;
+        const { pathname, search, hash } = resolvedUrl;
+        return pathname + search + hash;
     }
     return resolvedUrl.toString();
-  }
+}


### PR DESCRIPTION
The `path.join` function in Node uses a platform-dependent directory separator character. Since it is intended for file system paths, using it on a URL may not work. The path portion of a URL is always separated from the baseName by a forward-slash.

This PR adds a `resolveUrl` function to `utils.ts` which uses the WHATWG URL API to construct the full URL. The `resolveUrl` function is adapted from the example [found in the Node.js documentation](https://nodejs.org/api/url.html#url_url_resolve_from_to).