### PR TITLE
(fix) jest tests complain TextDecoder is undefined

### DIFF
--- a/packages/bson/src/bson-parser.ts
+++ b/packages/bson/src/bson-parser.ts
@@ -8,10 +8,12 @@
  * You should have received a copy of the MIT License along with this program.
  */
 
+import { TextDecoder } from 'util';
 import { BSON_BINARY_SUBTYPE_BIGINT, BSON_BINARY_SUBTYPE_BYTE_ARRAY, BSON_BINARY_SUBTYPE_UUID, BSONType, digitByteSize, TWO_PWR_32_DBL_N } from './utils';
 import { buildStringDecoder, decodeUTF8 } from './strings';
 import { nodeBufferToArrayBuffer, PropertySchema, typedArrayNamesMap } from '@deepkit/type';
 import { hexTable } from './model';
+
 
 declare var Buffer: any;
 

--- a/packages/bson/src/strings.ts
+++ b/packages/bson/src/strings.ts
@@ -9,6 +9,7 @@
  */
 
 import { CompilerContext } from '@deepkit/core';
+import { TextDecoder } from 'util';
 
 const decoder = new TextDecoder("utf-8");
 export function decodeUTF8(buffer: Uint8Array, off: number = 0, end: number) {


### PR DESCRIPTION
```
   ReferenceError: TextDecoder is not defined

      12 | import { Collection } from "mongodb";
      13 | import { t } from "@deepkit/type";
    > 14 | import { getBSONDecoder } from "@deepkit/bson";
         | ^
      15 | import {
      16 |   manyToMany,
      17 |   manyToOne,

      at Object.<anonymous> (node_modules/@deepkit/bson/src/bson-parser.ts:312:23)
      at Object.<anonymous> (node_modules/@deepkit/bson/src/bson-jit-parser.ts:13:1)
      at Object.<anonymous> (node_modules/@deepkit/bson/index.ts:11:1)
      at Object.<anonymous> (src/__tests__/integration/index.ts:14:1)
      at Object.<anonymous> (src/__tests__/index.ts:1:1)
      at processTicksAndRejections (node:internal/process/task_queues:94:5)

Test Suites: 1 failed, 1 total
```

Using: Node v15.12.0. 
This is only happening when running jest tests. I confirm it works when running with `ts-node` no clue why would TS do this to be honest, but adding `require()` in the compiled js folders solved it.