### PR TITLE
feat: improvements to env config loading

### DIFF
--- a/packages/api-console/main.ts
+++ b/packages/api-console/main.ts
@@ -14,4 +14,4 @@ const appModule = new AppModule({
     ]
 });
 
-new Application(appModule).loadConfigFromEnvVariables('APP_').run(['server:start']);
+new Application(appModule).loadConfigFromEnv().run(['server:start']);

--- a/packages/app/src/configuration.ts
+++ b/packages/app/src/configuration.ts
@@ -14,6 +14,13 @@ import { existsSync, readFileSync } from 'fs';
 class ConfigOptionNotFound extends Error {
 }
 
+export function resolveEnvFilePath(path: string): string | undefined {
+    const resolvedPath = isAbsolute(path) ? path : findFileUntilPackageRoot(path);
+    if (!resolvedPath || !existsSync(resolvedPath)) return undefined;
+
+    return resolvedPath;
+}
+
 function findFileUntilPackageRoot(fileName: string): string | undefined {
     let dir = process.cwd();
     while (true) {
@@ -35,10 +42,8 @@ export class EnvConfiguration {
      * Reads a .env file from given path, based to basePath.
      */
     public loadEnvFile(path: string): boolean {
-        const resolvedPath = isAbsolute(path) ? path : findFileUntilPackageRoot(path);
-
-        //search up folder until package.json root reached
-        if (!resolvedPath || !existsSync(resolvedPath)) return false;
+        const resolvedPath = resolveEnvFilePath(path);
+        if (!resolvedPath) return false
 
         const RE_INI_KEY_VAL = /^\s*([\w.-]+)\s*=\s*(.*)?\s*$/;
 

--- a/packages/app/tests/test.env
+++ b/packages/app/tests/test.env
@@ -1,2 +1,2 @@
-token=changed5
-base_db=changed6
+APP_TOKEN=changed5
+APP_BASE_DB=changed6


### PR DESCRIPTION
### Summary of changes

- Combines `loadConfigFromEnvFile` and `loadConfigFromEnvVariables` into a simpler unified API with sane defaults for `APP_` prefix and automatic loading of a root `.env` file if it is available

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
