### PR TITLE
TransientInjectorTarget & ScopedLogger

### DIFF
--- a/packages/framework/src/module.ts
+++ b/packages/framework/src/module.ts
@@ -40,6 +40,7 @@ import { ApiConsoleModule } from '@deepkit/api-console-module';
 import { AppModule, ControllerConfig, createModule } from '@deepkit/app';
 import { RpcControllers, RpcInjectorContext, RpcKernelWithStopwatch } from './rpc.js';
 import { normalizeDirectory } from './utils.js';
+import { ScopedLogger } from "@deepkit/logger";
 
 export class FrameworkModule extends createModule({
     config: FrameworkConfig,
@@ -50,6 +51,7 @@ export class FrameworkModule extends createModule({
         RpcServer,
         ConsoleTransport,
         Logger,
+        ScopedLogger,
         MigrationProvider,
         DebugController,
         { provide: DatabaseRegistry, useFactory: (ic: InjectorContext) => new DatabaseRegistry(ic) },
@@ -105,6 +107,7 @@ export class FrameworkModule extends createModule({
         MigrationCreateController,
     ],
     exports: [
+        ScopedLogger.provide,
         ProcessLocker,
         ApplicationServer,
         WebWorkerFactory,

--- a/packages/injector/src/injector.ts
+++ b/packages/injector/src/injector.ts
@@ -98,16 +98,17 @@ function propertyParameterNotFound(ofName: string, name: string, position: numbe
 
 function transientInjectionTargetUnavailable(ofName: string, name: string, position: number, token: any) {
     throw new DependenciesUnmetError(
-        `${TransientInjectionTarget.name} is not available for ${name} of ${ofName}. ${TransientInjectionTarget.name} is only available when injecting ${ofName} into other providers`
+        `${TransientInjectionTarget.name} is not available for ${name} of ${ofName}. ${TransientInjectionTarget.name} is only available when injecting into other providers`
     );
 }
 
-function createTransientInjectionTargetForProvider(provider: NormalizedProvider | undefined) {
-    if (!provider) {
+type Destination = { token: Token; };
+function createTransientInjectionTarget(destination: Destination | undefined) {
+    if (!destination) {
         return undefined;
     }
 
-    return new TransientInjectionTarget(provider.provide);
+    return new TransientInjectionTarget(destination.token);
 }
 
 
@@ -294,7 +295,7 @@ export class Injector implements InjectorInterface {
         resolverCompiler.context.set('propertyParameterNotFound', propertyParameterNotFound);
         resolverCompiler.context.set('factoryDependencyNotFound', factoryDependencyNotFound);
         resolverCompiler.context.set('transientInjectionTargetUnavailable', transientInjectionTargetUnavailable);
-        resolverCompiler.context.set('createTransientInjectionTargetForProvider', createTransientInjectionTargetForProvider);
+        resolverCompiler.context.set('createTransientInjectionTarget', createTransientInjectionTarget);
         resolverCompiler.context.set('injector', this);
 
         const lines: string[] = [];
@@ -338,7 +339,7 @@ export class Injector implements InjectorInterface {
                     //its a redirect
                     lines.push(`
                     case token === ${resolverCompiler.reserveConst(prepared.token, 'token')}${scopeObjectCheck}: {
-                        return ${resolverCompiler.reserveConst(prepared.resolveFrom, 'resolveFrom')}.injector.resolver(${resolverCompiler.reserveConst(prepared.token, 'token')}, scope);
+                        return ${resolverCompiler.reserveConst(prepared.resolveFrom, 'resolveFrom')}.injector.resolver(${resolverCompiler.reserveConst(prepared.token, 'token')}, scope, destination);
                     }
                     `);
 
@@ -383,7 +384,7 @@ export class Injector implements InjectorInterface {
                 ${resets.join('\n')};
             });
 
-            return function(token, scope, destinationProvider) {
+            return function(token, scope, destination) {
                 switch (true) {
                     ${lines.join('\n')}
                 }
@@ -424,7 +425,7 @@ export class Injector implements InjectorInterface {
             factory = this.createFactory(provider, accessor, compiler, useClass, resolveDependenciesFrom);
         } else if (isExistingProvider(provider)) {
             transient = provider.transient === true;
-            factory.code = `${accessor} = injector.resolver(${compiler.reserveConst(provider.useExisting)}, scope)`;
+            factory.code = `${accessor} = injector.resolver(${compiler.reserveConst(provider.useExisting)}, scope, destination)`;
         } else if (isFactoryProvider(provider)) {
             transient = provider.transient === true;
             const args: string[] = [];
@@ -433,11 +434,12 @@ export class Injector implements InjectorInterface {
             for (const parameter of reflection.getParameters()) {
                 factory.dependencies++;
                 const tokenType = getInjectOptions(parameter.getType() as Type);
+                const ofName = reflection.name === 'anonymous' ? 'useFactory' : reflection.name;
                 args.push(this.createFactoryProperty({
                     name: parameter.name,
                     type: tokenType || parameter.getType() as Type,
                     optional: !parameter.isValueRequired()
-                }, provider, compiler, resolveDependenciesFrom, reflection.name || 'useFactory', args.length, 'factoryDependencyNotFound'));
+                }, provider, compiler, resolveDependenciesFrom, ofName, args.length, 'factoryDependencyNotFound'));
             }
 
             factory.code = `${accessor} = ${compiler.reserveVariable('factory', provider.useFactory)}(${args.join(', ')});`;
@@ -463,7 +465,7 @@ export class Injector implements InjectorInterface {
                     for (const arg of call.args) {
                         if (arg instanceof InjectorReference) {
                             const injector = arg.module ? compiler.reserveConst(arg.module) + '.injector' : 'injector';
-                            args.push(`${injector}.resolver(${compiler.reserveConst(arg.to)}, scope)`);
+                            args.push(`${injector}.resolver(${compiler.reserveConst(arg.to)}, scope, destination)`);
                         } else {
                             args.push(`${compiler.reserveVariable('arg', arg)}`);
                         }
@@ -476,7 +478,7 @@ export class Injector implements InjectorInterface {
                     let value: string = '';
                     if (call.value instanceof InjectorReference) {
                         const injector = call.value.module ? compiler.reserveConst(call.value.module) + '.injector' : 'injector';
-                        value = `${injector}.resolver(${compiler.reserveConst(call.value.to)}, scope)`;
+                        value = `${injector}.resolver(${compiler.reserveConst(call.value.to)}, scope, destination)`;
                     } else {
                         value = compiler.reserveVariable('value', call.value);
                     }
@@ -572,6 +574,7 @@ export class Injector implements InjectorInterface {
         notFoundFunction: string
     ): string {
         let of = `${ofName}.${options.name}`;
+        const destinationVar = compiler.reserveConst({ token: fromProvider.provide });
 
         if (options.type.kind === ReflectionKind.class) {
             const found = findModuleForConfig(options.type.classType, resolveDependenciesFrom);
@@ -584,7 +587,7 @@ export class Injector implements InjectorInterface {
             if (fromProvider.transient === true) {
                 const tokenVar = compiler.reserveVariable('token', options.type.classType);
                 const orThrow = options.optional ? '' : `?? transientInjectionTargetUnavailable(${JSON.stringify(ofName)}, ${JSON.stringify(options.name)}, ${argPosition}, ${tokenVar})`;
-                return `createTransientInjectionTargetForProvider(destinationProvider) ${orThrow}`;
+                return `createTransientInjectionTarget(destination) ${orThrow}`;
             } else {
                 throw new Error(`Cannot inject ${TransientInjectionTarget.name} into ${JSON.stringify(ofName)}.${JSON.stringify(options.name)}, as ${JSON.stringify(ofName)} is not transient`);
             }
@@ -604,7 +607,7 @@ export class Injector implements InjectorInterface {
             const entries = this.buildContext.tagRegistry.resolve(options.type.classType);
             const args: string[] = [];
             for (const entry of entries) {
-                args.push(`${compiler.reserveConst(entry.module)}.injector.resolver(${compiler.reserveConst(entry.tagProvider.provider.provide)}, scope)`);
+                args.push(`${compiler.reserveConst(entry.module)}.injector.resolver(${compiler.reserveConst(entry.tagProvider.provider.provide)}, scope, ${destinationVar})`);
             }
             return `new ${tokenVar}(${resolvedVar} || (${resolvedVar} = [${args.join(', ')}]))`;
         }
@@ -721,11 +724,10 @@ export class Injector implements InjectorInterface {
         const orThrow = options.optional ? '' : `?? ${notFoundFunction}(${JSON.stringify(ofName)}, ${JSON.stringify(options.name)}, ${argPosition}, ${tokenVar})`;
 
         const resolveFromModule = foundPreparedProvider.resolveFrom || foundPreparedProvider.modules[0];
-        const destinationProvider = compiler.reserveConst(fromProvider);
         if (resolveFromModule === this.module) {
-            return `injector.resolver(${tokenVar}, scope, ${destinationProvider})`;
+            return `injector.resolver(${tokenVar}, scope, ${destinationVar})`;
         }
-        return `${compiler.reserveConst(resolveFromModule)}.injector.resolver(${tokenVar}, scope, ${destinationProvider}) ${orThrow}`;
+        return `${compiler.reserveConst(resolveFromModule)}.injector.resolver(${tokenVar}, scope, ${destinationVar}) ${orThrow}`;
     }
 
     createResolver(type: Type, scope?: Scope, label?: string): Resolver<any> {

--- a/packages/injector/src/provider.ts
+++ b/packages/injector/src/provider.ts
@@ -22,7 +22,18 @@ export interface ProviderBase {
 /** @reflection never */
 export type Token<T = any> = symbol | number | bigint | RegExp | boolean | string | AbstractClassType<T> | Type | T;
 
-export function provide<T>(provider: { useValue: T } | { useClass: ClassType } | { useExisting: any } | { useFactory: (...args: any[]) => T } | ClassType, type?: ReceiveType<T>): NormalizedProvider {
+export function provide<T>(
+    provider:
+        | (ProviderBase &
+        (
+            | { useValue: T }
+            | { useClass: ClassType }
+            | { useExisting: any }
+            | { useFactory: (...args: any[]) => T }
+            ))
+        | ClassType,
+    type?: ReceiveType<T>,
+): NormalizedProvider {
     if (isClass(provider)) return { provide: resolveReceiveType(type), useClass: provider };
     return { ...provider, provide: resolveReceiveType(type) };
 }

--- a/packages/injector/tests/injector.spec.ts
+++ b/packages/injector/tests/injector.spec.ts
@@ -808,4 +808,50 @@ test('TransientInjectionTarget', () => {
         const injector = Injector.from([{ provide: A, transient: true }]);
         expect(() => injector.get(A)).not.toThrow();
     }
+
+    {
+        class A {
+            constructor (public b: C) {
+            }
+        }
+
+        class B {
+            constructor (public target: TransientInjectionTarget) {
+            }
+        }
+
+        class C {
+            constructor (public target: TransientInjectionTarget) {
+            }
+        }
+
+        const injector = Injector.from([
+            A,
+            { provide: B, transient: true },
+            { provide: C, transient: true, useExisting: B },
+        ]);
+        const a = injector.get(A);
+        expect(a.b).toBeInstanceOf(B);
+        expect(a.b.target.token).toBe(A);
+    }
+
+    {
+        class A {
+            constructor (public b: B) {
+            }
+        }
+
+        interface B {
+            target: TransientInjectionTarget;
+        }
+
+        const injector = Injector.from([
+            A,
+            provide<B>({ transient: true, useFactory: (target: TransientInjectionTarget): B => ({ target }) }),
+        ]);
+
+        const a = injector.get(A);
+        expect(a.b).toBeDefined();
+        expect(a.b.target.token).toBe(A);
+    }
 });

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -24,7 +24,8 @@
   "author": "Marc J. Schmidt <marc@marcjschmidt.de>",
   "license": "MIT",
   "peerDependencies": {
-    "@deepkit/core": "^1.0.1-alpha.13"
+    "@deepkit/core": "^1.0.1-alpha.13",
+    "@deepkit/injector": "^1.0.1-alpha.97"
   },
   "dependencies": {
     "@types/format-util": "^1.0.1",
@@ -32,7 +33,8 @@
     "format-util": "^1.0.5"
   },
   "devDependencies": {
-    "@deepkit/core": "^1.0.1-alpha.97"
+    "@deepkit/core": "^1.0.1-alpha.97",
+    "@deepkit/injector": "^1.0.1-alpha.97"
   },
   "jest": {
     "testEnvironment": "node",

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -11,7 +11,7 @@
 import style from 'ansi-styles';
 import format from 'format-util';
 import { arrayRemoveItem, ClassType } from '@deepkit/core';
-import { Inject, Provider, TransientInjectionTarget } from '@deepkit/injector';
+import { FactoryProvider, Inject, TransientInjectionTarget } from '@deepkit/injector';
 
 export enum LoggerLevel {
     none,
@@ -312,9 +312,9 @@ export class Logger implements LoggerInterface {
 }
 
 export type ScopedLogger = Inject<Logger, 'scoped-logger'>;
-export const ScopedLogger: Provider<Logger> = {
+export const ScopedLogger = {
     provide: 'scoped-logger',
     transient: true,
     useFactory: (target: TransientInjectionTarget, logger: Logger = new Logger()) =>
         logger.scoped(target.token?.name ?? String(target.token)),
-};
+} as const;

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -11,6 +11,7 @@
 import style from 'ansi-styles';
 import format from 'format-util';
 import { arrayRemoveItem, ClassType } from '@deepkit/core';
+import { Inject, Provider, TransientInjectionTarget } from '@deepkit/injector';
 
 export enum LoggerLevel {
     none,
@@ -309,3 +310,11 @@ export class Logger implements LoggerInterface {
         this.send(message, LoggerLevel.debug);
     }
 }
+
+export type ScopedLogger = Inject<Logger, 'scoped-logger'>;
+export const ScopedLogger: Provider<Logger> = {
+    provide: 'scoped-logger',
+    transient: true,
+    useFactory: (target: TransientInjectionTarget, logger: Logger = new Logger()) =>
+        logger.scoped(target.token?.name ?? String(target.token)),
+};

--- a/packages/logger/tests/logger.spec.ts
+++ b/packages/logger/tests/logger.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@jest/globals';
 import { JSONTransport, Logger, LoggerLevel, ScopedLogger, ScopeFormatter } from '../src/logger.js';
 import { MemoryLoggerTransport } from '../src/memory-logger.js';
-import { Injector, ServiceNotFoundError } from '@deepkit/injector';
+import { Injector, ServiceNotFoundError, TransientInjectionTarget } from '@deepkit/injector';
 
 test('log level', () => {
     const logger = new Logger();
@@ -108,5 +108,58 @@ test('scoped logger', () => {
         expect(() => injector.get(Logger)).toThrow(ServiceNotFoundError);
         const provider = injector.get(MyProvider);
         expect(provider.logger).toBeInstanceOf(Logger);
+    }
+
+    {
+        class A {
+            constructor (public b: B) {
+            }
+        }
+
+        class B {
+            constructor (public c: C, public target: TransientInjectionTarget) {
+            }
+        }
+
+        class C {
+            constructor (public target: TransientInjectionTarget) {
+            }
+        }
+
+        const injector = Injector.from([
+            A,
+            { provide: B, transient: true },
+            { provide: C, transient: true },
+        ]);
+        const a = injector.get(A);
+        expect(a.b.c.target.token).toBe(B);
+        expect(a.b.target.token).toBe(A);
+    }
+
+    {
+        class A {
+            constructor (public b: C) {
+            }
+        }
+
+        class B {
+            constructor (public target: TransientInjectionTarget) {
+            }
+        }
+
+        class C {
+            constructor (public target: TransientInjectionTarget) {
+            }
+        }
+
+        const injector = Injector.from([
+            A,
+            { provide: B, transient: true },
+            { provide: C, transient: true, useExisting: B },
+        ]);
+
+        const a = injector.get(A);
+        expect(a.b).toBeInstanceOf(B);
+        expect(a.b.target.token).toBe(A);
     }
 });

--- a/packages/logger/tests/logger.spec.ts
+++ b/packages/logger/tests/logger.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@jest/globals';
-import { JSONTransport, Logger, LoggerLevel, ScopeFormatter } from '../src/logger.js';
+import { JSONTransport, Logger, LoggerLevel, ScopedLogger, ScopeFormatter } from '../src/logger.js';
 import { MemoryLoggerTransport } from '../src/memory-logger.js';
+import { Injector, ServiceNotFoundError } from '@deepkit/injector';
 
 test('log level', () => {
     const logger = new Logger();
@@ -78,4 +79,34 @@ test('colorless', () => {
     const logger = new Logger([jsonLogger]);
 
     logger.log('This is a <yellow>color</yellow> test');
+});
+
+test('scoped logger', () => {
+    class MyProvider {
+        constructor (public logger: ScopedLogger) {
+        }
+    }
+
+    {
+        const injector = Injector.from([
+            MyProvider,
+            Logger, // optional base logger used by ScopedLogger
+            ScopedLogger,
+        ]);
+        const logger = injector.get(Logger);
+        const provider = injector.get(MyProvider);
+        expect(logger).toBeInstanceOf(Logger);
+        expect(provider.logger).toBeInstanceOf(Logger);
+        expect(provider.logger).toBe(logger.scoped('MyProvider'));
+    }
+
+    {
+        const injector = Injector.from([
+            MyProvider,
+            ScopedLogger,
+        ]);
+        expect(() => injector.get(Logger)).toThrow(ServiceNotFoundError);
+        const provider = injector.get(MyProvider);
+        expect(provider.logger).toBeInstanceOf(Logger);
+    }
 });


### PR DESCRIPTION
### Summary of changes

Adds a `TransientInjectorTarget` class that can be injected into transient providers/useFactory functions when the provider is injected into other providers. This allows for the creation of context aware classes, such as loggers scoped to the class they are used in.

Also adds a `ScopedLogger` to @deepkit/logger and @deepkit/framework's `FrameworkModule` that uses `TransientInjectorTarget` to create loggers scoped to the provider token name


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
