### PR TITLE
fix(postgres): add @types/pg to dependencies

### DIFF
--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -30,6 +30,7 @@
     "@deepkit/type": "^1.0.1-alpha.13"
   },
   "dependencies": {
+    "@types/pg": "^7.14.7",
     "pg": "^8.5.1",
     "pg-native": "^3.0.0",
     "sqlstring": "^2.3.2"
@@ -41,7 +42,6 @@
     "@deepkit/sql": "^1.0.1-alpha.71",
     "@deepkit/stopwatch": "^1.0.1-alpha.71",
     "@deepkit/type": "^1.0.1-alpha.71",
-    "@types/pg": "^7.14.7",
     "@types/sqlstring": "^2.2.1"
   },
   "jest": {


### PR DESCRIPTION
@types/pg is not installed for the end user if it is in devDependencies. this breaks type completion for the PostgresDatabaseAdapter constructor

### Summary of changes


<!-- My summary here. -->


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
