### PR TITLE
feat: expose validators metadata

### DIFF
--- a/packages/type/src/field-decorator.ts
+++ b/packages/type/src/field-decorator.ts
@@ -18,7 +18,7 @@ import validator from 'validator';
 /**
  * @throws PropertyValidatorError when validation invalid
  */
-export type ValidatorFn = (value: any, property: PropertySchema, classType?: ClassType) => void;
+export type ValidatorFn = (value: any, property: PropertySchema, classType?: ClassType, ...args: any[]) => void;
 
 export interface FieldDecoratorResult<T> extends FieldDecoratorResultBase<T> {
     pattern(regex: RegExp): this;

--- a/packages/type/src/model.ts
+++ b/packages/type/src/model.ts
@@ -133,6 +133,8 @@ export interface PropertySchemaSerialized {
 }
 
 export interface PropertyValidator {
+    name?: string;
+    options?: any[];
     /**
      * @throws PropertyValidatorError when validation invalid
      */

--- a/packages/type/tests/validation.spec.ts
+++ b/packages/type/tests/validation.spec.ts
@@ -1001,3 +1001,25 @@ test('decorator metadata are exposed', () => {
     expect(eValidator.name).toBe('FooValidator');
     expect(eValidator.options).toBeUndefined();
 });
+
+test('createValidator result can be validated', () => {
+
+    function xValidator(value: number, property: PropertySchema, classType: ClassType | undefined, x: number) {
+        if (value !== x) throw new PropertyValidatorError('must_be_given_value', `Must be ${x}`);
+    }
+
+    const validator = createValidator('test', xValidator);
+
+    class Model {
+        @t.validator(validator(10))
+        prop: number = 2;
+    }
+
+    expect(validate(Model, { prop: 5 })).toMatchObject([
+        {
+            path: 'prop',
+            code: 'must_be_given_value',
+            message: 'Must be 10'
+        }
+    ]);
+});


### PR DESCRIPTION
### Summary of changes
Basically this PR is an attempt at exposing validator names as well as their arguments if there are any.
To achieve this, the built-in validator names and arguments are directly forwarded to `PropertyValidator`. As for user-defined validator, and in order to prevent breaking changes, I suggest a `createValidator` helper that can take a `ValidatorFn`, and optionally a name, and output a parameterized validator. The signature of `ValidatorFn` has been modified to include user-defined options: `(value: any, property: PropertySchema, classType?: ClassType, ...args: any[])`
```ts
function validatorFn(value: any, property: PropertySchema, classType: ClassType, max: number) {
  if (value > max) throw /* ... */
}

const maximum = createValidator('optionalName', validatorFn);

@t.validator(maximum(10))
```

**If breaking changes are acceptable, the `ValidatorFn` signature could be changed to improve DX.**

Validator metadata are retrievable from `PropertyValidator`.
```ts
const schema = getClassSchema(Model);
const propSchema = schema.getProperty('prop');
const validator = new propSchema.validators[0];
// validator.name
// validator.args
```

If the changes are acceptable, I can proceed to update the docs.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
