### PR TITLE
refactor(sqlite): getter/setter for maxConnections

### DIFF
--- a/packages/sqlite/src/sqlite-adapter.ts
+++ b/packages/sqlite/src/sqlite-adapter.ts
@@ -176,7 +176,7 @@ export class SQLiteConnection extends SQLConnection {
 }
 
 export class SQLiteConnectionPool extends SQLConnectionPool {
-    public maxConnections: number = 10;
+    protected maxConnections: number = 10;
 
     protected queue: ((connection: SQLiteConnection) => void)[] = [];
 
@@ -186,7 +186,23 @@ export class SQLiteConnectionPool extends SQLConnectionPool {
     constructor(protected dbPath: string | ':memory:') {
         super();
         //memory databases can not have more than one connection
-        if (dbPath === ':memory:') this.maxConnections = 1;
+        if (dbPath === ':memory:') this.setMaxConnections(1);
+    }
+
+    getMaxConnections(): number {
+        return this.maxConnections;
+    }
+
+    setMaxConnections(maxConnections: number) {
+        if (maxConnections < 1) {
+            throw new Error('Max connections must be at least 1');
+        }
+
+        if (this.dbPath === ':memory:' && maxConnections !== 1) {
+            throw new Error('Memory databases can not have more than one connection');
+        }
+
+        this.maxConnections = maxConnections;
     }
 
     close() {

--- a/packages/sqlite/tests/sqlite.spec.ts
+++ b/packages/sqlite/tests/sqlite.spec.ts
@@ -2,10 +2,10 @@ import { expect, test } from '@jest/globals';
 import { SQLitePlatform } from '../src/sqlite-platform';
 import { databaseFactory } from './factory';
 import { User, UserCredentials } from '@deepkit/orm-integration';
-import { SQLiteConnection, SQLiteDatabaseAdapter, SQLiteDatabaseTransaction } from '../src/sqlite-adapter';
+import { SQLiteDatabaseAdapter, SQLiteDatabaseTransaction } from '../src/sqlite-adapter';
 import { sleep } from '@deepkit/core';
 import { AutoIncrement, cast, Entity, entity, PrimaryKey, Reference, ReflectionClass, serialize, typeOf, UUID, uuid } from '@deepkit/type';
-import { Database, DatabaseEntityRegistry } from '@deepkit/orm';
+import { DatabaseEntityRegistry } from '@deepkit/orm';
 import { BackReference } from '@deepkit/type';
 
 test('reflection circular reference', () => {
@@ -281,7 +281,8 @@ test(':memory: connection pool', async () => {
         const c2 = await createConnectionOrNull();
         const c3 = await createConnectionOrNull();
 
-        expect(sqlite.connectionPool.getActiveConnections()).toBeLessThanOrEqual(sqlite.connectionPool.maxConnections);
+        expect(sqlite.connectionPool.getActiveConnections())
+            .toBeLessThanOrEqual(sqlite.connectionPool.getMaxConnections());
 
         expect(c1).toBeDefined();
         expect(c2).toBeNull();


### PR DESCRIPTION
### Summary of changes


<!-- My summary here. -->
Made `SQLiteConnectionPool.maxConnections` a protected property, and introduced getters and setters. There is similarly already a getter `getActiveConnections()`, and the new setter ensures that it is impossible to have more than 1 connection for in-memory databases

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
