### PR TITLE
feat: conditionally start the http listener based on presence of routes, rpc and publicDir

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
             --ignore @deepkit/framework-examples \
             --ignore @deepkit/benchmark \
             --ignore @deepkit/mysql --ignore @deepkit/postgres \
-            --ignore @deepkit/orm-browser-examples \
+            --ignore @deepkit/orm-browser-example \
             --ignore @deepkit/orm-browser;
           ./node_modules/.bin/npm-local-development --no-watcher
       - name: Build

--- a/packages/framework/src/cli/server-start.ts
+++ b/packages/framework/src/cli/server-start.ts
@@ -13,10 +13,10 @@ import { cli, Command, flag } from '@deepkit/app';
 import { InjectorContext } from '@deepkit/injector';
 import { Logger, TimestampFormatter } from '@deepkit/logger';
 
-@cli.controller('server:listen', {
-    description: 'Starts the HTTP server'
+@cli.controller('server:start', {
+    description: 'Starts the application server. If HTTP or RPC controllers or a publicDir are provided this will include an HTTP listener'
 })
-export class ServerListenController implements Command {
+export class ServerStartController implements Command {
     constructor(
         protected logger: Logger,
         protected injectorContext: InjectorContext,

--- a/packages/framework/src/kernel.ts
+++ b/packages/framework/src/kernel.ts
@@ -17,7 +17,7 @@ import { BrokerModule } from './broker/broker.module';
 import { LiveDatabase } from './database/live-database';
 import { DebugRouterController } from './cli/debug-router';
 import { DebugDIController } from './cli/debug-di';
-import { ServerListenController } from './cli/server-listen';
+import { ServerStartController } from './cli/server-start';
 import { DebugController } from './debug/debug.controller';
 import { registerDebugHttpController } from './debug/http-debug.controller';
 import { HttpKernel, HttpListener, HttpLogger, HttpModule, Router, serveStaticListener } from '@deepkit/http';
@@ -66,7 +66,7 @@ export const KernelModule = new AppModule({
         DatabaseListener,
     ],
     controllers: [
-        ServerListenController,
+        ServerStartController,
         DebugRouterController,
         DebugDIController,
         DebugDebugFramesCommand,

--- a/packages/framework/tests/application-server.spec.ts
+++ b/packages/framework/tests/application-server.spec.ts
@@ -1,5 +1,5 @@
 import { rpc } from '@deepkit/rpc';
-import { expect, test } from '@jest/globals';
+import { describe, expect, test } from '@jest/globals';
 import 'reflect-metadata';
 import { Application } from '../src/application';
 import { AppModule } from '@deepkit/app';
@@ -8,6 +8,7 @@ import { createTestingApp } from '../src/testing';
 import { ApplicationServer } from '../src/application-server';
 import { Logger, MemoryLoggerTransport } from '@deepkit/logger';
 import { KernelModule } from '../src/kernel';
+import { WebWorker } from '../src/worker';
 
 test('testing app api', async () => {
     @rpc.controller('test')
@@ -90,3 +91,29 @@ test('basic controller', async () => {
 
     await applicationServer.close();
 });
+
+describe('http worker', () => {
+    test('needed for publicDir', async () => {
+        const testing = createTestingApp({
+            controllers: [],
+            imports: [KernelModule.configure({ publicDir: 'public' })]
+        });
+
+        await testing.startServer();
+        const applicationServer = testing.app.get(ApplicationServer);
+        expect(applicationServer.getWorker()).toBeInstanceOf(WebWorker);
+        await testing.stopServer();
+    })
+
+    test('not needed without controllers or publicDir', async () => {
+        const testing = createTestingApp({
+            controllers: [],
+        });
+
+        await testing.startServer();
+        const applicationServer = testing.app.get(ApplicationServer);
+        expect(() => applicationServer.getWorker()).toThrow();
+        await testing.stopServer();
+    })
+})
+


### PR DESCRIPTION
### Summary of changes

Updates the ApplicationServer to determine if an HTTP worker is required based on whether or not the application specifies HTTP controllers/routes, RPC controllers or publicDir

Fixes #117 

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
