### PR TITLE
fix SQL not null

### DIFF
--- a/packages/sql/src/sql-filter-builder.ts
+++ b/packages/sql/src/sql-filter-builder.ts
@@ -30,6 +30,10 @@ export class SQLFilterBuilder {
         return 'IS NULL';
     }
 
+    isNotNull() {
+        return 'IS NOT NULL';
+    }
+
     regexpComparator() {
         return 'REGEXP';
     }
@@ -97,7 +101,7 @@ export class SQLFilterBuilder {
             rvalue = `${this.quoteIdWithTable(value.substr(1))}`;
         } else {
             if (value === undefined || value === null) {
-                cmpSign = this.isNull();
+                cmpSign = cmpSign === '!=' ? this.isNotNull() : this.isNull();
                 rvalue = '';
             } else {
                 const property = resolvePath(fieldName, this.schema.type);

--- a/packages/sql/tests/sql-query.spec.ts
+++ b/packages/sql/tests/sql-query.spec.ts
@@ -105,6 +105,9 @@ test('QueryToSql', () => {
     expect(queryToSql.convert({ id: { $lte: 44 } })).toBe(`user.id <= ?`);
     expect(queryToSql.convert({ id: { $in: [44, 55] } })).toBe(`user.id IN (?, ?)`);
 
+    expect(queryToSql.convert({ id: { $eq: null } })).toBe(`user.id IS NULL`);
+    expect(queryToSql.convert({ id: { $ne: null } })).toBe(`user.id IS NOT NULL`);
+
     expect(() => queryToSql.convert({ invalidField: { $nin: [44, 55] } })).toThrowError('No type found for path invalidField');
 
     expect(queryToSql.convert({ id: { $nin: [44, 55] } })).toBe(`user.id NOT IN (?, ?)`);


### PR DESCRIPTION
### Summary of changes

Fixes an issue where the SQL filter condition `{ fieldA: { $ne: null } }` yields `fieldA IS NULL` in the resulting SQL.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
