### PR TITLE
Extend `valuesOf` to work with unions

### DIFF
--- a/packages/type/src/reflection/type.ts
+++ b/packages/type/src/reflection/type.ts
@@ -1125,8 +1125,7 @@ export function indexAccess(container: Type, index: Type): Type {
 
                 // For each type in the union, t, resolve the type at index.
                 for (const t of container.types) {
-                    if (t.kind !== ReflectionKind.objectLiteral && t.kind !== ReflectionKind.class) continue;
-                    const resolvedType = resolveObjectIndexType(t, index);
+                    const resolvedType = indexAccess(t, index);
                     if (isTypeIncluded(union.types, resolvedType)) continue;
                     union.types.push(resolvedType);
                 }
@@ -1162,8 +1161,6 @@ export function indexAccess(container: Type, index: Type): Type {
             // is assumed to be an object literal or class, so we loop over
             // each of those types.
             for (const t of container.types) {
-                if (t.kind !== ReflectionKind.objectLiteral && t.kind !== ReflectionKind.class) continue;
-
                 // This approach does not produce identical results to
                 // TypeScript - as this reduces all duplicates from the result
                 // (i.e., it produces the 'set' of all types that would be
@@ -1172,40 +1169,10 @@ export function indexAccess(container: Type, index: Type): Type {
                 // literals. Unless this absolute fidelity is required, this
                 // approach is simpler and probably makes more sense too.
                 for (let index of indices) {
-                    const resolvedType = resolveObjectIndexType(t, index);
+                    const resolvedType = indexAccess(t, index);
                     if (isTypeIncluded(types, resolvedType)) continue;
                     types.push(resolvedType);
                 }
-
-                // This approach is left here for posterity, but would need to
-                // be adapted to fold the types that TypeScript also folds.
-                // (i.e., to fold numeric literals, but not string literals,
-                // etc.,).
-
-                // // Each type in an indexable union is an object literal, so we
-                // // loop over each of the members of that object literal.
-                // // If any of the members have a name identical to one of the
-                // // indices, we add the type of that member to the list of types
-                // // found in that union entry.
-                // let foundTypes: Type[] = [];
-                // for (const resultT of t.types) {
-                //     if (resultT.kind !== ReflectionKind.propertySignature) continue;
-                //
-                //     if (indices.map((index) => index.literal).includes(resultT.name)) {
-                //         if (isTypeIncluded(foundTypes, resultT.type)) continue;
-                //         foundTypes.push(resultT.type);
-                //     }
-                // }
-                //
-                // // If we found any types, we add them to the list of types
-                // // we've found in this literal.
-                // if (types.push(...foundTypes) === 0) {
-                //     // If we didn't add any types in this literal, the type is
-                //     // invalid - indexing a union is only valid when the union
-                //     // has at least one entry for that index per member of the
-                //     // union.
-                //     return { kind: ReflectionKind.never };
-                // }
             }
 
             return unboxUnion({ kind: ReflectionKind.union, types });

--- a/packages/type/src/reflection/type.ts
+++ b/packages/type/src/reflection/type.ts
@@ -723,10 +723,11 @@ export function isSameType(a: Type, b: Type, stack: StackEntry[] = []): boolean 
             if (a.parameters.length !== b.parameters.length) return false;
             if (a.kind === ReflectionKind.function && b.kind === ReflectionKind.function && a.function !== b.function) return false;
 
-            if (a.name !== b.name) return false;
             if (a.kind === ReflectionKind.method && b.kind === ReflectionKind.method) {
                 if (a.visibility !== b.visibility) return false;
             }
+
+            if (a.name !== b.name) return false;
 
             for (let i = 0; i < a.parameters.length; i++) {
                 if (!isSameType(a.parameters[i], b.parameters[i], stack)) return false;

--- a/packages/type/src/reflection/type.ts
+++ b/packages/type/src/reflection/type.ts
@@ -723,6 +723,11 @@ export function isSameType(a: Type, b: Type, stack: StackEntry[] = []): boolean 
             if (a.parameters.length !== b.parameters.length) return false;
             if (a.kind === ReflectionKind.function && b.kind === ReflectionKind.function && a.function !== b.function) return false;
 
+            if (a.name !== b.name) return false;
+            if (a.kind === ReflectionKind.method && b.kind === ReflectionKind.method) {
+                if (a.visibility !== b.visibility) return false;
+            }
+
             for (let i = 0; i < a.parameters.length; i++) {
                 if (!isSameType(a.parameters[i], b.parameters[i], stack)) return false;
             }
@@ -1121,7 +1126,9 @@ export function indexAccess(container: Type, index: Type): Type {
                 // For each type in the union, t, resolve the type at index.
                 for (const t of container.types) {
                     if (t.kind !== ReflectionKind.objectLiteral && t.kind !== ReflectionKind.class) continue;
-                    union.types.push(resolveObjectIndexType(t, index));
+                    const resolvedType = resolveObjectIndexType(t, index);
+                    if (isTypeIncluded(union.types, resolvedType)) continue;
+                    union.types.push(resolvedType);
                 }
 
                 return unboxUnion(union);

--- a/packages/type/tests/valuesof-union.spec.ts
+++ b/packages/type/tests/valuesof-union.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Deepkit Framework
+ * Copyright Deepkit UG, Marc J. Schmidt, Apollo Software Limited, SamJakob
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the MIT License.
+ *
+ * You should have received a copy of the MIT License along with this program.
+ */
+
+import { test } from '@jest/globals';
+import { expectEqualType } from "./utils";
+import { typeOf, valuesOf } from "../src/reflection/reflection";
+
+test('typeOf infers a simple union', () => {
+    type t = 'a' | 'b';
+    expectEqualType(valuesOf<t>(), ['a', 'b']);
+});
+
+test('typeOf infers a literal key on a union', () => {
+    type t = { foo: 'a' } | { foo: 'b' };
+    expectEqualType(valuesOf<t['foo']>(), ['a', 'b']);
+
+    type t2 = { 1: 'a' } | { 1: 'b' };
+    type t3 = { [1]: 'a' } | { [1]: 'b' };
+    expectEqualType(valuesOf<t2[1]>(), ['a', 'b']);
+    expectEqualType(valuesOf<t3[1]>(), ['a', 'b']);
+
+    const mySymbol = Symbol('mySymbol');
+    type t4 = { [mySymbol]: 'a', 1: 2 } | { [mySymbol]: 'b', 1: 4 };
+    expectEqualType(valuesOf<t4[typeof mySymbol|1]>(), ['a', 2, 'b', 4]);
+
+    type t5 = ['a'] | ['b'];
+    expectEqualType(valuesOf<t5[0]>(), ['a', 'b']);
+});
+
+type AdvancedTest = { foo: 1, bar: 2, baz: 3 } | { foo: 4, bar: 5, baz: 6 };
+
+test('typeOf infers a union key on a union', () => {
+    expectEqualType(valuesOf<AdvancedTest['foo'|'baz']>(), [1, 3, 4, 6]);
+
+    type AdvancedTest2 = { 1: 'foo', 2: 'bar', 3: 'baz' } | { 1: 'fizz', 2: 'buzz', 3: 'fizzbuzz' };
+    expectEqualType(valuesOf<AdvancedTest2[1|3]>(), ['foo', 'baz', 'fizz', 'fizzbuzz']);
+
+    type AdvancedTest3 = { [1]: 'foo', [2]: 'bar', [3]: 'baz' } | { [1]: 'fizz', [2]: 'buzz', [3]: 'fizzbuzz' };
+    expectEqualType(valuesOf<AdvancedTest3[1|3]>(), ['foo', 'baz', 'fizz', 'fizzbuzz']);
+
+    const mySymbol = Symbol('mySymbol');
+    type AdvancedTest4 = { [mySymbol]: 'foo', bar: 'bar', baz: 'baz' } | { [mySymbol]: 'fizz', bar: 'buzz', baz: 'fizzbuzz' };
+    // Note: the current implementation reduces duplicate values
+    expectEqualType(valuesOf<AdvancedTest4[typeof mySymbol|'baz']>(), ['foo', 'baz', 'fizz']);
+
+    type AdvancedTest5 = ['a', 'b'] | ['c', 'd'];
+    expectEqualType(valuesOf<AdvancedTest5[0|1]>(), ['a', 'b', 'c', 'd']);
+});
+
+class AdvancedTestClass {
+    public foo() {}
+    public bar() {}
+    public baz() {}
+}
+
+type MoreAdvancedTest = AdvancedTest | AdvancedTestClass;
+
+test('typeOf infers a union key on a union with a class', () => {
+    expectEqualType(valuesOf<MoreAdvancedTest['foo'|'baz']>(), [1, 3, 4, 6, typeOf<AdvancedTestClass['foo']>(), typeOf<AdvancedTestClass['baz']>()]);
+});

--- a/packages/type/tests/valuesof-union.spec.ts
+++ b/packages/type/tests/valuesof-union.spec.ts
@@ -58,6 +58,7 @@ class AdvancedTestClass {
     public foo() {}
     public bar() {}
     public baz() {}
+    private fizz() {}
 }
 
 type MoreAdvancedTest = AdvancedTest | AdvancedTestClass;


### PR DESCRIPTION
### Summary of changes

This enables `valuesOf` to work on indexed unions and when the index into the union is also a union.
See the included tests for examples of functionality that now works (all of which did not previously work).

### License/Waiver

I hereby release these code changes under the MIT license but waive the requirement for name attribution, inclusion of copyright and/or permission notice.
