### PR TITLE
Fix: Make mixin inherit methods

### DIFF
--- a/packages/type/src/model.ts
+++ b/packages/type/src/model.ts
@@ -1758,7 +1758,7 @@ export function mixin<T extends (ClassSchema | ClassType)[]>(...classTypes: T): 
     for (const classType of classTypes) {
         const foreignSchema = getClassSchema(classType);
 
-        for (const i in foreignSchema.classType.prototype) {
+        for (const i of Object.getOwnPropertyNames(foreignSchema.classType.prototype)) {
             schema.classType.prototype[i] = foreignSchema.classType.prototype[i];
         }
 


### PR DESCRIPTION
### Summary of changes

Fix for issue where child classes did not actually inherit methods of the base classes when using mixins. 

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
