### PR TITLE
fix(http): prevent JSON payloads from spoofing UploadedFile

### DIFF
--- a/packages/http/src/router.ts
+++ b/packages/http/src/router.ts
@@ -75,7 +75,7 @@ export class UploadedFile {
 
 serializer.typeGuards.getRegistry(1).registerClass(UploadedFile, (type, state) => {
     state.setContext({ UploadedFileSymbol });
-    state.addSetterAndReportErrorIfInvalid('uploadSecurity', 'Not an uploaded file', `typeof ${state.accessor} === 'object' && ${state.accessor}.validator === UploadedFileSymbol`);
+    state.addSetterAndReportErrorIfInvalid('uploadSecurity', 'Not an uploaded file', `typeof ${state.accessor} === 'object' && ${state.accessor} !== null && ${state.accessor}.validator === UploadedFileSymbol`);
 });
 
 export interface RouteFunctionControllerAction {

--- a/packages/http/tests/router.spec.ts
+++ b/packages/http/tests/router.spec.ts
@@ -1377,6 +1377,20 @@ test('upload security', async () => {
         message: 'Validation error:\nsomeFile(uploadSecurity): Not an uploaded file'
     });
 
+    // ensure type deserialization doesn't set the invalid 'fake value' value to UploadedFileSymbol
+    expect((await httpKernel.request(HttpRequest.POST('/upload').json({
+        someFile: {
+            validator: 'fake value',
+            size: 12345,
+            path: '/etc/secure-file',
+            name: 'fakefile',
+            type: 'image/jpeg',
+            lastModifiedDate: null
+        }
+    }))).json).toMatchObject({
+        message: 'Validation error:\nsomeFile(uploadSecurity): Not an uploaded file'
+    });
+
     expect((await httpKernel.request(HttpRequest.POST('/upload').multiPart([
         {
             name: 'someFile',


### PR DESCRIPTION
### Summary of changes

An API consumer is currently able to manually specify a JSON payload matching the shape of UploadedFile and Deepkit will accept it. This opens the application up to exploitation by bad actors providing payloads with sensitive paths.

While the developer could verify against the uploadedFiles property of HttpRequest to prevent against this manually, I believe this should be something the framework protects against, plus has the benefit of cleaner code in controllers.

This is an alternate implementation to #459, as #459 does not work when the HttpBody/HttpBodyValidation type argument is a complex type.  The `typeof UploadedFileSymbol | null` union resolves the issue described [here](https://github.com/deepkit/deepkit-framework/pull/459#issuecomment-1616574406).

My preference would have been to use a Symbol as a key so that it doesn't show up in JSON serialization or IntelliSense, but  I couldn't get the symbol to work through deserialization, so even valid uploads would fail post-deserialization validation.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
