### PR TITLE
fix(create-app): remove .js extension for the files being created

### DIFF
--- a/packages/create-app/files/app.ts
+++ b/packages/create-app/files/app.ts
@@ -2,11 +2,11 @@ import { App } from '@deepkit/app';
 import { FrameworkModule } from '@deepkit/framework';
 import { Logger, JSONTransport } from '@deepkit/logger';
 
-import { HelloWorldControllerCli } from './src/controller/hello-world.cli.js';
-import { HelloWorldControllerHttp } from './src/controller/hello-world.http.js';
-import { HelloWorldControllerRpc } from './src/controller/hello-world.rpc.js';
-import { Service } from './src/app/service.js';
-import { AppConfig } from './src/app/config.js';
+import { HelloWorldControllerCli } from './src/controller/hello-world.cli';
+import { HelloWorldControllerHttp } from './src/controller/hello-world.http';
+import { HelloWorldControllerRpc } from './src/controller/hello-world.rpc';
+import { Service } from './src/app/service';
+import { AppConfig } from './src/app/config';
 
 new App({
     config: AppConfig,

--- a/packages/create-app/files/client.rpc.ts
+++ b/packages/create-app/files/client.rpc.ts
@@ -1,7 +1,7 @@
 import { RpcWebSocketClient } from '@deepkit/rpc';
 
 //`import type` is important, since we do not want to import server code in the runtime.
-import type { HelloWorldControllerRpc } from './src/controller/hello-world.rpc.js';
+import type { HelloWorldControllerRpc } from './src/controller/hello-world.rpc';
 
 async function main() {
     const client = new RpcWebSocketClient('http://localhost:8080');

--- a/packages/create-app/files/package.json
+++ b/packages/create-app/files/package.json
@@ -50,9 +50,6 @@
     "transform": {
       "^.+\\.(ts|tsx)$": "ts-jest"
     },
-    "moduleNameMapper": {
-      "(.+)\\.js": "$1"
-    },
     "testEnvironment": "node",
     "testMatch": [
       "**/*.spec.ts"

--- a/packages/create-app/files/src/controller/hello-world.cli.ts
+++ b/packages/create-app/files/src/controller/hello-world.cli.ts
@@ -1,7 +1,7 @@
 import { MaxLength } from '@deepkit/type';
 import { cli, arg } from '@deepkit/app';
 import { Logger } from '@deepkit/logger';
-import { Service } from '../app/service.js';
+import { Service } from '../app/service';
 
 @cli.controller('hello')
 export class HelloWorldControllerCli {

--- a/packages/create-app/files/src/controller/hello-world.http.ts
+++ b/packages/create-app/files/src/controller/hello-world.http.ts
@@ -1,6 +1,6 @@
 import { MaxLength } from '@deepkit/type';
 import { http } from '@deepkit/http';
-import { Service } from '../app/service.js';
+import { Service } from '../app/service';
 
 export class HelloWorldControllerHttp {
     constructor(private service: Service) {

--- a/packages/create-app/files/src/controller/hello-world.rpc.ts
+++ b/packages/create-app/files/src/controller/hello-world.rpc.ts
@@ -1,6 +1,6 @@
 import { MaxLength } from '@deepkit/type';
 import { rpc } from '@deepkit/rpc';
-import { Service } from '../app/service.js';
+import { Service } from '../app/service';
 
 @rpc.controller('/main')
 export class HelloWorldControllerRpc {

--- a/packages/create-app/files/tests/app.spec.ts
+++ b/packages/create-app/files/tests/app.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@jest/globals';
-import { Service } from '../src/app/service.js';
+import { Service } from '../src/app/service';
 import { Logger, MemoryLoggerTransport } from '@deepkit/logger';
 import { createTestingApp } from '@deepkit/framework';
 

--- a/packages/create-app/files/tests/cli.spec.ts
+++ b/packages/create-app/files/tests/cli.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@jest/globals';
 import { createTestingApp } from '@deepkit/framework';
-import { Service } from '../src/app/service.js';
-import { HelloWorldControllerCli } from '../src/controller/hello-world.cli.js';
+import { Service } from '../src/app/service';
+import { HelloWorldControllerCli } from '../src/controller/hello-world.cli';
 
 test('cli command', async () => {
     const testing = createTestingApp({

--- a/packages/create-app/files/tests/http.spec.ts
+++ b/packages/create-app/files/tests/http.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@jest/globals';
 import { createTestingApp } from '@deepkit/framework';
-import { Service } from '../src/app/service.js';
-import { HelloWorldControllerHttp } from '../src/controller/hello-world.http.js';
+import { Service } from '../src/app/service';
+import { HelloWorldControllerHttp } from '../src/controller/hello-world.http';
 import { HttpRequest } from '@deepkit/http';
 
 test('http controller', async () => {

--- a/packages/create-app/files/tests/rpc.spec.ts
+++ b/packages/create-app/files/tests/rpc.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@jest/globals';
 import { createTestingApp } from '@deepkit/framework';
-import { Service } from '../src/app/service.js';
-import { HelloWorldControllerRpc } from '../src/controller/hello-world.rpc.js';
+import { Service } from '../src/app/service';
+import { HelloWorldControllerRpc } from '../src/controller/hello-world.rpc';
 
 test('rpc controller', async () => {
     const testing = createTestingApp({


### PR DESCRIPTION
### Summary of changes


This change removes the .js extension for the files that will be created through `npm init @deepkit/app`


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
