### PR TITLE
Use cross-environment `globalThis` to access the global object.

### DIFF
--- a/packages/type/src/type-serialization.ts
+++ b/packages/type/src/type-serialization.ts
@@ -234,7 +234,7 @@ export type SerializedType =
 
 export type SerializedTypes = SerializedType[];
 
-const envGlobal = typeof globalThis !== "undefined"
+const envGlobal: any = typeof globalThis !== "undefined"
     ? globalThis
     : typeof global !== "undefined"
     ? global
@@ -353,7 +353,7 @@ function serialize(type: Type, state: SerializerState): SerializedTypeReference 
             }
 
             const classType = getClassName(type.classType);
-            const globalObject: boolean = envGlobal && (envGlobal as any)[classType] === type.classType;
+            const globalObject: boolean = envGlobal && envGlobal[classType] === type.classType;
 
             Object.assign(result, {
                 kind: ReflectionKind.class,
@@ -637,7 +637,7 @@ function deserialize(type: SerializedType | SerializedTypeReference, state: Dese
                 }
             }
 
-            const classType = type.globalObject ? (envGlobal as any)[type.classType] : newClass
+            const classType = type.globalObject ? envGlobal[type.classType] : newClass
                 ? (type.superClass ? class extends (deserialize(type.superClass, state) as TypeClass).classType {
                     constructor(...args: any[]) {
                         super(...args);

--- a/packages/type/src/type-serialization.ts
+++ b/packages/type/src/type-serialization.ts
@@ -234,6 +234,12 @@ export type SerializedType =
 
 export type SerializedTypes = SerializedType[];
 
+const envGlobal = typeof globalThis !== "undefined"
+    ? globalThis
+    : typeof global !== "undefined"
+    ? global
+    : window;
+
 function isWithSerializedAnnotations(type: any): type is SerializedTypeAnnotations {
     return isWithAnnotations(type);
 }
@@ -347,7 +353,7 @@ function serialize(type: Type, state: SerializerState): SerializedTypeReference 
             }
 
             const classType = getClassName(type.classType);
-            const globalObject: boolean = global && (global as any)[classType] === type.classType;
+            const globalObject: boolean = envGlobal && (envGlobal as any)[classType] === type.classType;
 
             Object.assign(result, {
                 kind: ReflectionKind.class,
@@ -631,7 +637,7 @@ function deserialize(type: SerializedType | SerializedTypeReference, state: Dese
                 }
             }
 
-            const classType = type.globalObject ? (global as any)[type.classType] : newClass
+            const classType = type.globalObject ? (envGlobal as any)[type.classType] : newClass
                 ? (type.superClass ? class extends (deserialize(type.superClass, state) as TypeClass).classType {
                     constructor(...args: any[]) {
                         super(...args);


### PR DESCRIPTION
### Summary of changes


Prefers using [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) to access the global object, which is standard across node and browser environments. I'm not sure what versions of browsers/node Deepkit is obligated to support, so we may be able to drop the `envGlobal` variable and just go with `globalThis` everywhere.


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
