### PR TITLE
feat(app): allow normalized providers to be exported in modules

### DIFF
--- a/packages/app/src/module.ts
+++ b/packages/app/src/module.ts
@@ -8,7 +8,7 @@
  * You should have received a copy of the MIT License along with this program.
  */
 
-import { InjectorModule, ProviderWithScope, Token } from '@deepkit/injector';
+import { InjectorModule, ProviderWithScope, Token, NormalizedProvider } from '@deepkit/injector';
 import { AbstractClassType, ClassType, CustomError, ExtractClassType, isClass } from '@deepkit/core';
 import { EventListener } from '@deepkit/event';
 import { WorkflowDefinition } from '@deepkit/workflow';
@@ -22,7 +22,7 @@ export interface MiddlewareConfig {
 
 export type MiddlewareFactory = () => MiddlewareConfig;
 
-export type ExportType = AbstractClassType | string | AppModule<any> | Type;
+export type ExportType = AbstractClassType | string | AppModule<any> | Type | NormalizedProvider;
 
 export interface ModuleDefinition {
     /**

--- a/packages/app/tests/module.spec.ts
+++ b/packages/app/tests/module.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@jest/globals';
 import { Minimum, MinLength } from '@deepkit/type';
-import { injectorReference } from '@deepkit/injector';
+import { injectorReference, provide } from '@deepkit/injector';
 import { ServiceContainer } from '../src/service-container.js';
 import { ClassType } from '@deepkit/core';
 import { AppModule, createModule } from '../src/module.js';
@@ -246,6 +246,22 @@ test('same module loaded twice', () => {
         expect(serviceContainer.getInjector(a).get(Service).path).toBe('/a');
         expect(serviceContainer.getInjector(b).get(Service).path).toBe('/b');
     }
+});
+
+test('interface provider can be exported', () => {
+   interface Test {}
+
+   const TEST = {};
+
+   const Test = provide<Test>({ useValue: TEST });
+
+   const test = new AppModule({ providers: [Test], exports: [Test] });
+
+   const app = new AppModule({ imports: [test] });
+
+    const serviceContainer = new ServiceContainer(app);
+
+   serviceContainer.getInjector(app).get<Test>().toBe(TEST);
 });
 
 test('non-exported providers can not be overwritten', () => {


### PR DESCRIPTION
### Summary of changes

Currently, it's only possible to export interface providers using `this.addExport(provider)` in modules. This aims to try to solve that by allowing `NormalizedProvider`s to be exported directly in `createModule`.

https://discord.com/channels/759513055117180999/956486106709364776/1089925501113614527

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
