### PR TITLE
fix(http): filterMiddlewaresForRoute should only needs one match

### DIFF
--- a/packages/http/src/router.ts
+++ b/packages/http/src/router.ts
@@ -335,14 +335,20 @@ function filterMiddlewaresForRoute(middlewareRawConfigs: MiddlewareRegistryEntry
         if (v.config.selfModule && v.module.id !== routeConfig.module?.id) return false;
 
         if (v.config.routeNames.length) {
+            let found: boolean = false;
             for (const name of v.config.routeNames) {
                 if (name.includes('*')) {
                     const regex = new RegExp('^' + name.replace(/\*/g, '.*') + '$');
-                    if (!regex.test(routeConfig.name)) return false;
-                } else if (name !== routeConfig.name) {
-                    return false;
+                    if (regex.test(routeConfig.name)) {
+                        found = true;
+                        break;
+                    }
+                } else if (name === routeConfig.name) {
+                    found = true;
+                    break;
                 }
             }
+            if (!found) return false;
         }
 
         if (v.config.excludeRouteNames.length) {


### PR DESCRIPTION
### Summary of changes

Fix https://github.com/deepkit/deepkit-framework/issues/284

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
