### PR TITLE
fix(type-compiler): Node InferType did not pass test isEntityName

### DIFF
--- a/packages/type-compiler/src/compiler.ts
+++ b/packages/type-compiler/src/compiler.ts
@@ -2308,8 +2308,8 @@ export class ReflectionTransformer implements CustomTransformer {
                         return node;
                     };
 
-                    const updatedParameterType = visitEachChild(parameter.type, searchArgument, this.context);
                     if (found && isIdentifier(parameter.name)) {
+                        const updatedParameterType = visitEachChild(parameter.type, searchArgument, this.context);
                         foundUsers.push({ type: updatedParameterType, parameterName: parameter.name });
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/deepkit/deepkit-framework/issues/455

Author @timvandam (https://discord.com/channels/759513055117180999/956485210676002816/1138433915221196912)
