### PR TITLE
mysql: fix patch PrimaryKey extraction when there were no modified rows

### DIFF
--- a/packages/mysql/src/mysql-adapter.ts
+++ b/packages/mysql/src/mysql-adapter.ts
@@ -485,7 +485,9 @@ export class MySQLQueryResolver<T extends OrmEntity> extends SQLQueryResolver<T>
             const packet = result[0];
             patchResult.modified = packet.affectedRows;
             const returning = result[1][0];
-            patchResult.primaryKeys = (JSON.parse(returning['@_pk']) as any[]).map(primaryKeyConverted as any);
+            if (patchResult.modified > 0) {
+                patchResult.primaryKeys = (JSON.parse(returning['@_pk']) as any[]).map(primaryKeyConverted as any);
+            }
 
             for (const i in aggregateFields) {
                 patchResult.returning[i] = (JSON.parse(returning['@_f_' + asAliasName(i)]) as any[]).map(aggregateFields[i].converted);

--- a/packages/mysql/tests/mysql.spec.ts
+++ b/packages/mysql/tests/mysql.spec.ts
@@ -190,3 +190,34 @@ test('for update/share', async () => {
     const items = await database.query(Model).forUpdate().find();
     expect(items).toHaveLength(2);
 });
+
+test('patch primary keys', async () => {
+    @entity.name('model5')
+    class Model {
+        firstName: string = '';
+
+        constructor(public id: number & PrimaryKey) {
+        }
+    }
+
+    const database = await databaseFactory([Model]);
+    await database.persist(new Model(1), new Model(2));
+
+    {
+        const result = await database
+            .query(Model)
+            .filter({ id: { $gt: 5 } })
+            .patchMany({ firstName: 'test' });
+        expect(result.modified).toEqual(0);
+        expect(result.primaryKeys.length).toEqual(0);
+    }
+
+    {
+        const result = await database
+            .query(Model)
+            .filter({ id: { $gt: 1 } })
+            .patchMany({ firstName: 'test' });
+        expect(result.modified).toEqual(1);
+        expect(result.primaryKeys).toEqual([{ id: 2 }]);
+    }
+});


### PR DESCRIPTION
### Summary of changes

Without the added condition, executing a patch that has zero modified rows throws:
```
    TypeError: Cannot read properties of null (reading 'map')

      487 |             const returning = result[1][0];
    > 488 |             patchResult.primaryKeys = (JSON.parse(returning['@_pk']) as any[]).map(primaryKeyConverted as any);
          |                                                                                   ^
      489 |
      490 |             for (const i in aggregateFields) {

      at MySQLQueryResolver.patch (src/mysql-adapter.ts:488:83)
      at MySQLDatabaseQuery.patch (../orm/src/query.ts:859:17)
      at MySQLDatabaseQuery.patchMany (../orm/src/query.ts:825:16)
      at Object.<anonymous> (tests/mysql.spec.ts:207:24)
```

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
