### PR TITLE
fix(mysql): update JSON field with null value

### DIFF
--- a/packages/sql/src/platform/default-platform.ts
+++ b/packages/sql/src/platform/default-platform.ts
@@ -189,7 +189,7 @@ export abstract class DefaultPlatform {
         return fields;
     }
 
-    protected getTypeMapping(type: Type): TypeMapping | undefined {
+    public getTypeMapping(type: Type): TypeMapping | undefined {
         let mapping = undefined as TypeMapping | undefined;
         for (const [checker, m] of this.typeMapping.entries()) {
             if ('number' === typeof checker) {


### PR DESCRIPTION
### Summary of changes

When defining a model field as `SomeObjectType | null`, an attempt to replace a JSON object with `null` throws a SQL error:

```
 ● json nulls

    (conn=237, no: 3142, SQLState: HY000) The JSON binary value contains invalid data.
    sql: 
                  WITH _tmp(`_origin_id`, doc) AS (
                    SELECT _.`_origin_id`, IF(_set.`_changed_doc` = 0, _origin.`doc`, _.`doc`) as `doc` FROM
                        (VALUES ROW(?,?)) as _(`_origin_id`, doc)
                        INNER JOIN (VALUES R...

      81 |             //mysql/mariadb driver does not maintain error.stack when they throw errors, so
      82 |             //we have to manually convert it using asyncOperation.
    > 83 |             const rows = await asyncOperation<any[]>((resolve, reject) => {
         |                          ^
      84 |                 this.connection.query(this.sql, params).then(resolve).catch(reject);
      85 |             });
      86 |             this.logger.logQuery(this.sql, params);

      at Object.<anonymous>.module.exports.createError (../../node_modules/mariadb/lib/misc/errors.js:61:10)
      at PacketNodeEncoded.readError (../../node_modules/mariadb/lib/io/packet.js:511:19)
      at Query.readResponsePacket (../../node_modules/mariadb/lib/cmd/resultset.js:46:28)
      at PacketInputStream.receivePacketBasic (../../node_modules/mariadb/lib/io/packet-input-stream.js:104:9)
      at PacketInputStream.onData (../../node_modules/mariadb/lib/io/packet-input-stream.js:169:20)
      at MySQLStatement.all (src/mysql-adapter.ts:83:26)
      at MySQLConnection.execAndReturnAll (../sql/src/sql-adapter.ts:137:20)
      at MySQLPersistence.batchUpdate (src/mysql-adapter.ts:333:24)
      at MySQLPersistence.update (../sql/src/sql-adapter.ts:749:13)
      at DatabaseSessionRound.doPersist (../orm/src/database-session.ts:220:25)
      at DatabaseSessionRound.commit (../orm/src/database-session.ts:126:13)
      at DatabaseSession.flush (../orm/src/database-session.ts:553:17)
      at DatabaseSession.commit (../orm/src/database-session.ts:363:9)
      at Database.persist (../orm/src/database.ts:354:9)
      at Object.<anonymous> (tests/mysql.spec.ts:215:9)
```

Although `SELECT NULL` returns `NULL` with type `NULL`, `SELECT * FROM (VALUES ROW(NULL)) as _(testCol)` returns `NULL` with type `BINARY`.  MySQL doesn't seem to want to update a `JSON` column with `NULL` of type `BINARY`.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
