### PR TITLE
fix(framework): use NoopStopwatchStore when debugger is disabled

### DIFF
--- a/packages/framework/src/module.ts
+++ b/packages/framework/src/module.ts
@@ -24,7 +24,7 @@ import { BrokerConfig, FrameworkConfig } from './module.config.js';
 import { LoggerInterface } from '@deepkit/logger';
 import { SessionHandler } from './session.js';
 import { RpcServer, WebWorkerFactory } from './worker.js';
-import {NoopStopwatchStore, Stopwatch, StopwatchStore} from '@deepkit/stopwatch';
+import { NoopStopwatchStore, Stopwatch, StopwatchStore } from '@deepkit/stopwatch';
 import { OrmBrowserController } from './orm-browser/controller.js';
 import { DatabaseListener } from './database/database-listener.js';
 import { Database, DatabaseRegistry } from '@deepkit/orm';

--- a/packages/framework/src/module.ts
+++ b/packages/framework/src/module.ts
@@ -24,7 +24,7 @@ import { BrokerConfig, FrameworkConfig } from './module.config.js';
 import { LoggerInterface } from '@deepkit/logger';
 import { SessionHandler } from './session.js';
 import { RpcServer, WebWorkerFactory } from './worker.js';
-import { Stopwatch, StopwatchStore } from '@deepkit/stopwatch';
+import {NoopStopwatchStore, Stopwatch, StopwatchStore} from '@deepkit/stopwatch';
 import { OrmBrowserController } from './orm-browser/controller.js';
 import { DatabaseListener } from './database/database-listener.js';
 import { Database, DatabaseRegistry } from '@deepkit/orm';
@@ -209,10 +209,14 @@ export class FrameworkModule extends createModule({
             }));
 
             // this.setupProvider(LiveDatabase).enableChangeFeed(DebugRequest);
+
+            this.addProvider(FileStopwatchStore);
+            this.addProvider({ provide: StopwatchStore, useExisting: FileStopwatchStore });
+        } else {
+            this.addProvider(NoopStopwatchStore);
+            this.addProvider({ provide: StopwatchStore, useExisting: NoopStopwatchStore });
         }
 
-        this.addProvider(FileStopwatchStore);
-        this.addProvider({ provide: StopwatchStore, useExisting: FileStopwatchStore });
         this.addProvider({
             provide: Stopwatch,
             useFactory(store: StopwatchStore, profile: FrameworkConfig['debugProfiler']) {

--- a/packages/framework/tests/application-server.spec.ts
+++ b/packages/framework/tests/application-server.spec.ts
@@ -142,7 +142,13 @@ describe('application-server', () => {
 
             const testing = createTestingApp({
                 controllers: [MyController],
-                imports: [new FrameworkModule({ publicDir: 'public', gracefulShutdownTimeout: 1 })]
+                imports: [
+                    new FrameworkModule({
+                        publicDir: 'public',
+                        gracefulShutdownTimeout: 1,
+                        debugProfiler: false,
+                    })
+                ]
             });
 
             await testing.startServer();
@@ -164,7 +170,13 @@ describe('application-server', () => {
 
             const testing = createTestingApp({
                 controllers: [MyController],
-                imports: [new FrameworkModule({ publicDir: 'public', gracefulShutdownTimeout: 1 })]
+                imports: [
+                    new FrameworkModule({
+                        publicDir: 'public',
+                        gracefulShutdownTimeout: 1,
+                        debugProfiler: false,
+                    })
+                ]
             });
 
             await testing.startServer();

--- a/packages/stopwatch/src/stopwatch.ts
+++ b/packages/stopwatch/src/stopwatch.ts
@@ -76,6 +76,17 @@ export abstract class StopwatchStore {
     }
 }
 
+export class NoopStopwatchStore extends StopwatchStore {
+
+    run<T>(data: { [name: string]: any }, cb: () => Promise<T>): Promise<T> {
+        return cb();
+    }
+
+    getZone(): { [name: string]: any } | undefined {
+        return undefined;
+    }
+}
+
 export interface StopwatchFrameInterface<C extends FrameCategory> {
     data(data: TypeOfCategory<C>): void;
 

--- a/packages/stopwatch/src/stopwatch.ts
+++ b/packages/stopwatch/src/stopwatch.ts
@@ -77,7 +77,6 @@ export abstract class StopwatchStore {
 }
 
 export class NoopStopwatchStore extends StopwatchStore {
-
     run<T>(data: { [name: string]: any }, cb: () => Promise<T>): Promise<T> {
         return cb();
     }


### PR DESCRIPTION
### Summary of changes
Use `NoopStopwatchStore` instead of `FileStopwatchStore` when debugging is disabled.

Fixes the following error
```
unhandledRejection [Error: ENOENT: no such file or directory, open 'var/debug/frames.bin'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'var/debug/frames.bin'
}
```

<!-- My summary here. -->


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
