### PR TITLE
debugger: show the route description with original formatting (newlines)

### DIFF
--- a/packages/api-console-gui/src/app/views/http/route-detail.component.ts
+++ b/packages/api-console-gui/src/app/views/http/route-detail.component.ts
@@ -92,7 +92,7 @@ import { getTypeJitContainer } from '@deepkit/type';
                         </div>
                         <div style="margin-top: 10px; flex: 2 1 auto;">
                             <label>Description</label>
-                            {{route.description || 'none'}}
+                            <div class="formatted-text">{{route.description || 'none'}}</div>
                         </div>
                     </div>
                 </deepkit-box>

--- a/packages/api-console-gui/src/app/views/overview.component.html
+++ b/packages/api-console-gui/src/app/views/overview.component.html
@@ -61,7 +61,7 @@
                         </div>
                         <div style="margin-top: 10px; flex: 2 1 auto;">
                             <label>Description</label>
-                            {{route.description || 'none'}}
+                            <div class="formatted-text">{{route.description || 'none'}}</div>
                         </div>
                     </div>
                 </div>

--- a/packages/api-console-gui/src/app/views/view-styles.scss
+++ b/packages/api-console-gui/src/app/views/view-styles.scss
@@ -62,3 +62,7 @@
         flex: 0 0 50%;
     }
 }
+
+.formatted-text {
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
### Summary of changes


show the route description with white-space:pre-wrap to respect the newlines the developer used in description for formatting



### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
