### PR TITLE
fix(injector): remove unused `deps` property

### DIFF
--- a/packages/framework/src/module.ts
+++ b/packages/framework/src/module.ts
@@ -161,7 +161,6 @@ export class FrameworkModule extends createModule({
 
             this.addProvider({
                 provide: OrmBrowserController,
-                deps: [DatabaseRegistry],
                 useFactory: (registry: DatabaseRegistry) => new OrmBrowserController(registry.getDatabases())
             });
             this.addController(DebugController);
@@ -179,7 +178,6 @@ export class FrameworkModule extends createModule({
                 this.addProvider(FileStopwatchStore);
                 this.addProvider({
                     provide: Stopwatch,
-                    deps: [FileStopwatchStore],
                     useFactory(store: FileStopwatchStore) {
                         return new Stopwatch(store);
                     }

--- a/packages/framework/src/testing.ts
+++ b/packages/framework/src/testing.ts
@@ -76,7 +76,7 @@ export function createTestingApp<O extends RootModuleDefinition>(options: O, ent
     module.addProvider(BrokerMemoryServer);
     module.addProvider(MemoryLoggerTransport);
     module.addProvider({
-        provide: Broker, deps: [BrokerServer], useFactory: (server: BrokerMemoryServer) => {
+        provide: Broker, useFactory: (server: BrokerMemoryServer) => {
             return new DirectBroker(server.kernel);
         }
     });

--- a/packages/injector/src/provider.ts
+++ b/packages/injector/src/provider.ts
@@ -70,18 +70,9 @@ export interface FactoryProvider<T> extends ProviderBase {
     provide: Token<T>;
 
     /**
-     * A function to invoke to create a value for this `token`. The function is invoked with
-     * resolved values of `token`s in the `deps` field.
+     * A function to invoke to create a value for this `token`.
      */
     useFactory: (...args: any[]) => T;
-
-    /**
-     * A list of `token`s which need to be resolved by the injector. The list of values is then
-     * used as arguments to the `useFactory` function.
-     *
-     * @deprecated not necessary anymore
-     */
-    deps?: any[];
 }
 
 /** @reflection never */


### PR DESCRIPTION
useFactory no longer relies on a `deps` array, but it is still being autocompleted

### Summary of changes


<!-- My summary here. -->


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
