### PR TITLE
fix(sql): make GROUP BY/ORDER BY/HAVING use fully qualified column name

### DIFF
--- a/packages/event/src/event.ts
+++ b/packages/event/src/event.ts
@@ -11,6 +11,7 @@
 import { ClassType, CompilerContext, isClass, isFunction } from '@deepkit/core';
 import { ConfigSlice, ConfigToken, InjectorContext, InjectorModule } from '@deepkit/injector';
 import { createClassDecoratorContext, createPropertyDecoratorContext } from '@deepkit/type';
+import '@deepkit/type';
 
 export type EventListenerCallback<T> = (event: T) => void | Promise<void>;
 

--- a/packages/example-app/slim.ts
+++ b/packages/example-app/slim.ts
@@ -2,12 +2,20 @@ import { App } from '@deepkit/app';
 import { http, HttpKernel, HttpModule, HttpRequest, HttpResponse } from '@deepkit/http';
 import { Server } from 'http';
 import { injectable } from '@deepkit/injector';
+import { getClassSchema, t } from '@deepkit/type';
 
 class MyService {
     helloWorld () {
         return 'Hello World'
     }
 }
+
+class Entity {
+    @t tags: string[] = [];
+}
+
+const schema = getClassSchema(Entity);
+console.log('schema read', schema.toString());
 
 @injectable
 class MyController {

--- a/packages/sql/src/sql-builder.ts
+++ b/packages/sql/src/sql-builder.ts
@@ -157,10 +157,10 @@ export class SqlBuilder {
             }
         }
 
+        const forJoinIndex = this.joins.length - 1;
         for (const join of model.joins) {
             if (join.populate) {
                 join.as = refName + '__' + join.propertySchema.name;
-                const forJoinIndex = this.joins.length - 1;
                 const joinMap = {
                     join,
                     forJoinIndex: forJoinIndex,

--- a/packages/type/README.md
+++ b/packages/type/README.md
@@ -10,7 +10,7 @@ and then use it everywhere: frontend, backend, CLI, database records, http-trans
 
 ## Features
 
-* [Fastest serialization and validation](#benchmark) thanks to a JIT engine. It's the the by far fastest serialization library for both, Nodejs and browsers.
+* [Fastest serialization and validation](#benchmark) thanks to a JIT engine. It's by far the fastest serialization library for both, Nodejs and browsers.
 * Supported types: String, Number, Boolean, Date, Moment.js, ArrayBuffer (binary), custom classes, Array, object maps, any.
 * Typed arrays: Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array
 * Cross referencing/Circular references using `@t.type(() => MyClass)`
@@ -22,5 +22,5 @@ and then use it everywhere: frontend, backend, CLI, database records, http-trans
 * Support declaring method arguments and return type for method serialization
 * Implicit type detection as far as Typescript allows it technically
 * Supports getters
-* One decorator for all. Best and mist efficient UX possible, with full type hinting support
+* One decorator for all. Best and most efficient UX possible, with full type hinting support
 * Soft type castings (so implicit cast from number -> string, if necessary)

--- a/packages/type/install-transformer.ts
+++ b/packages/type/install-transformer.ts
@@ -1,42 +1,50 @@
+#!/usr/bin/env node
+
 /**
  * This script installs the deepkit/type transformer (that extracts automatically types and adds the correct @t decorator) to the typescript node_modules.
  *
  * The critical section that needs adjustment is in the `function getScriptTransformers` in `node_modules/typescript/lib/tsc.js`.
  */
 
-//@ts-ignore
 import { dirname, join, relative } from 'path';
-//@ts-ignore
 import { readFileSync, writeFileSync } from 'fs';
+import { cwd } from 'process';
 
-function getCode(deepkitDistPath: string): string {
+function getCode(deepkitDistPath: string, varName: string): string {
     return `
         var typeTransformer = require('${deepkitDistPath}/src/transformer');
         if (typeTransformer) {
-            if (!customTransformers) customTransformers = {}
-            if (!customTransformers.before) customTransformers.before = []
-            customTransformers.before.push(typeTransformer.transformer);
+            if (!${varName}) ${varName} = {}
+            if (!${varName}.before) ${varName}.before = []
+            ${varName}.before.push(typeTransformer.transformer);
         }
     `;
 }
 
-function injectTransformer(deepkitDistPath: string, code: string): string {
+function injectTransformerForTsc(deepkitDistPath: string, code: string): string {
     if (code.includes(deepkitDistPath)) return code;
 
-    return code.replace(/function getScriptTransformers\([^)]+\)\s*{/, function (a) {
-        return a + '\n    ' + getCode(deepkitDistPath);
+    code = code.replace(/function getScriptTransformers\([^)]+\)\s*{/, function (a) {
+        return a + '\n    ' + getCode(deepkitDistPath, 'customTransformers');
     });
+
+    return code;
 }
 
-//@ts-ignore
-const typeScriptPath = dirname(require.resolve('typescript'));
-//@ts-ignore
-const deepkitDistPath = relative(typeScriptPath, __dirname);
-// console.log('typeScriptPath', typeScriptPath);
-// console.log('deepkitDistPath', deepkitDistPath);
-// console.log('code', injectTransformer(deepkitDistPath, code));
+function injectTransformerForTypescript(deepkitDistPath: string, code: string): string {
+    if (code.includes(deepkitDistPath)) return code;
 
-const tscContent = readFileSync(join(typeScriptPath, 'tsc.js'), 'utf8');
-writeFileSync(join(typeScriptPath, 'tsc.js'), injectTransformer(deepkitDistPath, tscContent));
+    code = code.replace(/var customTransformers = (.*);/, function (a) {
+        return a + '\n    ' + getCode(deepkitDistPath, 'customTransformers');
+    });
+
+    return code;
+}
+
+const typeScriptPath = dirname(require.resolve('typescript', {paths: [cwd()]}));
+const deepkitDistPath = relative(typeScriptPath, __dirname);
+
+const tscContent = readFileSync(join(typeScriptPath, 'typescript.js'), 'utf8');
+writeFileSync(join(typeScriptPath, 'typescript.js'), injectTransformerForTypescript(deepkitDistPath, tscContent));
 
 console.log('Deepkit Type: Injected TypeScript transformer at', typeScriptPath);

--- a/packages/type/install-transformer.ts
+++ b/packages/type/install-transformer.ts
@@ -1,0 +1,42 @@
+/**
+ * This script installs the deepkit/type transformer (that extracts automatically types and adds the correct @t decorator) to the typescript node_modules.
+ *
+ * The critical section that needs adjustment is in the `function getScriptTransformers` in `node_modules/typescript/lib/tsc.js`.
+ */
+
+//@ts-ignore
+import { dirname, join, relative } from 'path';
+//@ts-ignore
+import { readFileSync, writeFileSync } from 'fs';
+
+function getCode(deepkitDistPath: string): string {
+    return `
+        var typeTransformer = require('${deepkitDistPath}/src/transformer');
+        if (typeTransformer) {
+            if (!customTransformers) customTransformers = {}
+            if (!customTransformers.before) customTransformers.before = []
+            customTransformers.before.push(typeTransformer.transformer);
+        }
+    `;
+}
+
+function injectTransformer(deepkitDistPath: string, code: string): string {
+    if (code.includes(deepkitDistPath)) return code;
+
+    return code.replace(/function getScriptTransformers\([^)]+\)\s*{/, function (a) {
+        return a + '\n    ' + getCode(deepkitDistPath);
+    });
+}
+
+//@ts-ignore
+const typeScriptPath = dirname(require.resolve('typescript'));
+//@ts-ignore
+const deepkitDistPath = relative(typeScriptPath, __dirname);
+// console.log('typeScriptPath', typeScriptPath);
+// console.log('deepkitDistPath', deepkitDistPath);
+// console.log('code', injectTransformer(deepkitDistPath, code));
+
+const tscContent = readFileSync(join(typeScriptPath, 'tsc.js'), 'utf8');
+writeFileSync(join(typeScriptPath, 'tsc.js'), injectTransformer(deepkitDistPath, tscContent));
+
+console.log('Deepkit Type: Injected TypeScript transformer at', typeScriptPath);

--- a/packages/type/package.json
+++ b/packages/type/package.json
@@ -12,12 +12,16 @@
       "default": "./dist/esm/index.js"
     }
   },
+  "bin": {
+    "deepkit-type-install": "./dist/install-transformer.js"
+  },
   "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "build": "echo '{\"type\": \"module\"}' > ./dist/esm/package.json"
+    "build": "echo '{\"type\": \"module\"}' > ./dist/esm/package.json",
+    "install": "node ./dist/cjs/install-transformer.js || exit 0"
   },
   "repository": "https://github.com/deepkit/deepkit-framework",
   "author": "Marc J. Schmidt <marc@marcjschmidt.de>",
@@ -35,6 +39,7 @@
   },
   "devDependencies": {
     "@deepkit/core": "^1.0.1-alpha.58",
+    "@types/node": "14.14.28",
     "@types/clone": "^0.1.30"
   },
   "jest": {

--- a/packages/type/package.json
+++ b/packages/type/package.json
@@ -13,7 +13,7 @@
     }
   },
   "bin": {
-    "deepkit-type-install": "./dist/install-transformer.js"
+    "deepkit-type-install": "./dist/cjs/install-transformer.js"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/type/src/decorators.ts
+++ b/packages/type/src/decorators.ts
@@ -395,7 +395,7 @@ function createFieldDecoratorResult<T>(
     fn.jsonType = (type: WideTypes) => {
         resetIfNecessary();
         return createFieldDecoratorResult(cb, givenPropertyName, [...modifier, (target: object, property: PropertySchema) => {
-            property.jsonType ||= new PropertySchema('jsonType');
+            if (!property.jsonType) property.jsonType = new PropertySchema('jsonType');
             assignWideTypeToProperty(property.jsonType, type);
         }]);
     };

--- a/packages/type/src/jit-validation.ts
+++ b/packages/type/src/jit-validation.ts
@@ -67,7 +67,7 @@ export function handleCustomValidator<T>(
 ) {
     try {
         validator.validate(value, propSchema, classType);
-    } catch (error) {
+    } catch (error: any) {
         if (error instanceof PropertyValidatorError) {
             errors.push(new ValidationFailedItem(propertyPath, error.code, error.message || String(error)));
         } else {

--- a/packages/type/src/json-serializer.ts
+++ b/packages/type/src/json-serializer.ts
@@ -57,7 +57,7 @@ export function plainToClass<T extends ClassType | ClassSchema>(
     data: PlainOrFullEntityFromClassTypeOrSchema<ExtractClassType<T>>,
     options?: JitConverterOptions
 ): ExtractClassType<T> {
-    return getXToClassFunction(getClassSchema(classTypeOrSchema), jsonSerializer)(data, options);
+    return getXToClassFunction(getClassSchema(classTypeOrSchema), jsonSerializer)(data, options) as ExtractClassType<T>;
 }
 
 /**

--- a/packages/type/src/transformer.ts
+++ b/packages/type/src/transformer.ts
@@ -1,0 +1,194 @@
+import {
+    createDecorator,
+    createNodeArray,
+    Decorator,
+    Expression,
+    Identifier,
+    isArrayTypeNode,
+    isIdentifier,
+    isImportDeclaration,
+    isIndexSignatureDeclaration,
+    isLiteralTypeNode,
+    isMethodDeclaration,
+    isNamedImports,
+    isParenthesizedTypeNode,
+    isPropertyDeclaration,
+    isSourceFile,
+    isStringLiteral,
+    isTypeLiteralNode,
+    isTypeReferenceNode,
+    isUnionTypeNode,
+    MethodDeclaration,
+    Node,
+    NodeArray,
+    NodeFactory,
+    PropertyAccessExpression,
+    PropertyDeclaration,
+    QualifiedName,
+    SourceFile,
+    SyntaxKind,
+    TransformerFactory,
+    TypeNode,
+    visitEachChild,
+    visitNode
+} from 'typescript';
+
+function getTypeExpressions(f: NodeFactory, t: Identifier, types: NodeArray<TypeNode>): Expression[] {
+    const args: Expression[] = [];
+    for (const subType of types) {
+        if (isLiteralTypeNode(subType)) {
+            args.push(subType.literal);
+        } else {
+            args.push(getTypeExpression(f, t, t, subType));
+        }
+    }
+    return args;
+}
+
+function resolveEntityName(f: NodeFactory, e: QualifiedName): PropertyAccessExpression {
+    return f.createPropertyAccessExpression(
+        isIdentifier(e.left) ? e.left : resolveEntityName(f, e.left),
+        e.right,
+    );
+}
+
+function getTypeExpression(f: NodeFactory, t: Identifier, entry: Expression, type: TypeNode): Expression {
+    if (isParenthesizedTypeNode(type)) return getTypeExpression(f, t, entry, type.type);
+    let markAsOptional: boolean = !!type.parent && isPropertyDeclaration(type.parent) && !!type.parent.questionToken;
+    let markAsNullable = false;
+    let wrap = (e: Expression) => {
+        if (markAsOptional) {
+            //its optional
+            e = f.createPropertyAccessExpression(e, 'optional');
+        }
+        if (markAsNullable) {
+            //its optional
+            e = f.createPropertyAccessExpression(e, 'nullable');
+        }
+        return e;
+    };
+
+    if (type.kind === SyntaxKind.StringKeyword) return wrap(f.createPropertyAccessExpression(entry, 'string'));
+    if (type.kind === SyntaxKind.NumberKeyword) return wrap(f.createPropertyAccessExpression(entry, 'number'));
+    if (type.kind === SyntaxKind.BooleanKeyword) return wrap(f.createPropertyAccessExpression(entry, 'boolean'));
+    if (isLiteralTypeNode(type)) {
+        return wrap(f.createCallExpression(f.createPropertyAccessExpression(entry, 'literal'), [], [
+            type.literal
+        ]));
+    }
+
+    if (isArrayTypeNode(type)) {
+        return wrap(f.createCallExpression(f.createPropertyAccessExpression(entry, 'array'), [], [getTypeExpression(f, t, t, type.elementType)]));
+    }
+
+    if (isTypeLiteralNode(type)) {
+        //{[name: string]: number} => t.record(t.string, t.number)
+        const [first] = type.members;
+        if (first && isIndexSignatureDeclaration(first)) {
+            const [parameter] = first.parameters;
+            if (parameter && parameter.type) {
+                return wrap(f.createCallExpression(f.createPropertyAccessExpression(entry, 'record'), [], [
+                    getTypeExpression(f, t, entry, parameter.type),
+                    getTypeExpression(f, t, entry, first.type),
+                ]));
+            }
+        }
+    }
+
+    if (isTypeReferenceNode(type) && isIdentifier(type.typeName) && type.typeName.escapedText === 'Record' && type.typeArguments && type.typeArguments.length === 2) {
+        //Record<string, number> => t.record(t.string, t.number)
+        const [key, value] = type.typeArguments;
+        return wrap(f.createCallExpression(f.createPropertyAccessExpression(entry, 'record'), [], [
+            getTypeExpression(f, t, entry, key),
+            getTypeExpression(f, t, entry, value),
+        ]));
+    }
+
+    if (isUnionTypeNode(type)) {
+        const args: Expression[] = [];
+        let literalAdded = false;
+        for (const subType of type.types) {
+            if (subType.kind === SyntaxKind.NullKeyword) {
+                markAsNullable = true;
+            } else if (subType.kind === SyntaxKind.UndefinedKeyword) {
+                markAsOptional = true;
+            } else if (isLiteralTypeNode(subType)) {
+                if (subType.literal.kind === SyntaxKind.NullKeyword) {
+                    markAsNullable = true;
+                } else {
+                    args.push(subType.literal);
+                    literalAdded = true;
+                }
+            } else {
+                args.push(getTypeExpression(f, t, t, subType));
+            }
+        }
+        //t.array(t.union(t.number).optional) => t.array(t.number.optional)
+        if (args.length === 1 && !literalAdded) return wrap(args[0]);
+        return wrap(f.createCallExpression(f.createPropertyAccessExpression(entry, 'union'), [], args));
+    }
+
+    if (isTypeReferenceNode(type)) {
+        if (isIdentifier(type.typeName) && type.typeName.escapedText === 'Date') return wrap(f.createPropertyAccessExpression(entry, 'date'));
+        return wrap(f.createCallExpression(f.createPropertyAccessExpression(entry, 'type'), [], [
+            isIdentifier(type.typeName) ? type.typeName : resolveEntityName(f, type.typeName)
+        ]));
+    }
+
+    return wrap(f.createPropertyAccessExpression(entry, 'any'));
+}
+
+function getDecoratorFromType(f: NodeFactory, t: Identifier, node: PropertyDeclaration | MethodDeclaration): Decorator | void {
+    if (isPropertyDeclaration(node) && node.type) {
+        const type = getTypeExpression(f, t, t, node.type);
+        if (type) {
+            return createDecorator(type);
+        }
+    }
+}
+
+export const transformer: TransformerFactory<SourceFile> = (context) => {
+    return (fileNode) => {
+
+        // const importT = context.factory.createImportDeclaration(
+        //     undefined, undefined,
+        //     context.factory.createImportClause(false, context.factory.createIdentifier('t'), undefined),
+        //     context.factory.createIdentifier('@deepkit/type')
+        // );
+        // context.factory.updateSourceFile(fileNode, [
+        //     importT,
+        //     ...fileNode.statements,
+        // ]);
+
+        let importT: Identifier | undefined = undefined;
+        if (isSourceFile(fileNode)) {
+            for (const statement of fileNode.statements) {
+                if (isImportDeclaration(statement) && statement.importClause) {
+                    if (isStringLiteral(statement.moduleSpecifier) && statement.moduleSpecifier.text === '@deepkit/type') {
+                        if (statement.importClause.namedBindings && isNamedImports(statement.importClause.namedBindings)) {
+                            for (const element of statement.importClause.namedBindings.elements) {
+                                if (element.name.escapedText === 't') {
+                                    importT = element.name;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!importT) return fileNode;
+
+        const visitor = (node: Node): Node => {
+            if ((isPropertyDeclaration(node) || isMethodDeclaration(node)) && node.decorators) {
+                const typeDecorator = getDecoratorFromType(context.factory, importT!, node);
+                if (typeDecorator) {
+                    return { ...node, decorators: createNodeArray([...node.decorators, typeDecorator]) };
+                }
+            }
+
+            return visitEachChild(node, visitor, context);
+        };
+        return visitNode(fileNode, visitor);
+    };
+};

--- a/packages/type/src/transformer.ts
+++ b/packages/type/src/transformer.ts
@@ -1,16 +1,19 @@
 import {
-    createDecorator,
-    createNodeArray,
+    __String,
+    Declaration,
     Decorator,
     Expression,
     Identifier,
     isArrayTypeNode,
+    isEnumDeclaration,
     isIdentifier,
     isImportDeclaration,
+    isImportSpecifier,
     isIndexSignatureDeclaration,
     isLiteralTypeNode,
     isMethodDeclaration,
     isNamedImports,
+    isParameter,
     isParenthesizedTypeNode,
     isPropertyDeclaration,
     isSourceFile,
@@ -20,136 +23,49 @@ import {
     isUnionTypeNode,
     MethodDeclaration,
     Node,
-    NodeArray,
     NodeFactory,
+    ParameterDeclaration,
     PropertyAccessExpression,
     PropertyDeclaration,
     QualifiedName,
+    ScriptReferenceHost,
     SourceFile,
+    Symbol,
+    SymbolTable,
     SyntaxKind,
+    TransformationContext,
     TransformerFactory,
     TypeNode,
     visitEachChild,
     visitNode
 } from 'typescript';
 
-function getTypeExpressions(f: NodeFactory, t: Identifier, types: NodeArray<TypeNode>): Expression[] {
-    const args: Expression[] = [];
-    for (const subType of types) {
-        if (isLiteralTypeNode(subType)) {
-            args.push(subType.literal);
-        } else {
-            args.push(getTypeExpression(f, t, t, subType));
-        }
-    }
-    return args;
-}
+// function getTypeExpressions(f: NodeFactory, t: Identifier, types: NodeArray<TypeNode>): Expression[] {
+//     const args: Expression[] = [];
+//     for (const subType of types) {
+//         if (isLiteralTypeNode(subType)) {
+//             args.push(subType.literal);
+//         } else {
+//             args.push(getTypeExpression(f, t, subType));
+//         }
+//     }
+//     return args;
+// }
 
-function resolveEntityName(f: NodeFactory, e: QualifiedName): PropertyAccessExpression {
-    return f.createPropertyAccessExpression(
-        isIdentifier(e.left) ? e.left : resolveEntityName(f, e.left),
-        e.right,
-    );
-}
+export class DeepkitTransformer {
+    protected host!: ScriptReferenceHost;
+    protected f: NodeFactory;
 
-function getTypeExpression(f: NodeFactory, t: Identifier, entry: Expression, type: TypeNode): Expression {
-    if (isParenthesizedTypeNode(type)) return getTypeExpression(f, t, entry, type.type);
-    let markAsOptional: boolean = !!type.parent && isPropertyDeclaration(type.parent) && !!type.parent.questionToken;
-    let markAsNullable = false;
-    let wrap = (e: Expression) => {
-        if (markAsOptional) {
-            //its optional
-            e = f.createPropertyAccessExpression(e, 'optional');
-        }
-        if (markAsNullable) {
-            //its optional
-            e = f.createPropertyAccessExpression(e, 'nullable');
-        }
-        return e;
-    };
+    sourceFile!: SourceFile;
 
-    if (type.kind === SyntaxKind.StringKeyword) return wrap(f.createPropertyAccessExpression(entry, 'string'));
-    if (type.kind === SyntaxKind.NumberKeyword) return wrap(f.createPropertyAccessExpression(entry, 'number'));
-    if (type.kind === SyntaxKind.BooleanKeyword) return wrap(f.createPropertyAccessExpression(entry, 'boolean'));
-    if (isLiteralTypeNode(type)) {
-        return wrap(f.createCallExpression(f.createPropertyAccessExpression(entry, 'literal'), [], [
-            type.literal
-        ]));
+    constructor(
+        protected context: TransformationContext,
+    ) {
+        this.f = context.factory;
+        this.host = (context as any).getEmitHost() as ScriptReferenceHost;
     }
 
-    if (isArrayTypeNode(type)) {
-        return wrap(f.createCallExpression(f.createPropertyAccessExpression(entry, 'array'), [], [getTypeExpression(f, t, t, type.elementType)]));
-    }
-
-    if (isTypeLiteralNode(type)) {
-        //{[name: string]: number} => t.record(t.string, t.number)
-        const [first] = type.members;
-        if (first && isIndexSignatureDeclaration(first)) {
-            const [parameter] = first.parameters;
-            if (parameter && parameter.type) {
-                return wrap(f.createCallExpression(f.createPropertyAccessExpression(entry, 'record'), [], [
-                    getTypeExpression(f, t, entry, parameter.type),
-                    getTypeExpression(f, t, entry, first.type),
-                ]));
-            }
-        }
-    }
-
-    if (isTypeReferenceNode(type) && isIdentifier(type.typeName) && type.typeName.escapedText === 'Record' && type.typeArguments && type.typeArguments.length === 2) {
-        //Record<string, number> => t.record(t.string, t.number)
-        const [key, value] = type.typeArguments;
-        return wrap(f.createCallExpression(f.createPropertyAccessExpression(entry, 'record'), [], [
-            getTypeExpression(f, t, entry, key),
-            getTypeExpression(f, t, entry, value),
-        ]));
-    }
-
-    if (isUnionTypeNode(type)) {
-        const args: Expression[] = [];
-        let literalAdded = false;
-        for (const subType of type.types) {
-            if (subType.kind === SyntaxKind.NullKeyword) {
-                markAsNullable = true;
-            } else if (subType.kind === SyntaxKind.UndefinedKeyword) {
-                markAsOptional = true;
-            } else if (isLiteralTypeNode(subType)) {
-                if (subType.literal.kind === SyntaxKind.NullKeyword) {
-                    markAsNullable = true;
-                } else {
-                    args.push(subType.literal);
-                    literalAdded = true;
-                }
-            } else {
-                args.push(getTypeExpression(f, t, t, subType));
-            }
-        }
-        //t.array(t.union(t.number).optional) => t.array(t.number.optional)
-        if (args.length === 1 && !literalAdded) return wrap(args[0]);
-        return wrap(f.createCallExpression(f.createPropertyAccessExpression(entry, 'union'), [], args));
-    }
-
-    if (isTypeReferenceNode(type)) {
-        if (isIdentifier(type.typeName) && type.typeName.escapedText === 'Date') return wrap(f.createPropertyAccessExpression(entry, 'date'));
-        return wrap(f.createCallExpression(f.createPropertyAccessExpression(entry, 'type'), [], [
-            isIdentifier(type.typeName) ? type.typeName : resolveEntityName(f, type.typeName)
-        ]));
-    }
-
-    return wrap(f.createPropertyAccessExpression(entry, 'any'));
-}
-
-function getDecoratorFromType(f: NodeFactory, t: Identifier, node: PropertyDeclaration | MethodDeclaration): Decorator | void {
-    if (isPropertyDeclaration(node) && node.type) {
-        const type = getTypeExpression(f, t, t, node.type);
-        if (type) {
-            return createDecorator(type);
-        }
-    }
-}
-
-export const transformer: TransformerFactory<SourceFile> = (context) => {
-    return (fileNode) => {
-
+    transform<T extends Node>(sourceFile: T): T {
         // const importT = context.factory.createImportDeclaration(
         //     undefined, undefined,
         //     context.factory.createImportClause(false, context.factory.createIdentifier('t'), undefined),
@@ -159,15 +75,15 @@ export const transformer: TransformerFactory<SourceFile> = (context) => {
         //     importT,
         //     ...fileNode.statements,
         // ]);
-
         let importT: Identifier | undefined = undefined;
-        if (isSourceFile(fileNode)) {
-            for (const statement of fileNode.statements) {
+        if (isSourceFile(sourceFile)) {
+            this.sourceFile = sourceFile;
+            for (const statement of sourceFile.statements) {
                 if (isImportDeclaration(statement) && statement.importClause) {
                     if (isStringLiteral(statement.moduleSpecifier) && statement.moduleSpecifier.text === '@deepkit/type') {
                         if (statement.importClause.namedBindings && isNamedImports(statement.importClause.namedBindings)) {
                             for (const element of statement.importClause.namedBindings.elements) {
-                                if (element.name.escapedText === 't') {
+                                if (element.name.text === 't') {
                                     importT = element.name;
                                 }
                             }
@@ -175,20 +91,220 @@ export const transformer: TransformerFactory<SourceFile> = (context) => {
                     }
                 }
             }
+        } else {
+            return sourceFile;
         }
 
-        if (!importT) return fileNode;
+        if (!importT) return sourceFile;
 
         const visitor = (node: Node): Node => {
-            if ((isPropertyDeclaration(node) || isMethodDeclaration(node)) && node.decorators) {
-                const typeDecorator = getDecoratorFromType(context.factory, importT!, node);
-                if (typeDecorator) {
-                    return { ...node, decorators: createNodeArray([...node.decorators, typeDecorator]) };
+            if ((isPropertyDeclaration(node) || isMethodDeclaration(node)) && node.type && node.decorators) {
+                const typeDecorator = this.getDecoratorFromType(importT!, node);
+                if (isMethodDeclaration(node)) {
+                    return {
+                        ...node,
+                        decorators: this.f.createNodeArray([...node.decorators, typeDecorator]),
+                        parameters: this.f.createNodeArray(node.parameters.map(parameter => {
+                            if (!parameter.type) return parameter;
+                            return { ...parameter, decorators: this.f.createNodeArray([...(parameter.decorators || []), this.getDecoratorFromType(importT!, parameter)]) };
+                        }))
+                    } as MethodDeclaration;
+                }
+                return { ...node, decorators: this.f.createNodeArray([...node.decorators, typeDecorator]) };
+            }
+            return visitEachChild(node, visitor, this.context);
+        };
+        return visitNode(sourceFile, visitor);
+    }
+
+
+    resolveEntityName(e: QualifiedName): PropertyAccessExpression {
+        return this.f.createPropertyAccessExpression(
+            isIdentifier(e.left) ? e.left : this.resolveEntityName(e.left),
+            e.right,
+        );
+    }
+
+    isNodeWithLocals(node: Node): node is (Node & { locals: SymbolTable | undefined }) {
+        return 'locals' in node;
+    }
+
+    findSymbol(type: TypeNode): Symbol | undefined {
+        let current = type.parent;
+        const name = isIdentifier(type) ? type.text : type.getText();
+        do {
+            if (this.isNodeWithLocals(current) && current.locals) {
+                //check if its here
+                const symbol = current.locals.get(name as __String);
+                if (symbol) return symbol;
+            }
+            current = current.parent;
+        } while (current);
+        return;
+    }
+
+    findDeclaration(symbol: Symbol): Declaration | undefined {
+        if (symbol && symbol.declarations && symbol.declarations[0]) {
+            const declaration = symbol.declarations[0];
+            if (!declaration) return;
+            if (isImportSpecifier(declaration)) {
+                const declarationName = declaration.name.text;
+                const imp = declaration.parent.parent.parent;
+                if (isImportDeclaration(imp) && isStringLiteral(imp.moduleSpecifier)) {
+                    let fromFile = imp.moduleSpecifier.text;
+                    if (!fromFile.endsWith('.js') && !fromFile.endsWith('.ts')) fromFile += '.ts';
+                    const source = this.host.getSourceFile(fromFile.startsWith('./') ? this.sourceFile.fileName + '/.' + fromFile : fromFile);
+                    if (source && this.isNodeWithLocals(source) && source.locals) {
+                        const declarationSymbol = source.locals.get(declarationName as __String);
+                        if (declarationSymbol && declarationSymbol.declarations) return declarationSymbol.declarations[0];
+                    }
                 }
             }
+            return declaration;
+        }
+        return;
+    }
 
-            return visitEachChild(node, visitor, context);
+    getTypeExpression(t: Identifier, type: TypeNode, options: { allowShort?: boolean } = {}): Expression {
+        if (isParenthesizedTypeNode(type)) return this.getTypeExpression(t, type.type);
+        let markAsOptional: boolean = !!type.parent && isPropertyDeclaration(type.parent) && !!type.parent.questionToken;
+        let markAsNullable = false;
+        let wrap = (e: Expression) => {
+            if (markAsOptional) {
+                //its optional
+                e = this.f.createPropertyAccessExpression(e, 'optional');
+            }
+            if (markAsNullable) {
+                //its optional
+                e = this.f.createPropertyAccessExpression(e, 'nullable');
+            }
+            return e;
         };
-        return visitNode(fileNode, visitor);
+
+        if (type.kind === SyntaxKind.StringKeyword) return wrap(this.f.createPropertyAccessExpression(t, 'string'));
+        if (type.kind === SyntaxKind.NumberKeyword) return wrap(this.f.createPropertyAccessExpression(t, 'number'));
+        if (type.kind === SyntaxKind.BooleanKeyword) return wrap(this.f.createPropertyAccessExpression(t, 'boolean'));
+        if (type.kind === SyntaxKind.BigIntKeyword) return wrap(this.f.createPropertyAccessExpression(t, 'bigint'));
+        if (isLiteralTypeNode(type)) {
+            return wrap(this.f.createCallExpression(this.f.createPropertyAccessExpression(t, 'literal'), [], [
+                type.literal
+            ]));
+        }
+
+        if (isArrayTypeNode(type)) {
+            return wrap(this.f.createCallExpression(this.f.createPropertyAccessExpression(t, 'array'), [], [this.getTypeExpression(t, type.elementType)]));
+        }
+
+        if (isTypeLiteralNode(type)) {
+            //{[name: string]: number} => t.record(t.string, t.number)
+            const [first] = type.members;
+            if (first && isIndexSignatureDeclaration(first)) {
+                const [parameter] = first.parameters;
+                if (parameter && parameter.type) {
+                    return wrap(this.f.createCallExpression(this.f.createPropertyAccessExpression(t, 'record'), [], [
+                        this.getTypeExpression(t, parameter.type),
+                        this.getTypeExpression(t, first.type),
+                    ]));
+                }
+            }
+        }
+
+        if (isTypeReferenceNode(type) && isIdentifier(type.typeName) && type.typeName.text === 'Record' && type.typeArguments && type.typeArguments.length === 2) {
+            //Record<string, number> => t.record(t.string, t.number)
+            const [key, value] = type.typeArguments;
+            return wrap(this.f.createCallExpression(this.f.createPropertyAccessExpression(t, 'record'), [], [
+                this.getTypeExpression(t, key),
+                this.getTypeExpression(t, value),
+            ]));
+        }
+
+        if (isTypeReferenceNode(type) && isIdentifier(type.typeName) && type.typeName.text === 'Partial' && type.typeArguments && type.typeArguments.length === 1) {
+            //Record<string, number> => t.record(t.string, t.number)
+            const [T] = type.typeArguments;
+            return wrap(this.f.createCallExpression(this.f.createPropertyAccessExpression(t, 'partial'), [], [
+                this.getTypeExpression(t, T, { allowShort: true }),
+            ]));
+        }
+
+        if (isUnionTypeNode(type)) {
+            const args: Expression[] = [];
+            let literalAdded = false;
+            for (const subType of type.types) {
+                if (subType.kind === SyntaxKind.NullKeyword) {
+                    markAsNullable = true;
+                } else if (subType.kind === SyntaxKind.UndefinedKeyword) {
+                    markAsOptional = true;
+                } else if (isLiteralTypeNode(subType)) {
+                    if (subType.literal.kind === SyntaxKind.NullKeyword) {
+                        markAsNullable = true;
+                    } else {
+                        args.push(subType.literal);
+                        literalAdded = true;
+                    }
+                } else {
+                    args.push(this.getTypeExpression(t, subType, { allowShort: true }));
+                }
+            }
+            //t.array(t.union(t.number).optional) => t.array(t.number.optional)
+            if (args.length === 1 && !literalAdded) return wrap(args[0]);
+            return wrap(this.f.createCallExpression(this.f.createPropertyAccessExpression(t, 'union'), [], args));
+        }
+
+        if (isTypeReferenceNode(type)) {
+            if (isIdentifier(type.typeName) && type.typeName.text === 'Date') return wrap(this.f.createPropertyAccessExpression(t, 'date'));
+
+            const symbol = this.findSymbol(type);
+            if (symbol) {
+                const declaration = this.findDeclaration(symbol);
+                if (declaration && isEnumDeclaration(declaration)) {
+                    return wrap(this.f.createCallExpression(this.f.createPropertyAccessExpression(t, 'enum'), [], [
+                        isIdentifier(type.typeName) ? type.typeName : this.resolveEntityName(type.typeName)
+                    ]));
+                }
+            }
+            if (isIdentifier(type.typeName) && type.typeName.text === 'Promise') {
+                return wrap(this.f.createCallExpression(
+                    this.f.createPropertyAccessExpression(t, 'promise'), [],
+                    type.typeArguments ? type.typeArguments.map(T => this.getTypeExpression(t, T)) : []
+                ));
+            }
+
+            if (options?.allowShort && !type.typeArguments) {
+                return isIdentifier(type.typeName) ? type.typeName : this.resolveEntityName(type.typeName);
+            }
+
+            let e: Expression = this.f.createCallExpression(this.f.createPropertyAccessExpression(t, 'type'), [], [
+                isIdentifier(type.typeName) ? type.typeName : this.resolveEntityName(type.typeName)
+            ]);
+
+            if (type.typeArguments) {
+                e = this.f.createCallExpression(
+                    this.f.createPropertyAccessExpression(e, 'generic'), [],
+                    type.typeArguments.map(T => this.getTypeExpression(t, T, { allowShort: true }))
+                );
+            }
+            return wrap(e);
+        }
+
+        return wrap(this.f.createPropertyAccessExpression(t, 'any'));
+    }
+
+    getDecoratorFromType(t: Identifier, node: PropertyDeclaration | MethodDeclaration | ParameterDeclaration): Decorator {
+        if (!node.type) throw new Error('No type given');
+
+        let e = this.getTypeExpression(t, node.type);
+
+        if (isParameter(node) && isIdentifier(node.name)) {
+            e = this.f.createCallExpression(this.f.createPropertyAccessExpression(e, 'name'), [], [this.f.createStringLiteral(node.name.text, true)]);
+        }
+
+        return this.f.createDecorator(e);
+    }
+}
+
+export const transformer: TransformerFactory<SourceFile> = (context) => {
+    const deepkitTransformer = new DeepkitTransformer(context);
+    return <T extends Node>(sourceFile: T): T => {
+        return deepkitTransformer.transform(sourceFile);
     };
 };

--- a/packages/type/tests/transformer.spec.ts
+++ b/packages/type/tests/transformer.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from '@jest/globals';
+import { CompilerOptions, ModuleKind, ScriptTarget, transpileModule } from 'typescript';
+import { transformer } from '../src/transformer';
+
+Error.stackTraceLimit = 200;
+
+function transpile(code: string): string {
+    const options: CompilerOptions = {
+        experimentalDecorators: true,
+        module: ModuleKind.CommonJS,
+        target: ScriptTarget.ES2020,
+    };
+
+    return transpileModule(code, {
+        compilerOptions: options,
+        transformers: { before: [transformer] }
+    }).outputText;
+}
+
+const tests: [code: string, contains: string][] = [
+    [`import {t} from '@deepkit/type'; class Entity { @t p: number;}`, 'type_1.t.number'],
+    [`import {t} from '@deepkit/type'; class Entity { @t p?: number;}`, 'type_1.t.number.optional'],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: string;}`, 'type_1.t.string'],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: boolean;}`, 'type_1.t.boolean'],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: Date;}`, 'type_1.t.date'],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: Uint8Array;}`, 'type_1.t.type(Uint8Array)'],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: ArrayBuffer;}`, 'type_1.t.type(ArrayBuffer)'],
+    [`import {t} from '@deepkit/type'; class Model {} class Entity { @t p: Model;}`, 'type_1.t.type(Model)'],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: 'a';}`, `type_1.t.literal('a')`],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: 'a' | 'b';}`, `type_1.t.union('a', 'b')`],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: 'a' | 'b' | undefined;}`, `type_1.t.union('a', 'b').optional`],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: 'a' | 'b' | null;}`, `type_1.t.union('a', 'b').nullable`],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: number[];}`, 'type_1.t.array(type_1.t.number)'],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: (number|undefined)[];}`, 'type_1.t.array(type_1.t.number.optional)'],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: boolean[];}`, 'type_1.t.array(type_1.t.boolean)'],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: ('a' | 'b')[];}`, `type_1.t.array(type_1.t.union('a', 'b'))`],
+    [`import {t} from '@deepkit/type'; class Entity { @t p?: ('a' | 'b')[];}`, `type_1.t.array(type_1.t.union('a', 'b')).optional`],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: {[name: string]: number};}`, `type_1.t.record(type_1.t.string, type_1.t.number)`],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: {[name: string]: number|undefined};}`, `type_1.t.record(type_1.t.string, type_1.t.number.optional)`],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: Record<string, number>;}`, `type_1.t.record(type_1.t.string, type_1.t.number)`],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: Record<string, number|undefined>;}`, `type_1.t.record(type_1.t.string, type_1.t.number.optional)`],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: Record<string, number|string>;}`, `type_1.t.record(type_1.t.string, type_1.t.union(type_1.t.number, type_1.t.string)`],
+];
+
+describe('transformer', () => {
+    for (const entry of tests) {
+        const [code, contains] = entry;
+        test(`${contains}: ${code.slice(-40)}`, () => {
+            expect(transpile(code)).toContain(contains);
+        });
+    }
+});

--- a/packages/type/tests/transformer.spec.ts
+++ b/packages/type/tests/transformer.spec.ts
@@ -1,28 +1,121 @@
 import { describe, expect, test } from '@jest/globals';
-import { CompilerOptions, ModuleKind, ScriptTarget, transpileModule } from 'typescript';
-import { transformer } from '../src/transformer';
+import {
+    CompilerOptions,
+    createCompilerHost,
+    createProgram,
+    createSourceFile,
+    Declaration,
+    isEnumDeclaration,
+    isPropertyDeclaration,
+    ModuleKind,
+    Node,
+    ScriptKind,
+    ScriptTarget,
+    SourceFile,
+    TransformationContext,
+    TransformerFactory,
+    transpileModule,
+    visitEachChild,
+    visitNode
+} from 'typescript';
+import { DeepkitTransformer, transformer } from '../src/transformer';
 
 Error.stackTraceLimit = 200;
 
-function transpile(code: string): string {
-    const options: CompilerOptions = {
-        experimentalDecorators: true,
-        module: ModuleKind.CommonJS,
-        target: ScriptTarget.ES2020,
+const options: CompilerOptions = {
+    experimentalDecorators: true,
+    module: ModuleKind.CommonJS,
+    transpileOnly: true,
+    target: ScriptTarget.ES2020,
+};
+
+function transpile(source: string | { [file: string]: string }, useTransformer: TransformerFactory<SourceFile> = transformer) {
+    if ('string' === typeof source) {
+        return transpileModule(source, {
+            compilerOptions: options,
+            transformers: { before: [transformer] }
+        }).outputText;
+    }
+
+    const files: { [path: string]: SourceFile } = {};
+    if ('string' === typeof source) {
+        files['app.ts'] = createSourceFile('app.ts', source, ScriptTarget.ES2020, true, ScriptKind.TS);
+    } else {
+        for (const [file, src] of Object.entries(source)) {
+            files[file + '.ts'] = createSourceFile(file + '.ts', src, ScriptTarget.ES2020, true, ScriptKind.TS);
+        }
+    }
+
+    let appTs = '';
+    const host = createCompilerHost(options);
+    host.writeFile = (fileName, data, writeByteOrderMark, onError, sourceFiles) => {
+        if (fileName === 'app.js') appTs = data;
+    };
+    const originalGetSourceFile = host.getSourceFile;
+    host.getSourceFile = (fileName: string, languageVersion: ScriptTarget) => {
+        return files[fileName] || originalGetSourceFile(fileName, languageVersion);
     };
 
-    return transpileModule(code, {
-        compilerOptions: options,
-        transformers: { before: [transformer] }
-    }).outputText;
+    const program = createProgram(Object.keys(files), options, host);
+    program.emit(files['app.ts'], undefined, undefined, undefined, { before: [useTransformer] });
+    return appTs;
 }
 
-const tests: [code: string, contains: string][] = [
+test('transpile single', () => {
+    expect(transpile(`const p: string = '';`).trim()).toBe(`const p = '';`);
+});
+
+test('transpile transformer', () => {
+    let foundDeclaration: Declaration | undefined;
+    const transformer: TransformerFactory<SourceFile> = (context: TransformationContext) => {
+        const deepkitTransformer = new DeepkitTransformer(context);
+        return (sourceFile) => {
+            deepkitTransformer.sourceFile = sourceFile;
+            const visitor = (node: Node): Node => {
+                if (isPropertyDeclaration(node) && node.type) {
+                    const symbol = deepkitTransformer.findSymbol(node.type);
+                    if (symbol) {
+                        foundDeclaration = deepkitTransformer.findDeclaration(symbol);
+                    }
+                }
+                return visitEachChild(node, visitor, context);
+            };
+            return visitNode(sourceFile, visitor);
+        };
+    };
+    transpile({
+            app: `import {MyEnum} from './module'; class Controller {p: MyEnum;}`,
+            module: `export const enum MyEnum {}`
+        },
+        transformer
+    );
+    expect(foundDeclaration && isEnumDeclaration(foundDeclaration)).toBe(true);
+});
+
+const tests: [code: string | { [file: string]: string }, contains: string][] = [
+    [`import {t} from '@deepkit/type'; class Entity { @t p(): number {}}`, 'type_1.t.number'],
+    [`import {t} from '@deepkit/type'; class Entity { @t p(param: string): number {}}`, `type_1.t.number`],
+    [`import {t} from '@deepkit/type'; class Entity { @t p(param: string): number {}}`, `type_1.t.string.name('param')`],
     [`import {t} from '@deepkit/type'; class Entity { @t p: number;}`, 'type_1.t.number'],
     [`import {t} from '@deepkit/type'; class Entity { @t p?: number;}`, 'type_1.t.number.optional'],
     [`import {t} from '@deepkit/type'; class Entity { @t p: string;}`, 'type_1.t.string'],
     [`import {t} from '@deepkit/type'; class Entity { @t p: boolean;}`, 'type_1.t.boolean'],
     [`import {t} from '@deepkit/type'; class Entity { @t p: Date;}`, 'type_1.t.date'],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: any;}`, 'type_1.t.any'],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: bigint;}`, 'type_1.t.bigint'],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: Promise<number>;}`, 'type_1.t.promise(type_1.t.number)'],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: Entity<number, string>;}`, 'type_1.t.type(Entity).generic(type_1.t.number, type_1.t.string)'],
+    [`import {t} from '@deepkit/type'; class Entity { @t p: Promise<Subject<number>>;}`, 'type_1.t.promise(type_1.t.type(Subject).generic(type_1.t.number))'],
+    [`import {t} from '@deepkit/type'; class Model{}; class Entity { @t p: Partial<Model>;}`, 'type_1.t.partial(Model)'],
+    [{
+        app: `import {t} from '@deepkit/type'; import {MyEnum} from './enum'; class Entity { @t p: MyEnum;}`,
+        enum: `export enum MyEnum {}`
+    }, 'type_1.t.enum(enum_1.MyEnum)'],
+    [{
+        app: `import {t} from '@deepkit/type'; import {Model} from './model'; class Entity { @t p: Model;}`,
+        model: `export class Model {}`
+    }, 'type_1.t.type(model_1.Model)'],
+    [`import {t} from '@deepkit/type'; function() {enum MyEnum {}; class Entity { @t p: MyEnum;} }`, 'type_1.t.enum(MyEnum)'],
     [`import {t} from '@deepkit/type'; class Entity { @t p: Uint8Array;}`, 'type_1.t.type(Uint8Array)'],
     [`import {t} from '@deepkit/type'; class Entity { @t p: ArrayBuffer;}`, 'type_1.t.type(ArrayBuffer)'],
     [`import {t} from '@deepkit/type'; class Model {} class Entity { @t p: Model;}`, 'type_1.t.type(Model)'],
@@ -45,7 +138,8 @@ const tests: [code: string, contains: string][] = [
 describe('transformer', () => {
     for (const entry of tests) {
         const [code, contains] = entry;
-        test(`${contains}: ${code.slice(-40)}`, () => {
+        const label = 'string' === typeof code ? code : code['app.ts'] || '';
+        test(`${contains}: ${label.slice(-40)}`, () => {
             expect(transpile(code)).toContain(contains);
         });
     }

--- a/packages/type/tsconfig.json
+++ b/packages/type/tsconfig.json
@@ -29,6 +29,7 @@
   "include": [
     "src",
     "test",
+    "install-transformer.ts",
     "index.ts"
   ],
   "references": [

--- a/packages/type/tsconfig.json
+++ b/packages/type/tsconfig.json
@@ -21,9 +21,6 @@
       "ES2019",
       "ES2020",
       "DOM"
-    ],
-    "types": [
-      "reflect-metadata"
     ]
   },
   "include": [

--- a/release-notes/alpha-53.md
+++ b/release-notes/alpha-53.md
@@ -84,7 +84,7 @@ Modules are now stateful, which means they need to be instantiated when importin
 Its configuration options can be changed via the first argument.
 
 ```typescript
-new Application({
+new App({
     imports: [
         new MyModule({configValue: true})
     ]

--- a/release-notes/alpha-53.md
+++ b/release-notes/alpha-53.md
@@ -71,13 +71,13 @@ export class MyModule extends createModule({
 
 
 //imported as 
-new Application({
+new App({
     imports: [new MyModule({enabled: true})]
 })
 ```
 
 Please note: while regular modules can not import other modules in the module definition object anymore 
-(as it would become a global instance in a deeper nested import tree), a `new Application({imports: []})` or `new App({imports: []})`,
+(as it would become a global instance in a deeper nested import tree), a `new App({imports: []})`,
 can still do so (as it would not become a global instance).
 
 Modules are now stateful, which means they need to be instantiated when importing.
@@ -85,7 +85,7 @@ Its configuration options can be changed via the first argument.
 
 ```typescript
 new Application({
-    Imports: [
+    imports: [
         new MyModule({configValue: true})
     ]
 }).run();


### PR DESCRIPTION
### Summary of changes
GROUP BY, ORDER BY and HAVING did not use a `tableName.` prefix for specifying columns so if there were columns with the same name in the query it would break


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
