### PR TITLE
Allow to process RPC errors, fixes #168

### DIFF
--- a/packages/rpc/src/server/action.ts
+++ b/packages/rpc/src/server/action.ts
@@ -254,7 +254,7 @@ export class RpcServerAction {
                         v: next
                     });
                 }, (error) => {
-                    const extracted = rpcEncodeError(error);
+                    const extracted = rpcEncodeError(this.security.transformError(error));
                     response.reply(RpcTypes.ResponseActionObservableError, rpcResponseActionObservableSubscriptionError, { ...extracted, id: body.id });
                 }, () => {
                     response.reply(RpcTypes.ResponseActionObservableComplete, rpcActionObservableSubscribeId, {
@@ -450,7 +450,7 @@ export class RpcServerAction {
                                 v: next
                             });
                         }, (error) => {
-                            const extracted = rpcEncodeError(error);
+                            const extracted = rpcEncodeError(this.security.transformError(error));
                             response.reply(RpcTypes.ResponseActionObservableError, rpcResponseActionObservableSubscriptionError, { ...extracted, id: message.id });
                         }, () => {
                             const v = this.observableSubjects[message.id];
@@ -486,7 +486,7 @@ export class RpcServerAction {
                 }
             }
         } catch (error) {
-            response.error(error);
+            response.error(this.security.transformError(error));
         }
     }
 }

--- a/packages/rpc/src/server/security.ts
+++ b/packages/rpc/src/server/security.ts
@@ -46,6 +46,10 @@ export class RpcKernelSecurity {
     async authenticate(token: any): Promise<Session> {
         throw new Error('Authentication not implemented');
     }
+
+    transformError(err: Error) {
+        return err;
+    }
 }
 
 export class SessionState {


### PR DESCRIPTION
### Summary of changes
There should be a way to hide internal stack-traces which can contain confidential information, or needlessly helping hackers to figure out how the system is built

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
