### PR TITLE
fix(sqlite): fix off-by-one in max number of active connections

### DIFF
--- a/packages/sqlite/src/sqlite-adapter.ts
+++ b/packages/sqlite/src/sqlite-adapter.ts
@@ -207,7 +207,7 @@ export class SQLiteConnectionPool extends SQLConnectionPool {
         }
 
         const connection = this.firstConnection && this.firstConnection.released ? this.firstConnection :
-            this.activeConnections > this.maxConnections
+            this.activeConnections >= this.maxConnections
                 //we wait for the next query to be released and reuse it
                 ? await asyncOperation<SQLiteConnection>((resolve) => {
                     this.queue.push(resolve);

--- a/packages/sqlite/tests/sqlite.spec.ts
+++ b/packages/sqlite/tests/sqlite.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@jest/globals';
 import { SQLitePlatform } from '../src/sqlite-platform';
 import { databaseFactory } from './factory';
 import { User, UserCredentials } from '@deepkit/orm-integration';
-import { SQLiteDatabaseAdapter, SQLiteDatabaseTransaction } from '../src/sqlite-adapter';
+import { SQLiteConnection, SQLiteDatabaseAdapter, SQLiteDatabaseTransaction } from '../src/sqlite-adapter';
 import { sleep } from '@deepkit/core';
 import { AutoIncrement, cast, Entity, entity, PrimaryKey, Reference, ReflectionClass, serialize, typeOf, UUID, uuid } from '@deepkit/type';
 import { Database, DatabaseEntityRegistry } from '@deepkit/orm';
@@ -262,6 +262,32 @@ test('connection pool', async () => {
         c2.release();
         await sleep(0.01);
         expect(c12).toBe(c2);
+    }
+});
+
+test(':memory: connection pool', async () => {
+    const sqlite = new SQLiteDatabaseAdapter(':memory:');
+
+    // create a connection, or return null if it takes longer than 100 ms
+    const createConnectionOrNull = () => Promise.race([
+        sqlite.connectionPool.getConnection(),
+        sleep(0.1).then(() => null),
+    ])
+
+    {
+        const c1 = await sqlite.connectionPool.getConnection();
+        const c2 = await createConnectionOrNull();
+        const c3 = await createConnectionOrNull();
+
+        expect(sqlite.connectionPool.getActiveConnections()).toBeLessThanOrEqual(sqlite.connectionPool.maxConnections);
+
+        expect(c1).toBeDefined();
+        expect(c2).toBeNull();
+        expect(c3).toBeNull();
+
+        c1.release();
+        c2?.release();
+        c3?.release();
     }
 });
 

--- a/packages/sqlite/tests/sqlite.spec.ts
+++ b/packages/sqlite/tests/sqlite.spec.ts
@@ -229,6 +229,8 @@ test('connection pool', async () => {
 
         const c3 = await sqlite.connectionPool.getConnection();
         expect(c3 === c1).toBe(true);
+
+        c3.release();
     }
 
     {


### PR DESCRIPTION
### Summary of changes


<!-- My summary here. -->

Fixed an off-by-one error in the connection pool for sqlite, that causes one too many connections to be allowed to be created. This is especially problematic for SQLite :memory: databases, as having multiple connections to these is not possible. Instead, this will create two disjoint in-memory databases, which is problematic 


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
