### PR TITLE
fix: app crashed with --enable-source-maps

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -700,7 +700,8 @@ export function isIterable(value: any): boolean {
  */
 export function getCurrentFileName(): string {
     const e = new Error;
-    const initiator = e.stack!.split('\n').slice(2, 3)[0];
+    const errorStart = e.stack.indexOf('Error\n');
+    const initiator = e.stack.slice(errorStart).split('\n').slice(2, 3)[0];
     let path = /(?<path>[^(\s]+):[0-9]+:[0-9]+/.exec(initiator)!.groups!.path;
     if (path.indexOf('file') >= 0) {
         path = new URL(path).pathname;


### PR DESCRIPTION
It seems counting on the line number of the stacktrace doesn't always get us to the "__filename".

```bash
    const e = new Error;
              ^

Error
    at null.getCurrentFileName (/Users/chenyuwang/deepkit-openapi/node_modules/@deepkit/core/src/core.ts:702:15)
    at App.execute (/Users/chenyuwang/deepkit-openapi/node_modules/@deepkit/app/src/app.ts:335:75)
    at App.run (/Users/chenyuwang/deepkit-openapi/node_modules/@deepkit/app/src/app.ts:264:37)
    at Object.<anonymous> (/Users/chenyuwang/deepkit-openapi/packages/example-app/app.ts:92:4)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47
```

when `NODE_OPTIONS=--enable-source-maps`, the first lines will be the snippet of where that error happens, instead of part of the stacktrace.

This patch ensures us to find the beginning of the stacktrace.

Signed-off-by: wang chenyu <26056783+hanayashiki@users.noreply.github.com>

### Summary of changes


<!-- My summary here. -->


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
