### PR TITLE
feat(orm): redesign query filter methods

### DIFF
--- a/packages/orm/src/plugin/soft-delete.ts
+++ b/packages/orm/src/plugin/soft-delete.ts
@@ -84,7 +84,7 @@ export class SoftDeleteQuery<T extends SoftDeleteEntity> extends Query<T> {
     isSoftDeleted(): this {
         const m = this.clone();
         m.includeSoftDeleted = true;
-        return m.addFilter('deletedAt', {$ne: undefined});
+        return m.filterField('deletedAt', {$ne: undefined});
     }
 
     deletedBy(value: T['deletedBy']): this {
@@ -160,7 +160,7 @@ export class SoftDelete {
             if (event.classSchema !== schema) return; //do nothing
 
             //attach the filter to exclude deleted records
-            event.query = event.query.addFilter(deletedAtName, undefined);
+            event.query = event.query.filterField(deletedAtName, undefined);
         }
 
         const queryFetch = this.database.queryEvents.onFetch.subscribe(queryFilter);

--- a/packages/orm/src/query.ts
+++ b/packages/orm/src/query.ts
@@ -379,7 +379,7 @@ export class BaseQuery<T extends OrmEntity> {
     /**
      * Clear all filter conditions.
      */
-    filterNone(): this {
+    clearFilter(): this {
         const c = this.clone();
         c.model.filter = undefined;
         return c;

--- a/packages/orm/tests/query.spec.ts
+++ b/packages/orm/tests/query.spec.ts
@@ -31,6 +31,43 @@ test('query select', async () => {
     }
 });
 
+test('query filter', async () => {
+    class s {
+        id!: number & PrimaryKey;
+        score!: number;
+    }
+
+    const database = new Database(new MemoryDatabaseAdapter());
+    await database.persist(deserialize<s>({ id: 1, score: 1 }));
+    await database.persist(deserialize<s>({ id: 2, score: 2 }));
+    await database.persist(deserialize<s>({ id: 3, score: 3 }));
+
+    {
+        const results = await database.query(s).filter({ score: { $gt: 1 } }).find();
+        expect(results).toHaveLength(2);
+        expect(results).toMatchObject([{ id: 2 }, { id: 3 }]);
+    }
+
+    {
+        const results = await database.query(s).filter({ score: { $gt: 1 } }).filter({ score: { $lt: 3 } }).find();
+        expect(results).toHaveLength(1);
+        expect(results).toMatchObject([{ id: 2 }]);
+    }
+
+    {
+        const results = await database.query(s).filter({ score: { $gt: 1 } }).filterField('score', { $lt: 3 }).find();
+        expect(results).toHaveLength(1);
+        expect(results).toMatchObject([{ id: 2 }]);
+    }
+
+    {
+        const results = await database.query(s).filter({ score: { $gt: 1 } }).filterNone().find();
+        expect(results).toHaveLength(3);
+        expect(results).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    }
+    
+});
+
 test('query lift', async () => {
     class s {
         id!: number & PrimaryKey;
@@ -66,7 +103,7 @@ test('query lift', async () => {
 
     class BilligQuery<T extends { openBillings: number }> extends Query<T> {
         due() {
-            return this.addFilter('openBillings', { $gt: 0 });
+            return this.filterField('openBillings', { $gt: 0 });
         }
     }
 

--- a/packages/orm/tests/query.spec.ts
+++ b/packages/orm/tests/query.spec.ts
@@ -61,7 +61,7 @@ test('query filter', async () => {
     }
 
     {
-        const results = await database.query(s).filter({ score: { $gt: 1 } }).filterNone().find();
+        const results = await database.query(s).filter({ score: { $gt: 1 } }).clearFilter().find();
         expect(results).toHaveLength(3);
         expect(results).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
     }


### PR DESCRIPTION
### Summary of changes

- `query.filter()` now appends to rather than replaces the previous filter conditions.
- `query.addField()` is replaced by `query.filterField()`
- `query.filterNone()` is added to clear filter conditions

BREAKING CHANGE

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
