### PR TITLE
Update official Deepkit Documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Standalone TypeScript libraries and a framework that brings everything together.
 
 ## Docs
 
-Check out the [Deepkit Documentation](https://docs.deepkit.io) to get started.
+Check out the [Deepkit Documentation](https://deepkit.io) to get started.
 
 There is also an [eBook version](https://docs.deepkit.io/deepkit-book-english.html). 
 


### PR DESCRIPTION
Update official Deepkit Documentation link

### Summary of changes

The current link to the official Deepkit documentation is broken, I just updated it with the new Url.


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
