### PR TITLE
Allow clients to provide the CompilerHost

### DIFF
--- a/packages/type-compiler/src/compiler.ts
+++ b/packages/type-compiler/src/compiler.ts
@@ -485,7 +485,6 @@ export class ReflectionTransformer implements CustomTransformer {
     protected nodeConverter: NodeConverter;
     protected typeChecker?: TypeChecker;
     protected resolver: Resolver;
-    protected host: CompilerHost;
 
     /**
      * When an deep call expression was found a script-wide variable is necessary
@@ -495,10 +494,10 @@ export class ReflectionTransformer implements CustomTransformer {
 
     constructor(
         protected context: TransformationContext,
+        protected host: CompilerHost,
     ) {
         this.f = context.factory;
         this.nodeConverter = new NodeConverter(this.f);
-        this.host = createCompilerHost(context.getCompilerOptions());
         this.resolver = new Resolver(context.getCompilerOptions(), this.host);
     }
 
@@ -2484,15 +2483,25 @@ export class DeclarationTransformer extends ReflectionTransformer {
 
 let loaded = false;
 
-export const transformer: CustomTransformerFactory = function deepkitTransformer(context) {
+export function buildDeepkitTransformer(context: TransformationContext, host: CompilerHost) {
     if (!loaded) {
         debug('@deepkit/type transformer loaded\n');
         loaded = true;
     }
-    return new ReflectionTransformer(context);
+    return new ReflectionTransformer(context, host);
+}
+
+export function transformer(context: TransformationContext) {
+    const host = createCompilerHost(context.getCompilerOptions());
+    return buildDeepkitTransformer(context, host);
 };
 
-export const declarationTransformer: CustomTransformerFactory = function deepkitDeclarationTransformer(context) {
-    return new DeclarationTransformer(context);
+export function buildDeepkitDeclarationTransformer(context: TransformationContext, host: CompilerHost) {
+    return new DeclarationTransformer(context, host);
+};
+
+export function declarationTransformer(context: TransformationContext) {
+    const host = createCompilerHost(context.getCompilerOptions());
+    return buildDeepkitDeclarationTransformer(context, host);
 };
 

--- a/packages/type-compiler/src/loader.ts
+++ b/packages/type-compiler/src/loader.ts
@@ -1,7 +1,7 @@
 // import {urlToRequest} from 'loader-utils';
 import * as ts from 'typescript';
 import { CompilerOptions, createCompilerHost, createSourceFile, ScriptTarget, SourceFile, TransformationContext } from 'typescript';
-import { ReflectionTransformer } from './compiler.js';
+import { transformer as buildTransformer } from './compiler.js';
 import ScriptKind = ts.ScriptKind;
 
 export class DeepkitLoader {
@@ -44,7 +44,7 @@ export class DeepkitLoader {
 
         ts.transform(sourceFile, [
             (context: TransformationContext) => {
-                const transformer = new ReflectionTransformer(context).forHost(this.host).withReflectionMode('always');
+                const transformer = buildTransformer(context).forHost(this.host).withReflectionMode('always');
                 return (node: SourceFile): SourceFile => {
                     const sourceFile = transformer.transformSourceFile(node);
 

--- a/packages/type-compiler/tests/transform.spec.ts
+++ b/packages/type-compiler/tests/transform.spec.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript';
 import { createSourceFile, ScriptTarget } from 'typescript';
 import { expect, test } from '@jest/globals';
-import { ReflectionTransformer } from '../src/compiler';
+import { transformer as buildTransformer } from '../src/compiler';
 import { transform } from './utils';
 
 test('transform simple', () => {
@@ -11,7 +11,7 @@ test('transform simple', () => {
         function fn(logger: Logger) {}
     `, ScriptTarget.ESNext);
 
-    const res = ts.transform(sourceFile, [(context) => (node) => new ReflectionTransformer(context).withReflectionMode('always').transformSourceFile(node)]);
+    const res = ts.transform(sourceFile, [(context) => (node) => buildTransformer(context).withReflectionMode('always').transformSourceFile(node)]);
     const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
     const code = printer.printNode(ts.EmitHint.SourceFile, res.transformed[0], res.transformed[0]);
 

--- a/packages/type-compiler/tests/utils.ts
+++ b/packages/type-compiler/tests/utils.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript';
 import { createSourceFile, getPreEmitDiagnostics, ScriptTarget, TransformationContext } from 'typescript';
 import { createSystem, createVirtualCompilerHost, knownLibFilesForCompilerOptions } from '@typescript/vfs';
-import { ReflectionTransformer } from '../src/compiler';
+import { transformer } from '../src/compiler';
 import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { first } from '@deepkit/core';
@@ -53,7 +53,7 @@ export function transform(files: Record<string, string>, options: ts.CompilerOpt
     for (const fileName of Object.keys(files)) {
         const sourceFile = host.compilerHost.getSourceFile(fullPath(fileName), ScriptTarget.ES2022);
         if (!sourceFile) continue;
-        const transform = ts.transform(sourceFile, [(context) => (node) => new ReflectionTransformer(context).forHost(host.compilerHost).withReflectionMode('always').transformSourceFile(node)]);
+        const transform = ts.transform(sourceFile, [(context) => (node) => transformer(context).forHost(host.compilerHost).withReflectionMode('always').transformSourceFile(node)]);
         const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
         const code = printer.printNode(ts.EmitHint.SourceFile, transform.transformed[0], transform.transformed[0]);
         res[fileName] = code;
@@ -111,7 +111,7 @@ export function transpile(files: Record<string, string>, options: ts.CompilerOpt
     program.emit(undefined, (fileName, data) => {
         res[fileName.slice(__dirname.length + 1).replace(/\.js$/, '')] = data;
     }, undefined, undefined, {
-        before: [(context: TransformationContext) => new ReflectionTransformer(context).forHost(host.compilerHost).withReflectionMode('always')],
+        before: [(context: TransformationContext) => transformer(context).forHost(host.compilerHost).withReflectionMode('always')],
     });
 
     return res;

--- a/packages/type/tests/compiler.spec.ts
+++ b/packages/type/tests/compiler.spec.ts
@@ -2,7 +2,7 @@
 import { describe, expect, test } from '@jest/globals';
 import * as ts from 'typescript';
 import { getPreEmitDiagnostics, ModuleKind, ScriptTarget, TransformationContext, transpileModule } from 'typescript';
-import { DeclarationTransformer, ReflectionTransformer, transformer } from '@deepkit/type-compiler';
+import { declarationTransformer, transformer } from '@deepkit/type-compiler';
 import { reflect, reflect as reflect2, ReflectionClass, removeTypeName, typeOf as typeOf2 } from '../src/reflection/reflection';
 import {
     assertType,
@@ -64,8 +64,8 @@ export function transpile<T extends string | Record<string, string>>(files: T, o
             fileName: __dirname + '/module.ts',
             compilerOptions,
             transformers: {
-                before: [(context: TransformationContext) => new ReflectionTransformer(context).withReflectionMode('always')],
-                afterDeclarations: [(context: TransformationContext) => new DeclarationTransformer(context).withReflectionMode('always')],
+                before: [(context: TransformationContext) => transformer(context).withReflectionMode('always')],
+                afterDeclarations: [(context: TransformationContext) => declarationTransformer(context).withReflectionMode('always')],
             }
         }).outputText as any;
     }
@@ -96,7 +96,7 @@ export function transpile<T extends string | Record<string, string>>(files: T, o
     program.emit(undefined, (fileName, data) => {
         res[fileName.slice(__dirname.length + 1)] = data;
     }, undefined, undefined, {
-        before: [(context: TransformationContext) => new ReflectionTransformer(context).forHost(host.compilerHost).withReflectionMode('always')],
+        before: [(context: TransformationContext) => transformer(context).forHost(host.compilerHost).withReflectionMode('always')],
     });
 
     return res as any;


### PR DESCRIPTION
### Summary of changes

TSC supports having clients pass the CompilerHost. This is used by Deno (and ChiselStrike) to integrate TSC. This PR makes it possible to use a TSC augmented with the deep type-compiler in the same way.

<!-- My summary here. -->


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
