### PR TITLE
adds support for expireAfterSeconds index for mongodb

### DIFF
--- a/packages/mongo/src/adapter.ts
+++ b/packages/mongo/src/adapter.ts
@@ -125,11 +125,14 @@ export class MongoDatabaseAdapter extends DatabaseAdapter {
 
             const indexName = index.options.name || index.names.join('_');
             const createIndex: CreateIndex = {
-                name: index.options.name || index.names.join('_'),
+                name: indexName,
                 key: fields,
                 unique: !!index.options.unique,
                 sparse: !!index.options.sparse,
             };
+            if (index.options.expireAfterSeconds) {
+                createIndex.expireAfterSeconds = Number(index.options.expireAfterSeconds);
+            }
 
             try {
                 await this.client.execute(new CreateIndexesCommand(schema, [createIndex]));

--- a/packages/mongo/src/client/command/createIndexes.ts
+++ b/packages/mongo/src/client/command/createIndexes.ts
@@ -16,7 +16,8 @@ export interface CreateIndex {
     key: { [name: string]: 1 },
     name: string,
     unique: boolean,
-    sparse: boolean
+    sparse: boolean,
+    expireAfterSeconds?: number
 }
 
 interface RequestSchema {
@@ -28,7 +29,7 @@ interface RequestSchema {
 export class CreateIndexesCommand<T extends ReflectionClass<any>> extends Command {
     constructor(
         public schema: T,
-        public indexes: { key: { [name: string]: 1 }, name: string, unique: boolean, sparse: boolean }[],
+        public indexes: CreateIndex[],
     ) {
         super();
     }

--- a/packages/mongo/tests/mongo-index.spec.ts
+++ b/packages/mongo/tests/mongo-index.spec.ts
@@ -1,0 +1,59 @@
+import {
+    entity, MongoId, Index, PrimaryKey, Unique, ReflectionClass,
+} from '@deepkit/type';
+import { expect, test } from '@jest/globals';
+import { MongoDatabaseAdapter } from '../src/adapter';
+import { Database } from '@deepkit/orm';
+
+@entity.name('model-with-indexes')
+class Model {
+    _id: MongoId & PrimaryKey = '';
+    department: number & Index & Unique = 0;
+    homeoffice: number & Index<{ sparse: true }> = 0;
+    something: number & Index<{ sparse: true, unique: true }> = 0;
+    another: number & Index<{ unique: true }> = 0;
+    // notIntendedAItSeemsOrBug: number & Index<{sparse: true}> & Unique = 0; // sparse missing: options: { unique: true }
+    createdAt: Date & Index<{ expireAfterSeconds: 3600 }> = new Date();
+
+    constructor(public name: string) {
+    }
+}
+
+
+test('Index in ClassSchema', async () => {
+
+    const schema = ReflectionClass.from(Model);
+
+    // console.log(schema.getIndexSignatures()); // throws todo error
+    // console.log(schema.indexes)
+
+    // get index with [0] is a bit lazy and might fail?
+    expect(schema.indexes[0]).toMatchObject({names: ['department'], options: {unique: true}});
+    expect(schema.indexes[1]).toMatchObject({names: ['homeoffice'], options: {sparse: true}});
+    expect(schema.indexes[2]).toMatchObject({names: ['something'], options: {sparse: true, unique: true}});
+    expect(schema.indexes[3]).toMatchObject({names: ['another'], options: {unique: true}});
+    expect(schema.indexes[4]).toMatchObject({names: ['createdAt'], options: {expireAfterSeconds: 3600}});
+});
+
+
+test('migrate()', async () => {
+    const db = new Database(new MongoDatabaseAdapter(`mongodb://127.0.0.1/testing`), [Model]);
+    await db.query(Model).deleteMany();
+
+    await db.migrate();
+
+    // TODO no idea how to get the indexes out of db to compare
+    // at least you can manually look into the db to check the indexes
+
+    // some data to see something
+    const item = new Model('foo');
+    item.department = 42;
+    item.homeoffice = 123;
+    item.something = 456;
+    item.another = 789;
+    await db.persist(item);
+    const dbItem = await db.query(Model).filter({name: 'foo'}).findOne();
+    expect(dbItem).not.toBe(item);
+
+    db.disconnect();
+});

--- a/packages/type/src/reflection/type.ts
+++ b/packages/type/src/reflection/type.ts
@@ -1677,6 +1677,8 @@ export type IndexOptions = {
     //only in mongodb
     fulltext?: boolean,
     where?: string,
+
+    expireAfterSeconds?: number,
 };
 
 export type Unique<Options extends IndexOptions = {}> = { __meta?: ['index', never & Options & { unique: true }] };


### PR DESCRIPTION
### Summary of changes

adds support for expireAfterSeconds index for mongodb

a jest test is provided BUT ...
I've no idea how to get the indexes out of db to compare.
At least you can manually look into the db to check the indexes and I can see that the indexes are created as intended.

A possible small bug I've found: look for "notIntendedAItSeemsOrBug"


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
