### PR TITLE
add type to RouteParameterResolverContext

### DIFF
--- a/packages/http/src/router.ts
+++ b/packages/http/src/router.ts
@@ -308,7 +308,7 @@ export interface RouteParameterResolverContext {
 
     query: HttpRequestQuery;
     parameters: HttpRequestResolvedParameters;
-    optional: boolean;
+    type: ReflectionParameter;
 }
 
 function filterMiddlewaresForRoute(middlewareRawConfigs: MiddlewareRegistryEntry[], routeConfig: RouteConfig, fullPath: string): { config: HttpMiddlewareConfig, module: InjectorModule<any> }[] {
@@ -790,7 +790,7 @@ export class HttpRouter {
                             value: parameters.${parameter.parameter.name},
                             query: _query,
                             parameters: parameters,
-                            optional: ${parameter.parameter.isOptional()}
+                            type: ${compiler.reserveVariable('parameterType', parameter.parameter)}
                         });
                     }`);
                 }

--- a/packages/http/src/router.ts
+++ b/packages/http/src/router.ts
@@ -308,6 +308,7 @@ export interface RouteParameterResolverContext {
 
     query: HttpRequestQuery;
     parameters: HttpRequestResolvedParameters;
+    optional: boolean;
 }
 
 function filterMiddlewaresForRoute(middlewareRawConfigs: MiddlewareRegistryEntry[], routeConfig: RouteConfig, fullPath: string): { config: HttpMiddlewareConfig, module: InjectorModule<any> }[] {
@@ -788,7 +789,8 @@ export class HttpRouter {
                             name: ${JSON.stringify(parameter.parameter.name)},
                             value: parameters.${parameter.parameter.name},
                             query: _query,
-                            parameters: parameters
+                            parameters: parameters,
+                            optional: ${parameter.parameter.isOptional()}
                         });
                     }`);
                 }

--- a/packages/http/tests/parameter-resolver.spec.ts
+++ b/packages/http/tests/parameter-resolver.spec.ts
@@ -6,6 +6,7 @@ import { RouteConfig, RouteParameterResolver, RouteParameterResolverContext, } f
 import { createHttpKernel } from './utils';
 import { HttpModule } from '../src/module.js';
 import { HttpKernel } from '../src/kernel.js';
+import { ReflectionClass } from '@deepkit/type';
 
 test('parameter resolver by name', async () => {
     class Resolver implements RouteParameterResolver {
@@ -27,6 +28,9 @@ test('parameter resolver by name', async () => {
     const httpKernel = createHttpKernel([Controller], [Resolver]);
     await httpKernel.request(HttpRequest.GET('/'));
 
+    const reflectionClass = ReflectionClass.from(Controller).getMethod('route');
+    const reflectionParameter = reflectionClass.getParameter('value');
+
     const expectedContext: RouteParameterResolverContext = {
         name: 'value',
         token: undefined,
@@ -35,6 +39,7 @@ test('parameter resolver by name', async () => {
         request: expect.anything() as any,
         query: {},
         parameters: { value: 'value' },
+        type: reflectionParameter
     };
     expect(Resolver.prototype.resolve).toHaveBeenCalledWith(expectedContext);
     expect(Controller.prototype.route).toHaveBeenCalledWith('value');


### PR DESCRIPTION
### Summary of changes
Provides resolvers with type information.  As an example case, this enables a resolver to determine optionality in order to understand if they should throw vs return `undefined` in the event they're unable to resolve a value.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
