### PR TITLE
Repair compilation of inline type definitions with generics

### DIFF
--- a/packages/type-compiler/src/compiler.ts
+++ b/packages/type-compiler/src/compiler.ts
@@ -1411,7 +1411,7 @@ export class ReflectionTransformer implements CustomTransformer {
                 if (isTypeLiteralNode(narrowed)) {
                     descriptionNode = narrowed.parent;
                 }
-                const description = extractJSDocAttribute(descriptionNode, 'description');
+                const description = descriptionNode && extractJSDocAttribute(descriptionNode, 'description');
                 if (description) program.pushOp(ReflectionOp.description, program.findOrAddStackEntry(description));
                 program.popFrameImplicit();
                 break;

--- a/packages/type-compiler/tests/transpile.spec.ts
+++ b/packages/type-compiler/tests/transpile.spec.ts
@@ -447,3 +447,20 @@ test('keep "use x" at top', () => {
     });
     expect(res.app.startsWith('"use client";')).toBe(true);
 });
+
+test('inline type definitions should compile', () => {
+    const res = transpile({
+        'app': `
+        function testFn<
+            T extends ClassType<any>,
+            Prop extends keyof InstanceType<T>
+        >(options: {
+            type: T;
+            props: Prop[];
+        }) {
+            type R = Pick<InstanceType<Schema>, Prop>;
+        }
+        `
+    });
+    console.log(res);
+});


### PR DESCRIPTION
### Summary of changes

#463 introduced a bug where compilation of certain inline types causes a crash of tsc due to `narrowed.parent` having an undefined value.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
