### PR TITLE
fix(type): Fix reflection on mapped types, fixes #514

### DIFF
--- a/packages/type/src/reflection/processor.ts
+++ b/packages/type/src/reflection/processor.ts
@@ -1503,7 +1503,7 @@ export class Processor {
         if (!isType(left)) {
             this.push({ kind: ReflectionKind.never });
         } else {
-            let t: Type = indexAccess(left, right);
+            const t: Type = indexAccess(left, right);
             if (isWithAnnotations(t)) {
                 t.indexAccessOrigin = { container: left as TypeObjectLiteral, index: right as Type };
             }

--- a/packages/type/src/reflection/processor.ts
+++ b/packages/type/src/reflection/processor.ts
@@ -53,12 +53,12 @@ import {
     validationAnnotation,
     widenLiteral
 } from './type.js';
-import { MappedModifier, ReflectionOp } from '@deepkit/type-spec';
-import { isExtendable } from './extends.js';
-import { ClassType, isArray, isClass, isFunction, stringifyValueWithType } from '@deepkit/core';
-import { isWithDeferredDecorators } from '../decorator.js';
-import { ReflectionClass, TData } from './reflection.js';
-import { state } from './state.js';
+import {MappedModifier, ReflectionOp} from '@deepkit/type-spec';
+import {isExtendable} from './extends.js';
+import {ClassType, isArray, isClass, isFunction, stringifyValueWithType} from '@deepkit/core';
+import {isWithDeferredDecorators} from '../decorator.js';
+import {ReflectionClass, TData} from './reflection.js';
+import {state} from './state.js';
 
 export type RuntimeStackEntry = Type | Object | (() => ClassType | Object) | string | number | boolean | bigint;
 
@@ -1503,13 +1503,12 @@ export class Processor {
         if (!isType(left)) {
             this.push({ kind: ReflectionKind.never });
         } else {
-            const t: Type = indexAccess(left, right);
+            let t: Type = indexAccess(left, right);
             if (isWithAnnotations(t)) {
                 t.indexAccessOrigin = { container: left as TypeObjectLiteral, index: right as Type };
             }
-
             if (t.parent) t.parent.parent = undefined;
-            this.push(t);
+            this.push(copyAndSetParent(t, undefined));
         }
     }
 

--- a/packages/type/tests/issues/514-optional-via-mapped-types.spec.ts
+++ b/packages/type/tests/issues/514-optional-via-mapped-types.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * Deepkit Framework
+ * Copyright Deepkit UG, Marc J. Schmidt, Apollo Software Limited, SamJakob
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the MIT License.
+ *
+ * You should have received a copy of the MIT License along with this program.
+ */
+
+
+import {expect, test } from '@jest/globals';
+import { integer } from "../../src/reflection/type";
+import {ReflectionClass} from "../../src/reflection/reflection";
+
+interface User {
+    readonly id: integer;
+    readonly name?: string;
+    readonly address: string;
+    readonly postcode: string;
+}
+
+type PartialUser = Pick<
+    User,
+    'id' | 'name'
+>;
+
+test('the optional modifier should be retained after a mapped type', () => {
+    // This has always worked: checking the optional property on the original type
+    const reflectionClass = ReflectionClass.from<User>();
+    expect(reflectionClass.getProperty('id').isOptional()).toBe(false);
+    expect(reflectionClass.getProperty('name').isOptional()).toBe(true);
+
+    // ...but it should work if we map it with - e.g., Pick - too.
+    const partialReflectionClass = ReflectionClass.from<PartialUser>();
+    expect(partialReflectionClass.getProperty('id').isOptional()).toBe(false);
+    expect(partialReflectionClass.getProperty('name').isOptional()).toBe(true);
+});

--- a/packages/type/tests/issues/514-optional-via-mapped-types.spec.ts
+++ b/packages/type/tests/issues/514-optional-via-mapped-types.spec.ts
@@ -11,7 +11,8 @@
 
 import {expect, test } from '@jest/globals';
 import { integer } from "../../src/reflection/type";
-import {ReflectionClass} from "../../src/reflection/reflection";
+import { ReflectionClass, typeOf } from "../../src/reflection/reflection";
+import {expectEqualType} from "../utils";
 
 interface User {
     readonly id: integer;
@@ -35,4 +36,31 @@ test('the optional modifier should be retained after a mapped type', () => {
     const partialReflectionClass = ReflectionClass.from<PartialUser>();
     expect(partialReflectionClass.getProperty('id').isOptional()).toBe(false);
     expect(partialReflectionClass.getProperty('name').isOptional()).toBe(true);
+});
+
+type Test = {name: User['name'], address: User['address']};
+type Username = User['name'];
+type Username2 = Test['name'];
+
+test('The optional property should not carry over when a property is mapped (consistent with TypeScript)', () => {
+    const reflectionClass = ReflectionClass.from<User>();
+    expect(reflectionClass.getProperty('address').isOptional()).toBe(false); // (sanity check)
+    expect(reflectionClass.getProperty('name').isOptional()).toBe(true);
+
+    const alteredReflectionClass = ReflectionClass.from<Test>();
+    expect(alteredReflectionClass.getProperty('address').isOptional()).toBe(false); // (sanity check)
+    expect(alteredReflectionClass.getProperty('name').isOptional()).toBe(false);
+
+    expectEqualType(typeOf<Username>(), typeOf<Username2>(), { noTypeNames: true });
+});
+
+type UserNestedType = Omit<Pick<
+    User,
+    'id' | 'name' | 'address'
+>, 'id'>;
+
+test('Nested mapped types should work', () => {
+    const nestedReflectionClass = ReflectionClass.from<UserNestedType>();
+    expect(nestedReflectionClass.getProperty('name').isOptional()).toBe(true);
+    expect(nestedReflectionClass.getProperty('address').isOptional()).toBe(false);
 });

--- a/packages/type/tests/processor.spec.ts
+++ b/packages/type/tests/processor.spec.ts
@@ -26,14 +26,14 @@ test('assertEqualType 1', () => {
     expect(() => expectEqualType({ kind: ReflectionKind.literal, literal: 'asd' }, {
         kind: ReflectionKind.literal,
         literal: 'asd2'
-    })).toThrow('Invalid type .literal: asd !== asd2');
+    })).toThrow('Invalid type .literal: expected type: asd !== actual type: asd2');
 
     const a: ParentLessType = { kind: ReflectionKind.tuple, types: [{ kind: ReflectionKind.tupleMember, type: { kind: ReflectionKind.string } }] };
     expectEqualType(a, a);
     expect(() => expectEqualType(a, {
         kind: ReflectionKind.tuple,
         types: [{ kind: ReflectionKind.tupleMember, type: { kind: ReflectionKind.number } }]
-    })).toThrow('Invalid type .types.0.type.kind: 5 !== 6');
+    })).toThrow('Invalid type .types.0.type.kind: expected type: 5 !== actual type: 6');
 
     const b: ParentLessType = {
         kind: ReflectionKind.function,

--- a/packages/type/tests/utils.ts
+++ b/packages/type/tests/utils.ts
@@ -125,7 +125,7 @@ export function expectEqualType(actual: any, expected: any, options: { noTypeNam
             }
         }
     } else {
-        if (expected !== actual) throw new Error(`Invalid type ${path}: ${expected} !== ${actual}`);
+        if (expected !== actual) throw new Error(`Invalid type ${path}: expected type: ${expected} !== actual type: ${actual}`);
     }
 
     options.stack.pop();


### PR DESCRIPTION
### Summary of changes

This enables the `optional` property to be carried forward from a mapped `propertySignature` by retaining the information about the signature on the parent (without retaining all of the parent information).

This should solve the issue on any mapped type, but specifically this should accommodate many of the TypeScript utility classes (e.g., `Pick`) as described in #514 

### License/Waiver

I hereby release these code changes under the MIT license but waive the requirement for name attribution, inclusion of copyright and/or permission notice.
