### PR TITLE
feat: added CUID type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ packages/create-app/files/dist
 packages/create-app/files/var
 .vs
 .fleet
+.vscode
+.tool-versions

--- a/packages/type/package-lock.json
+++ b/packages/type/package-lock.json
@@ -1,301 +1,607 @@
 {
-	"name": "@deepkit/type",
-	"version": "1.0.1-alpha.91",
-	"lockfileVersion": 2,
-	"requires": true,
-	"packages": {
-		"": {
-			"name": "@deepkit/type",
-			"version": "1.0.1-alpha.71",
-			"license": "MIT",
-			"dependencies": {
-				"@types/uuid": "^8.3.0",
-				"buffer": "^5.2.1",
-				"uuid": "^8.3.2"
-			},
-			"devDependencies": {
-				"@types/lz-string": "^1.3.34",
-				"@types/node": "14.14.28",
-				"@typescript/vfs": "^1.3.5",
-				"lz-string": "^1.4.4"
-			},
-			"peerDependencies": {
-				"@deepkit/core": "^1.0.1-alpha.13"
-			}
-		},
-		"node_modules/@deepkit/core": {
-			"version": "1.0.1-alpha.65",
-			"resolved": "https://registry.npmjs.org/@deepkit/core/-/core-1.0.1-alpha.65.tgz",
-			"integrity": "sha512-L52r3uSGu+kEjsq/9vVoora2fIWDFi/wmwkGtDJjbpbW1oY02jGYy73ImM7jeKeTfFen+3bw6Fk+tTVH4EChRg==",
-			"peer": true,
-			"dependencies": {
-				"dot-prop": "^5.1.1",
-				"to-fast-properties": "^3.0.1"
-			}
-		},
-		"node_modules/@types/lz-string": {
-			"version": "1.3.34",
-			"resolved": "https://registry.npmjs.org/@types/lz-string/-/lz-string-1.3.34.tgz",
-			"integrity": "sha512-j6G1e8DULJx3ONf6NdR5JiR2ZY3K3PaaqiEuKYkLQO0Czfi1AzrtjfnfCROyWGeDd5IVMKCwsgSmMip9OWijow==",
-			"dev": true
-		},
-		"node_modules/@types/node": {
-			"version": "14.14.28",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.28.tgz",
-			"integrity": "sha512-lg55ArB+ZiHHbBBttLpzD07akz0QPrZgUODNakeC09i62dnrywr9mFErHuaPlB6I7z+sEbK+IYmplahvplCj2g==",
-			"dev": true
-		},
-		"node_modules/@types/uuid": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-			"integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
-		},
-		"node_modules/@typescript/vfs": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.3.5.tgz",
-			"integrity": "sha512-pI8Saqjupf9MfLw7w2+og+fmb0fZS0J6vsKXXrp4/PDXEFvntgzXmChCXC/KefZZS0YGS6AT8e0hGAJcTsdJlg==",
-			"dev": true,
-			"dependencies": {
-				"debug": "^4.1.1"
-			}
-		},
-		"node_modules/base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
-		"node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/dot-prop": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-			"peer": true,
-			"dependencies": {
-				"is-obj": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/is-obj": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/lz-string": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-			"integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
-			"dev": true,
-			"bin": {
-				"lz-string": "bin/bin.js"
-			}
-		},
-		"node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
-		"node_modules/to-fast-properties": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-3.0.1.tgz",
-			"integrity": "sha512-/wtNi1tW1F3nf0OL6AqVxGw9Tr1ET70InMhJuVxPwFdGqparF0nQ4UWGLf2DsoI2bFDtthlBnALncZpUzOnsUw==",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		}
-	},
-	"dependencies": {
-		"@deepkit/core": {
-			"version": "1.0.1-alpha.65",
-			"resolved": "https://registry.npmjs.org/@deepkit/core/-/core-1.0.1-alpha.65.tgz",
-			"integrity": "sha512-L52r3uSGu+kEjsq/9vVoora2fIWDFi/wmwkGtDJjbpbW1oY02jGYy73ImM7jeKeTfFen+3bw6Fk+tTVH4EChRg==",
-			"peer": true,
-			"requires": {
-				"dot-prop": "^5.1.1",
-				"to-fast-properties": "^3.0.1"
-			}
-		},
-		"@types/lz-string": {
-			"version": "1.3.34",
-			"resolved": "https://registry.npmjs.org/@types/lz-string/-/lz-string-1.3.34.tgz",
-			"integrity": "sha512-j6G1e8DULJx3ONf6NdR5JiR2ZY3K3PaaqiEuKYkLQO0Czfi1AzrtjfnfCROyWGeDd5IVMKCwsgSmMip9OWijow==",
-			"dev": true
-		},
-		"@types/node": {
-			"version": "14.14.28",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.28.tgz",
-			"integrity": "sha512-lg55ArB+ZiHHbBBttLpzD07akz0QPrZgUODNakeC09i62dnrywr9mFErHuaPlB6I7z+sEbK+IYmplahvplCj2g==",
-			"dev": true
-		},
-		"@types/uuid": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-			"integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
-		},
-		"@typescript/vfs": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.3.5.tgz",
-			"integrity": "sha512-pI8Saqjupf9MfLw7w2+og+fmb0fZS0J6vsKXXrp4/PDXEFvntgzXmChCXC/KefZZS0YGS6AT8e0hGAJcTsdJlg==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.1.1"
-			}
-		},
-		"base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-		},
-		"buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"requires": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
-		"debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"requires": {
-				"ms": "2.1.2"
-			}
-		},
-		"dot-prop": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-			"peer": true,
-			"requires": {
-				"is-obj": "^2.0.0"
-			}
-		},
-		"ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-		},
-		"is-obj": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-			"peer": true
-		},
-		"lz-string": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-			"integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
-			"dev": true
-		},
-		"ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
-		"to-fast-properties": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-3.0.1.tgz",
-			"integrity": "sha512-/wtNi1tW1F3nf0OL6AqVxGw9Tr1ET70InMhJuVxPwFdGqparF0nQ4UWGLf2DsoI2bFDtthlBnALncZpUzOnsUw==",
-			"peer": true
-		},
-		"uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-		}
-	}
+  "name": "@deepkit/type",
+  "version": "1.0.1-alpha.91",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@deepkit/type",
+      "version": "1.0.1-alpha.91",
+      "license": "MIT",
+      "dependencies": {
+        "@deepkit/type-spec": "^1.0.1-alpha.89",
+        "@paralleldrive/cuid2": "^2.2.0",
+        "@types/uuid": "^8.3.0",
+        "buffer": "^5.2.1",
+        "uuid": "^8.3.2"
+      },
+      "devDependencies": {
+        "@deepkit/core": "^1.0.1-alpha.89",
+        "@deepkit/type-compiler": "^1.0.1-alpha.89",
+        "@types/lz-string": "^1.3.34",
+        "@types/node": "14.14.28",
+        "@typescript/vfs": "^1.3.5",
+        "lz-string": "^1.4.4"
+      },
+      "peerDependencies": {
+        "@deepkit/core": "^1.0.1-alpha.13"
+      }
+    },
+    "node_modules/@deepkit/core": {
+      "version": "1.0.1-alpha.89",
+      "resolved": "https://registry.npmjs.org/@deepkit/core/-/core-1.0.1-alpha.89.tgz",
+      "integrity": "sha512-jPZrAywuo70fsy8+ORO5lcCse5x0yLEP6Axnd4cg8HnByQK9sqtTP6VieAlIK5d2Li3TOoSHiSNiV2kxQsjpDw==",
+      "dev": true,
+      "dependencies": {
+        "dot-prop": "^5.1.1",
+        "to-fast-properties": "^3.0.1"
+      }
+    },
+    "node_modules/@deepkit/type-compiler": {
+      "version": "1.0.1-alpha.89",
+      "resolved": "https://registry.npmjs.org/@deepkit/type-compiler/-/type-compiler-1.0.1-alpha.89.tgz",
+      "integrity": "sha512-K+GAufjSepQsG6vkRAMErIeKno0BFCycSPWT/fWEjP6PtuWkTrgpi7vZKbXJsxV+yFoa/ePV1PKa4x2hkIv1xg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@deepkit/type-spec": "^1.0.1-alpha.89",
+        "@marcj/ts-clone-node": "^2.0.0",
+        "@typescript/vfs": "^1.4.0",
+        "lz-string": "^1.4.4",
+        "micromatch": "^4.0.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "deepkit-type-install": "dist/cjs/install-transformer.js"
+      },
+      "peerDependencies": {
+        "typescript": "^4.8.2"
+      }
+    },
+    "node_modules/@deepkit/type-spec": {
+      "version": "1.0.1-alpha.89",
+      "resolved": "https://registry.npmjs.org/@deepkit/type-spec/-/type-spec-1.0.1-alpha.89.tgz",
+      "integrity": "sha512-g+KTTw5FqtKYHlYInfxd+7sSv2M1XI9GFfzrxvpp8f5FxU/bU3sGzAcd2dXU4ksu1Z+PwoJsLV363OrT+3gmqQ=="
+    },
+    "node_modules/@marcj/ts-clone-node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@marcj/ts-clone-node/-/ts-clone-node-2.0.0.tgz",
+      "integrity": "sha512-GPafMHAdvXPOFzJ8mtnOa+S4NR+fWQEggKo1laAejeSzzp9k223xZjogkNQSVLrzn8sinHCkvJv9f7nVaX3gPQ==",
+      "dev": true,
+      "dependencies": {
+        "compatfactory": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=14.9.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/wessberg/ts-clone-node?sponsor=1"
+      },
+      "peerDependencies": {
+        "typescript": "^4.8"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.0.tgz",
+      "integrity": "sha512-CVQDpPIUHrUGGLdrMGz1NmqZvqmsB2j2rCIQEu1EvxWjlFh4fhvEGmgR409cY20/67/WlJsggenq0no3p3kYsw==",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@types/lz-string": {
+      "version": "1.3.34",
+      "resolved": "https://registry.npmjs.org/@types/lz-string/-/lz-string-1.3.34.tgz",
+      "integrity": "sha512-j6G1e8DULJx3ONf6NdR5JiR2ZY3K3PaaqiEuKYkLQO0Czfi1AzrtjfnfCROyWGeDd5IVMKCwsgSmMip9OWijow==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "14.14.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.28.tgz",
+      "integrity": "sha512-lg55ArB+ZiHHbBBttLpzD07akz0QPrZgUODNakeC09i62dnrywr9mFErHuaPlB6I7z+sEbK+IYmplahvplCj2g==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+    },
+    "node_modules/@typescript/vfs": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.4.0.tgz",
+      "integrity": "sha512-Pood7yv5YWMIX+yCHo176OnF8WUlKGImFG7XlsuH14Zb1YN5+dYD3uUtS7lqZtsH7tAveNUi2NzdpQCN0yRbaw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/compatfactory": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/compatfactory/-/compatfactory-1.0.1.tgz",
+      "integrity": "sha512-hR9u0HSZTKDNNchPtMHg6myeNx0XO+av7UZIJPsi4rPALJBHi/W5Mbwi19hC/xm6y3JkYpxVYjTqnSGsU5X/iw==",
+      "dev": true,
+      "dependencies": {
+        "helpertypes": "^0.0.18"
+      },
+      "engines": {
+        "node": ">=14.9.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=3.x || >= 4.x"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/helpertypes": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/helpertypes/-/helpertypes-0.0.18.tgz",
+      "integrity": "sha512-XRhfbSEmR+poXUC5/8AbmYNJb2riOT6qPzjGJZr0S9YedHiaY+/tzPYzWMUclYMEdCYo/1l8PDYrQFCj02v97w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+      "dev": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/to-fast-properties": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-3.0.1.tgz",
+      "integrity": "sha512-/wtNi1tW1F3nf0OL6AqVxGw9Tr1ET70InMhJuVxPwFdGqparF0nQ4UWGLf2DsoI2bFDtthlBnALncZpUzOnsUw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    }
+  },
+  "dependencies": {
+    "@deepkit/core": {
+      "version": "1.0.1-alpha.89",
+      "resolved": "https://registry.npmjs.org/@deepkit/core/-/core-1.0.1-alpha.89.tgz",
+      "integrity": "sha512-jPZrAywuo70fsy8+ORO5lcCse5x0yLEP6Axnd4cg8HnByQK9sqtTP6VieAlIK5d2Li3TOoSHiSNiV2kxQsjpDw==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "^5.1.1",
+        "to-fast-properties": "^3.0.1"
+      }
+    },
+    "@deepkit/type-compiler": {
+      "version": "1.0.1-alpha.89",
+      "resolved": "https://registry.npmjs.org/@deepkit/type-compiler/-/type-compiler-1.0.1-alpha.89.tgz",
+      "integrity": "sha512-K+GAufjSepQsG6vkRAMErIeKno0BFCycSPWT/fWEjP6PtuWkTrgpi7vZKbXJsxV+yFoa/ePV1PKa4x2hkIv1xg==",
+      "dev": true,
+      "requires": {
+        "@deepkit/type-spec": "^1.0.1-alpha.89",
+        "@marcj/ts-clone-node": "^2.0.0",
+        "@typescript/vfs": "^1.4.0",
+        "lz-string": "^1.4.4",
+        "micromatch": "^4.0.5",
+        "strip-json-comments": "^3.1.1"
+      }
+    },
+    "@deepkit/type-spec": {
+      "version": "1.0.1-alpha.89",
+      "resolved": "https://registry.npmjs.org/@deepkit/type-spec/-/type-spec-1.0.1-alpha.89.tgz",
+      "integrity": "sha512-g+KTTw5FqtKYHlYInfxd+7sSv2M1XI9GFfzrxvpp8f5FxU/bU3sGzAcd2dXU4ksu1Z+PwoJsLV363OrT+3gmqQ=="
+    },
+    "@marcj/ts-clone-node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@marcj/ts-clone-node/-/ts-clone-node-2.0.0.tgz",
+      "integrity": "sha512-GPafMHAdvXPOFzJ8mtnOa+S4NR+fWQEggKo1laAejeSzzp9k223xZjogkNQSVLrzn8sinHCkvJv9f7nVaX3gPQ==",
+      "dev": true,
+      "requires": {
+        "compatfactory": "^1.0.1"
+      }
+    },
+    "@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ=="
+    },
+    "@paralleldrive/cuid2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.0.tgz",
+      "integrity": "sha512-CVQDpPIUHrUGGLdrMGz1NmqZvqmsB2j2rCIQEu1EvxWjlFh4fhvEGmgR409cY20/67/WlJsggenq0no3p3kYsw==",
+      "requires": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "@types/lz-string": {
+      "version": "1.3.34",
+      "resolved": "https://registry.npmjs.org/@types/lz-string/-/lz-string-1.3.34.tgz",
+      "integrity": "sha512-j6G1e8DULJx3ONf6NdR5JiR2ZY3K3PaaqiEuKYkLQO0Czfi1AzrtjfnfCROyWGeDd5IVMKCwsgSmMip9OWijow==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "14.14.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.28.tgz",
+      "integrity": "sha512-lg55ArB+ZiHHbBBttLpzD07akz0QPrZgUODNakeC09i62dnrywr9mFErHuaPlB6I7z+sEbK+IYmplahvplCj2g==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+    },
+    "@typescript/vfs": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.4.0.tgz",
+      "integrity": "sha512-Pood7yv5YWMIX+yCHo176OnF8WUlKGImFG7XlsuH14Zb1YN5+dYD3uUtS7lqZtsH7tAveNUi2NzdpQCN0yRbaw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1"
+      }
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "compatfactory": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/compatfactory/-/compatfactory-1.0.1.tgz",
+      "integrity": "sha512-hR9u0HSZTKDNNchPtMHg6myeNx0XO+av7UZIJPsi4rPALJBHi/W5Mbwi19hC/xm6y3JkYpxVYjTqnSGsU5X/iw==",
+      "dev": true,
+      "requires": {
+        "helpertypes": "^0.0.18"
+      }
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^2.0.0"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "helpertypes": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/helpertypes/-/helpertypes-0.0.18.tgz",
+      "integrity": "sha512-XRhfbSEmR+poXUC5/8AbmYNJb2riOT6qPzjGJZr0S9YedHiaY+/tzPYzWMUclYMEdCYo/1l8PDYrQFCj02v97w==",
+      "dev": true
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true
+    },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-3.0.1.tgz",
+      "integrity": "sha512-/wtNi1tW1F3nf0OL6AqVxGw9Tr1ET70InMhJuVxPwFdGqparF0nQ4UWGLf2DsoI2bFDtthlBnALncZpUzOnsUw==",
+      "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "peer": true
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    }
+  }
 }

--- a/packages/type/package.json
+++ b/packages/type/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@deepkit/type-spec": "^1.0.1-alpha.89",
+    "@paralleldrive/cuid2": "^2.2.0",
     "@types/uuid": "^8.3.0",
     "buffer": "^5.2.1",
     "uuid": "^8.3.2"

--- a/packages/type/src/reflection/type.ts
+++ b/packages/type/src/reflection/type.ts
@@ -1453,6 +1453,18 @@ export type AutoIncrement = { __meta?: ['autoIncrement'] };
 export type UUID = string & { __meta?: ['UUIDv4'] };
 
 /**
+ * CUID 2, as string, serialized as string in JSON, and binary in database.
+ * Use `cuid()` as handy initializer.
+ *
+ * ```typescript
+ * class Entity {
+ *     id: CUID = cuid();
+ * }
+ * ```
+ */
+export type CUID = string & { __meta?: ['CUID2'] };
+
+/**
  * MongoDB's ObjectID type. serialized as string in JSON, ObjectID in database.
  */
 export type MongoId = string & { __meta?: ['mongoId'] };
@@ -1544,12 +1556,18 @@ export interface BackReferenceOptionsResolved {
 export const backReferenceAnnotation = new AnnotationDefinition<BackReferenceOptionsResolved>('backReference');
 export const validationAnnotation = new AnnotationDefinition<{ name: string, args: Type[] }>('validation');
 export const UUIDAnnotation = new AnnotationDefinition('UUID');
+export const CUIDAnnotation = new AnnotationDefinition('CUID');
 export const mongoIdAnnotation = new AnnotationDefinition('mongoID');
 export const uuidAnnotation = new AnnotationDefinition('uuid');
+export const cuidAnnotation = new AnnotationDefinition('cuid');
 export const defaultAnnotation = new AnnotationDefinition('default');
 
 export function isUUIDType(type: Type): boolean {
     return uuidAnnotation.getFirst(type) !== undefined;
+}
+
+export function isCUIDType(type: Type): boolean {
+    return cuidAnnotation.getFirst(type) !== undefined;
 }
 
 export function isPrimaryKeyType(type: Type): boolean {
@@ -1830,6 +1848,9 @@ export const typeDecorators: TypeDecorator[] = [
                 return true;
             case 'UUIDv4':
                 uuidAnnotation.register(annotations, true);
+                return true;
+            case 'CUID2':
+                cuidAnnotation.register(annotations, true);
                 return true;
             case 'embedded': {
                 const optionsType = meta.type.types[1];

--- a/packages/type/src/serializer.ts
+++ b/packages/type/src/serializer.ts
@@ -1873,7 +1873,7 @@ export class Serializer {
 
         this.deserializeRegistry.addDecorator(isCUIDType, (type, state) => {
             const v = state.accessor;
-            const check = `${v}.length >= 2 && /^[0-9a-z]+$/.test(${v})`; // createId from `@paralleldrive/cuid2` is available but I'm not sure if I can use it here
+            const check = `${v}.length >= 2 && /^[0-9a-z]+$/.test(${v})`; // isCuid from `@paralleldrive/cuid2` is available but I'm not sure if I can use it here
             state.addCode(`
                 if (!(${check})) ${state.throwCode(type, JSON.stringify('Not a CUID'))}
             `);
@@ -2063,7 +2063,7 @@ export class Serializer {
         });
         this.typeGuards.getRegistry(1).addDecorator(isCUIDType, (type, state) => {
             const v = state.originalAccessor;
-            const check = `${v}.length >= 2 && /^[0-9a-z]+$/.test(${v})`; // createId from `@paralleldrive/cuid2` is available but I'm not sure if I can use it here
+            const check = `${v}.length >= 2 && /^[0-9a-z]+$/.test(${v})`; // isCuid from `@paralleldrive/cuid2` is available but I'm not sure if I can use it here
             state.addSetterAndReportErrorIfInvalid('type', 'Not a CUID', check);
         });
         this.typeGuards.getRegistry(1).addDecorator(isMongoIdType, (type, state) => {

--- a/packages/type/src/utils.ts
+++ b/packages/type/src/utils.ts
@@ -9,6 +9,7 @@
  */
 
 import { stringify, v4 } from 'uuid';
+import { createId } from '@paralleldrive/cuid2';
 
 export class NoTypeReceived extends Error {
     constructor() {
@@ -36,6 +37,13 @@ export function writeUuid(buffer: Uint8Array, offset: number = 0): Uint8Array {
  */
 export function stringifyUuid(buffer: Uint8Array, offset: number = 0): string {
     return stringify(buffer, offset);
+}
+
+/**
+ * Returns a new CUID as string.
+ */
+export function cuid(): string {
+    return createId();
 }
 
 export type Binary = ArrayBuffer | Uint8Array | Int8Array | Uint8ClampedArray | Uint16Array | Int16Array | Uint32Array | Int32Array | Float32Array | Float64Array;

--- a/packages/type/src/utils.ts
+++ b/packages/type/src/utils.ts
@@ -9,7 +9,7 @@
  */
 
 import { stringify, v4 } from 'uuid';
-import { createId } from '@paralleldrive/cuid2';
+import { init } from '@paralleldrive/cuid2';
 
 export class NoTypeReceived extends Error {
     constructor() {
@@ -42,8 +42,27 @@ export function stringifyUuid(buffer: Uint8Array, offset: number = 0): string {
 /**
  * Returns a new CUID as string.
  */
-export function cuid(): string {
-    return createId();
+export function cuid(
+    options?: {
+        counter?: () => number
+        length?: number
+        fingerprint?: string
+    }
+): string {
+    return init(options)();
+}
+
+/**
+ * Initializes a new CUID generator.
+ */
+export function initCuid(
+    options?: {
+        counter?: () => number
+        length?: number
+        fingerprint?: string
+    }
+): () => string {
+    return init(options);
 }
 
 export type Binary = ArrayBuffer | Uint8Array | Int8Array | Uint8ClampedArray | Uint16Array | Int16Array | Uint32Array | Int32Array | Float32Array | Float64Array;

--- a/packages/type/tests/integration.spec.ts
+++ b/packages/type/tests/integration.spec.ts
@@ -55,7 +55,7 @@ import { validate, ValidatorError } from '../src/validator.js';
 import { expectEqualType } from './utils.js';
 import { MyAlias } from './types.js';
 import { resolveRuntimeType } from '../src/reflection/processor.js';
-import { uuid } from '../src/utils.js';
+import { cuid, uuid } from '../src/utils.js';
 
 test('class', () => {
     class Entity {
@@ -1968,6 +1968,7 @@ test('Array<T>', () => {
 test('default function expression', () => {
     class post {
         uuid: string = uuid();
+        cuid: string = cuid();
         id: integer & AutoIncrement & PrimaryKey = 0;
         created: Date = new Date;
         type: string = 'asd';
@@ -1975,6 +1976,7 @@ test('default function expression', () => {
 
     const reflection = ReflectionClass.from(post);
     expect(reflection.getProperty('uuid').hasDefaultFunctionExpression()).toBe(true);
+    expect(reflection.getProperty('cuid').hasDefaultFunctionExpression()).toBe(true);
     expect(reflection.getProperty('id').hasDefaultFunctionExpression()).toBe(false);
     expect(reflection.getProperty('created').hasDefaultFunctionExpression()).toBe(false);
     expect(reflection.getProperty('type').hasDefaultFunctionExpression()).toBe(false);

--- a/packages/type/tests/type-spec.spec.ts
+++ b/packages/type/tests/type-spec.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@jest/globals';
 import { ReceiveType, ReflectionClass, resolveReceiveType, typeOf } from '../src/reflection/reflection.js';
-import { AutoIncrement, BackReference, findMember, isReferenceType, MapName, MongoId, PrimaryKey, Reference, UUID } from '../src/reflection/type.js';
+import { AutoIncrement, BackReference, CUID, findMember, isReferenceType, MapName, MongoId, PrimaryKey, Reference, UUID } from '../src/reflection/type.js';
 import { cast, cloneClass, serialize } from '../src/serializer-facade.js';
 import { createReference } from '../src/reference.js';
 import { unpopulatedSymbol } from '../src/core.js';
@@ -470,6 +470,9 @@ test('optional basics', () => {
     expect(roundTrip<UUID | undefined>(undefined)).toBe(undefined);
     expect(roundTrip<UUID | undefined>(null)).toBe(undefined);
 
+    expect(roundTrip<CUID | undefined>(undefined)).toBe(undefined);
+    expect(roundTrip<CUID | undefined>(null)).toBe(undefined);
+
     expect(roundTrip<MongoId | undefined>(undefined)).toBe(undefined);
     expect(roundTrip<MongoId | undefined>(null)).toBe(undefined);
 
@@ -532,6 +535,9 @@ test('nullable basics', () => {
 
     expect(roundTrip<UUID | null>(undefined)).toBe(null);
     expect(roundTrip<UUID | null>(null)).toBe(null);
+
+    expect(roundTrip<CUID | null>(undefined)).toBe(null);
+    expect(roundTrip<CUID | null>(null)).toBe(null);
 
     expect(roundTrip<MongoId | null>(undefined)).toBe(null);
     expect(roundTrip<MongoId | null>(null)).toBe(null);

--- a/packages/type/tests/type.spec.ts
+++ b/packages/type/tests/type.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from '@jest/globals';
 import { hasCircularReference, ReceiveType, reflect, ReflectionClass, resolveReceiveType, typeOf, visit } from '../src/reflection/reflection.js';
 import {
     assertType,
+    CUID,
     Embedded,
     Excluded,
     excludedAnnotation,
@@ -193,6 +194,8 @@ test('type alias preserved', () => {
     expect(stringifyType(typeOf<MyString>())).toBe('MyString');
 
     expect(stringifyType(typeOf<UUID>())).toBe('UUID');
+
+    expect(stringifyType(typeOf<CUID>())).toBe('CUID');
 });
 
 test('stringify', () => {


### PR DESCRIPTION
### Summary of changes

Added a `cuid` type similar to the current `uuid` as discussed in #419.

I'm currently not using the `isCuid` function from `@paralleldrive/cuid2` for deserialization because I'm not sure how the importing would work in the string templates.
I'm making the same checks manually minus the string check

```ts
// @paralleldrive/cuid2

const isCuid = (id, { minLength = 2, maxLength = bigLength } = {}) => {
  const length = id.length;
  const regex = /^[0-9a-z]+$/;

  try {
    if (
      typeof id === "string" &&
      length >= minLength &&
      length <= maxLength &&
      regex.test(id)
    )
      return true;
  } finally {
  }

  return false;
};
```

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
