### PR TITLE
bump Node to current LTS (18.x)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: buildjet-2vcpu-ubuntu-2004
     strategy:
       matrix:
-        node-version: [ 16.x ]
+        node-version: [ 18.x ]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -96,7 +96,7 @@ jobs:
     runs-on: buildjet-2vcpu-ubuntu-2004
     strategy:
       matrix:
-        node-version: [ 14.x ]
+        node-version: [ 18.x ]
         postgres-version: [ 14 ]
     services:
       postgres:
@@ -144,7 +144,7 @@ jobs:
     runs-on: buildjet-2vcpu-ubuntu-2004
     strategy:
       matrix:
-        node-version: [ 14.x ]
+        node-version: [ 18.x ]
         mysql-version: [ 8.0 ]
     services:
       mysql:
@@ -191,7 +191,7 @@ jobs:
     runs-on: buildjet-2vcpu-ubuntu-2004
     strategy:
       matrix:
-        node-version: [ 14.x ]
+        node-version: [ 18.x ]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -228,7 +228,7 @@ jobs:
     runs-on: buildjet-2vcpu-ubuntu-2004
     strategy:
       matrix:
-        node-version: [ 14.x ]
+        node-version: [ 18.x ]
         mongo-version: [ 4.0 ]
     services:
       # this is used for the simple-auth test
@@ -312,10 +312,10 @@ jobs:
 #          - "5432:5432"
 #        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 #    steps:
-#      - name: Use Node.js 14.x
+#      - name: Use Node.js 18.x
 #        uses: actions/setup-node@v1
 #        with:
-#          node-version: 14.x
+#          node-version: 18.x
 #      - name: npm install
 #        run: npm install
 #      - name: Lerna bootstrap


### PR DESCRIPTION
### Summary of changes

I noticed CI is still running Node 14 for ORM tests, and Node 16 for unit tests.  Node 14 has been EOL'ed, Node 18 is the current LTS, and Node 16 will be EOL'ed in 5 months.

This PR bumps everything to Node 18.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
