### PR TITLE
fix default assignment for optional literals

### DIFF
--- a/packages/type/src/serializer.ts
+++ b/packages/type/src/serializer.ts
@@ -56,6 +56,7 @@ import {
     Type,
     TypeClass,
     TypeIndexSignature,
+    TypeLiteral,
     TypeObjectLiteral,
     TypeParameter,
     TypeProperty,
@@ -959,10 +960,10 @@ export function sortSignatures(signatures: TypeIndexSignature[]) {
 
 export function getStaticDefaultCodeForProperty(member: TypeProperty | TypePropertySignature, setter: string | ContainerAccessor, state: TemplateState) {
     let staticDefault = ``;
-    if (!hasDefaultValue(member)) {
+    if (!hasDefaultValue(member) && !isOptional(member)) {
         if (member.type.kind === ReflectionKind.literal) {
             staticDefault = `${setter} = ${state.compilerContext.reserveConst(member.type.literal)};`;
-        } else if (!isOptional(member) && isNullable(member.type)) {
+        } else if (isNullable(member.type)) {
             staticDefault = `${setter} = null;`;
         }
     }
@@ -1091,7 +1092,7 @@ export function serializeObjectLiteral(type: TypeObjectLiteral | TypeClass, stat
                 const readName = getNameExpression(state.namingStrategy.getPropertyName(property.property, state.registry.serializer.name), state);
 
                 const propertyState = state.fork(argumentName, new ContainerAccessor(state.accessor, readName)).extendPath(String(property.getName()));
-                const staticDefault = property.type.kind === ReflectionKind.literal ? `${argumentName} = ${state.compilerContext.reserveConst(property.type.literal)};` : '';
+                const staticDefault = property.type.kind === ReflectionKind.literal && !property.isOptional() ? `${argumentName} = ${state.compilerContext.reserveConst(property.type.literal)};` : '';
 
                 const embedded = property.getEmbedded();
                 if (embedded) {

--- a/packages/type/tests/serializer.spec.ts
+++ b/packages/type/tests/serializer.spec.ts
@@ -182,6 +182,26 @@ test('optional default value', () => {
     }
 });
 
+test('optional literal', () => {
+    interface LoginInput {
+        mechanism?: 'cookie';
+    }
+
+    {
+        const input = cast<LoginInput>({});
+        expect(input).toEqual({
+            mechanism: undefined
+        });
+    }
+
+    {
+        const input = cast<LoginInput>({ mechanism: 'cookie' });
+        expect(input).toEqual({
+            mechanism: 'cookie'
+        });
+    }
+});
+
 test('cast primitives', () => {
     expect(cast<string>('123')).toBe('123');
     expect(cast<string>(123)).toBe('123');


### PR DESCRIPTION
### Summary of changes
I have a use case where a client _may_ specify `"mechanism": "cookie"` as part of their payload.

The code looks like:
```
@http.POST()
login(body: HttpBody<{ ..., mechanism?: 'cookie' }>) {
  // ...
}
```

I found that `mechanism` was _always_ set to `cookie`, even when the client didn't specify it.

I can work around it with a `mechanism?: 'cookie' | 'jwt'`, which is more representative of the actual intent -- but I figure it's probably supposed to work the way I originally expected anyway.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
