### PR TITLE
Make JSDoc @description tags available on more reflection classes and types

### DIFF
--- a/packages/type/src/reflection/reflection.ts
+++ b/packages/type/src/reflection/reflection.ts
@@ -332,6 +332,7 @@ export class ReflectionParameter {
 
 export class ReflectionFunction {
     parameters: ReflectionParameter[] = [];
+    description: string = '';
 
     constructor(
         public readonly type: TypeMethod | TypeMethodSignature | TypeFunction,
@@ -339,6 +340,7 @@ export class ReflectionFunction {
         for (const p of this.type.parameters) {
             this.parameters.push(new ReflectionParameter(p, this));
         }
+        if (this.type.description) this.description = this.type.description;
     }
 
     static from(fn: Function): ReflectionFunction {
@@ -393,6 +395,10 @@ export class ReflectionFunction {
 
     getName(): number | string | symbol {
         return this.type.name || 'anonymous';
+    }
+
+    getDescription(): string {
+        return this.description;
     }
 
     get name(): string {
@@ -858,6 +864,7 @@ export class ReflectionClass<T> {
             this.name = parent.name;
             this.collectionName = parent.collectionName;
             this.databaseSchemaName = parent.databaseSchemaName;
+            this.description = parent.description;
 
             for (const member of parent.getProperties()) {
                 this.registerProperty(member.clone(this));
@@ -875,6 +882,7 @@ export class ReflectionClass<T> {
         if (entityOptions) {
             applyEntityOptions(this, entityOptions);
         }
+        this.description = this.type.description || this.description;
 
         //apply decorators
         if (type.kind === ReflectionKind.class && isWithDeferredDecorators(type.classType)) {
@@ -911,6 +919,7 @@ export class ReflectionClass<T> {
         reflection.indexes = this.indexes.slice();
         reflection.subClasses = this.subClasses.slice();
         reflection.data = { ...this.data };
+        reflection.description = this.description;
 
         return reflection;
     }
@@ -952,6 +961,10 @@ export class ReflectionClass<T> {
 
     getName(): string {
         return this.name || this.getClassName();
+    }
+
+    getDescription(): string {
+        return this.description;
     }
 
     getCollectionName(): string {

--- a/packages/type/src/reflection/type.ts
+++ b/packages/type/src/reflection/type.ts
@@ -269,6 +269,7 @@ export interface TypeMethod extends TypeBaseMember {
     kind: ReflectionKind.method,
     parent: TypeClass;
     name: number | string | symbol;
+    description?: string;
     parameters: TypeParameter[];
     return: Type;
 }
@@ -291,6 +292,7 @@ export interface TypeFunction extends TypeAnnotations {
     kind: ReflectionKind.function,
     parent?: Type;
     name?: number | string | symbol,
+    description?: string;
     function?: Function; //reference to the real function if available
     parameters: TypeParameter[];
     return: Type;
@@ -313,6 +315,7 @@ export interface TypeClass extends TypeAnnotations {
     kind: ReflectionKind.class,
     parent?: Type;
     classType: ClassType;
+    description?: string;
 
     /**
      * When the class extends another class and uses on it generic type arguments, then those arguments
@@ -339,6 +342,7 @@ export interface TypeEnum extends TypeAnnotations {
     enum: { [name: string]: string | number | undefined | null };
     values: (string | number | undefined | null)[];
     indexType: Type;
+    description?: string;
 }
 
 export interface TypeEnumMember extends TypeAnnotations {
@@ -387,6 +391,7 @@ export interface TypeMethodSignature extends TypeAnnotations {
     parent: TypeObjectLiteral;
     name: number | string | symbol;
     optional?: true;
+    description?: string;
     parameters: TypeParameter[];
     return: Type;
 }
@@ -397,6 +402,7 @@ export interface TypeMethodSignature extends TypeAnnotations {
 export interface TypeObjectLiteral extends TypeAnnotations {
     kind: ReflectionKind.objectLiteral,
     parent?: Type;
+    description?: string;
     types: (TypeIndexSignature | TypePropertySignature | TypeMethodSignature | TypeCallSignature)[];
 }
 

--- a/packages/type/tests/jsdoc.spec.ts
+++ b/packages/type/tests/jsdoc.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@jest/globals';
+import { TypeEnum } from '../src/reflection/type.js';
+import { ReflectionClass, ReflectionMethod, ReflectionFunction, typeOf } from '../src/reflection/reflection.js';
+
+test('description available on Interface and Type alias', () => {
+  /** @description user interface */
+  interface IUser {
+    username: string;
+  }
+
+  /** @description user type declaration */
+  type IUser2 = {
+    username: string;
+  }
+
+  const reflectTypeInterface = ReflectionClass.from(typeOf<IUser>());
+  expect(reflectTypeInterface.description).toEqual('user interface');
+  expect(reflectTypeInterface.type.description).toEqual('user interface');
+
+  const reflectTypeObjectLiteral = ReflectionClass.from(typeOf<IUser2>());
+  expect(reflectTypeObjectLiteral.description).toEqual('user type declaration');
+  expect(reflectTypeObjectLiteral.type.description).toEqual('user type declaration');
+});
+
+test('description available on ReflectionClass', () => {
+  class MyDate {}
+
+  /** @description user class */
+  class User {
+      myDate?: MyDate;
+      created: Date = new Date;
+  }
+  const reflection = ReflectionClass.from(typeOf<User>());
+  expect(reflection.description).toEqual('user class');
+});
+
+test('description available on ReflectionFunction and ReflectionMethod', () => {
+  class MyDate {}
+  /** @description user class */
+  class User {
+      myDate?: MyDate;
+      created: Date = new Date;
+  }
+  /** @description getUser function */
+  function getUser(): User {
+    return new User()
+  }
+
+  class FunctionContainer {
+    /** @description getUser member */
+    getUser(): User {
+      return new User()
+    }
+  }
+
+  const reflectionFunction = ReflectionFunction.from(getUser);
+  expect(reflectionFunction.getDescription()).toEqual('getUser function');
+
+  const fc = new FunctionContainer();
+  const reflection = ReflectionClass.from(typeOf<FunctionContainer>());
+  const method:ReflectionMethod = reflection.getMethod('getUser')
+  expect(method.description).toEqual('getUser member');
+});
+
+test('description available on TypeEnum', () => {
+  /** @description results enum */
+  enum RESULTS {
+    SUCCESS = 'success',
+    FAILURE = 'failure'
+  }
+  const type = typeOf<RESULTS>() as TypeEnum;
+  expect(type.description).toEqual('results enum');
+
+});
+
+


### PR DESCRIPTION
### Summary of changes

Expands support for jsDoc @description info, on classes, methods, functions, enums, interfaces, and type aliases. This was needed for an unreleased project I'm working on.

Changes are in `type/src/reflection/` and `type-compiler/src/compiler.ts`.
Tests have been added in `packages/type/tests/jsdoc.spec.ts`.

Thanks to the Deepkit team for the amazing project!


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
