### PR TITLE
Fix an error reported by TSC 4.7.4

### DIFF
--- a/packages/orm/src/query.ts
+++ b/packages/orm/src/query.ts
@@ -250,7 +250,8 @@ export class BaseQuery<T extends OrmEntity> {
     select<K extends (keyof Resolve<this>)[]>(...select: K): Replace<this, Pick<Resolve<this>, K[number]>> {
         const c = this.clone();
         for (const field of select) {
-            if (!this.classSchema.hasProperty(field as string)) throw new Error(`Field ${field} unknown`);
+            const fieldStr = String(field);
+            if (!this.classSchema.hasProperty(fieldStr)) throw new Error(`Field ${fieldStr} unknown`);
         }
         c.model.select = new Set([...select as string[]]);
         return c as any;
@@ -412,7 +413,8 @@ export class BaseQuery<T extends OrmEntity> {
     join<K extends keyof ReferenceFields<T>, ENTITY = FlattenIfArray<T[K]>>(field: K, type: 'left' | 'inner' = 'left', populate: boolean = false): this {
         const propertySchema = this.classSchema.getProperty(field as string);
         if (!propertySchema.isReference() && !propertySchema.isBackReference()) {
-            throw new Error(`Field ${field} is not marked as reference. Use @t.reference()`);
+            const fieldStr = String(field);
+            throw new Error(`Field ${fieldStr} is not marked as reference. Use @t.reference()`);
         }
         const c = this.clone();
 
@@ -458,7 +460,8 @@ export class BaseQuery<T extends OrmEntity> {
         for (const join of this.model.joins) {
             if (join.propertySchema.name === field) return join.query;
         }
-        throw new Error(`No join fo reference ${field} added.`);
+        const fieldStr = String(field);
+        throw new Error(`No join fo reference ${fieldStr} added.`);
     }
 
     /**


### PR DESCRIPTION
When trying to upgrade TSC I got errors like:

    packages/orm/src/query.ts:253:90 - error TS2731: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.

    253             if (!this.classSchema.hasProperty(field as string)) throw new Error(`Field ${field} unknown`);

This patch fixes them.


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
