### PR TITLE
Fix installation failure due to the lack of shebang.

### DIFF
--- a/packages/type-compiler/deepkit-type-install.js
+++ b/packages/type-compiler/deepkit-type-install.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 
 try {
     require('./dist/cjs/install-transformer.js');


### PR DESCRIPTION
### Summary of changes

Last release installation fails due to inability to install type compiler.
This PR adds required shebang


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
