### PR TITLE
use same serializer for reads as writes

### DIFF
--- a/packages/sql/src/sql-adapter.ts
+++ b/packages/sql/src/sql-adapter.ts
@@ -176,7 +176,7 @@ export class SQLQueryResolver<T extends OrmEntity> extends GenericQueryResolver<
     protected createFormatter(withIdentityMap: boolean = false) {
         return new SqlFormatter(
             this.classSchema,
-            sqlSerializer,
+            this.platform.serializer,
             this.session.getHydrator(),
             withIdentityMap ? this.session.identityMap : undefined
         );

--- a/packages/sql/src/sql-adapter.ts
+++ b/packages/sql/src/sql-adapter.ts
@@ -37,7 +37,6 @@ import { Changes, getPartialSerializeFunction, getSerializeFunction, ReceiveType
 import { DefaultPlatform, SqlPlaceholderStrategy } from './platform/default-platform';
 import { SqlBuilder } from './sql-builder';
 import { SqlFormatter } from './sql-formatter';
-import { sqlSerializer } from './serializer/sql-serializer';
 import { DatabaseComparator, DatabaseModel } from './schema/table';
 import { Stopwatch } from '@deepkit/stopwatch';
 


### PR DESCRIPTION
Signed-off-by: fergusean <fergusean@gmail.com>

### Summary of changes

When creating a custom class to support database features and registering a serializer and deserializer, it seems the base SQL adapter uses a different registry for [serialization](https://github.com/deepkit/deepkit-framework/blob/e1789a02174d0e48d76f641befb7af2421578cf2/packages/sql/src/sql-adapter.ts#L742) (`adapter.platform.serializer.serializerRegistry`) to the database than it does for deserialization from the database (`sqlSerializer.deserializerRegistry`).  This PR aligns them to use the same.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
