### PR TITLE
feat(type) add some options to the JIT compiler 

### DIFF
--- a/packages/type/src/serializer-facade.ts
+++ b/packages/type/src/serializer-facade.ts
@@ -24,7 +24,7 @@ import { findMember, getTypeJitContainer, ReflectionKind, Type, TypeClass, TypeO
  * @throws ValidationError if casting or validation fails
  */
 export function cast<T>(data: JSONPartial<T> | unknown, options?: SerializationOptions, serializerToUse: Serializer = serializer, namingStrategy?: NamingStrategy, type?: ReceiveType<T>): T {
-    const fn = getSerializeFunction(resolveReceiveType(type), serializerToUse.deserializeRegistry, namingStrategy);
+    const fn = getSerializeFunction(resolveReceiveType(type), serializerToUse.deserializeRegistry, namingStrategy, undefined, undefined, serializerToUse.options.emitErrors);
     const item = fn(data, options) as T;
     assert(item, undefined, type);
     return item;
@@ -34,7 +34,7 @@ export function cast<T>(data: JSONPartial<T> | unknown, options?: SerializationO
  * Same as cast but returns a ready to use function. Used to improve performance.
  */
 export function castFunction<T>(serializerToUse: Serializer = serializer, namingStrategy?: NamingStrategy, type?: ReceiveType<T>): (data: JSONPartial<T> | unknown, options?: SerializationOptions) => T {
-    const fn = getSerializeFunction(resolveReceiveType(type), serializerToUse.deserializeRegistry, namingStrategy);
+    const fn = getSerializeFunction(resolveReceiveType(type), serializerToUse.deserializeRegistry, namingStrategy, undefined, undefined, serializerToUse.options.emitErrors);
     return (data: JSONPartial<T> | unknown, options?: SerializationOptions) => {
         const item = fn(data, options);
         assert(item, undefined, type);
@@ -59,7 +59,7 @@ export function castFunction<T>(serializerToUse: Serializer = serializer, naming
  * ```
  */
 export function deserialize<T>(data: JSONPartial<T> | unknown, options?: SerializationOptions, serializerToUse: Serializer = serializer, namingStrategy?: NamingStrategy, type?: ReceiveType<T>): T {
-    const fn = getSerializeFunction(resolveReceiveType(type), serializerToUse.deserializeRegistry, namingStrategy);
+    const fn = getSerializeFunction(resolveReceiveType(type), serializerToUse.deserializeRegistry, namingStrategy, undefined, undefined, serializerToUse.options.emitErrors);
     return fn(data, options) as T;
 }
 
@@ -67,7 +67,7 @@ export function deserialize<T>(data: JSONPartial<T> | unknown, options?: Seriali
  * Same as deserialize but returns a ready to use function. Used to improve performance.
  */
 export function deserializeFunction<T>(serializerToUse: Serializer = serializer, namingStrategy?: NamingStrategy, type?: ReceiveType<T>): SerializeFunction<any, T> {
-    return getSerializeFunction(resolveReceiveType(type), serializerToUse.deserializeRegistry, namingStrategy);
+    return getSerializeFunction(resolveReceiveType(type), serializerToUse.deserializeRegistry, namingStrategy, undefined, undefined, serializerToUse.options.emitErrors);
 }
 
 /**
@@ -77,21 +77,21 @@ export function deserializeFunction<T>(serializerToUse: Serializer = serializer,
 export function patch<T>(data: DeepPartial<T>, options?: SerializationOptions, serializerToUse: Serializer = serializer, namingStrategy?: NamingStrategy, type?: ReceiveType<T>): (data: JSONPartial<T> | unknown) => T {
     type = resolveReceiveType(type);
     if (type.kind !== ReflectionKind.objectLiteral && type.kind !== ReflectionKind.class) throw new Error('patch() only works on object literals and classes');
-    return getPatchSerializeFunction(type, serializerToUse.deserializeRegistry, namingStrategy)(data, options);
+    return getPatchSerializeFunction(type, serializerToUse.deserializeRegistry, namingStrategy, serializerToUse.options.emitErrors)(data, options);
 }
 
 /**
  * Create a serializer/deserializer function including validator for the given type for a patch structure.
  * This is handy for deep patch structures like e.g '{user.address.street: "new street"}'.
  */
-export function getPatchSerializeFunction(type: TypeClass | TypeObjectLiteral, registry: TemplateRegistry, namingStrategy: NamingStrategy = new NamingStrategy()):
+export function getPatchSerializeFunction(type: TypeClass | TypeObjectLiteral, registry: TemplateRegistry, namingStrategy: NamingStrategy = new NamingStrategy(), emitErrors = true):
     (data: any, state?: SerializationOptions, patch?: { normalizeArrayIndex: boolean }) => any {
 
     const jitContainer = getTypeJitContainer(type);
     const id = registry.id + '_' + namingStrategy.id + '_' + 'patch';
     if (jitContainer[id]) return jitContainer[id];
 
-    const partialSerializer = getPartialSerializeFunction(type, registry, namingStrategy);
+    const partialSerializer = getPartialSerializeFunction(type, registry, namingStrategy, emitErrors);
     // const partialValidator = getValidatorFunction(registry.serializer, getPartialType(type));
 
     return jitContainer[id] = function (data: any, state?: SerializationOptions, patch?: { normalizeArrayIndex: boolean }) {
@@ -148,7 +148,7 @@ export function getPatchSerializeFunction(type: TypeClass | TypeObjectLiteral, r
                         }
                     }
                     if (newPath) {
-                        result[newPath] = getSerializeFunction(currentType, registry, namingStrategy)(data[i], state);
+                        result[newPath] = getSerializeFunction(currentType, registry, namingStrategy, undefined, undefined, emitErrors)(data[i], state);
                         // assert(result[newPath], undefined, currentType);
                     }
                 }
@@ -179,7 +179,7 @@ export function getPatchSerializeFunction(type: TypeClass | TypeObjectLiteral, r
  * @throws ValidationError when serialization or validation fails.
  */
 export function serialize<T>(data: T, options?: SerializationOptions, serializerToUse: Serializer = serializer, namingStrategy?: NamingStrategy, type?: ReceiveType<T>): JSONSingle<T> {
-    const fn = getSerializeFunction(resolveReceiveType(type), serializerToUse.serializeRegistry, namingStrategy);
+    const fn = getSerializeFunction(resolveReceiveType(type), serializerToUse.serializeRegistry, namingStrategy, undefined, undefined, serializerToUse.options.emitErrors);
     return fn(data, options) as JSONSingle<T>;
 }
 
@@ -187,7 +187,7 @@ export function serialize<T>(data: T, options?: SerializationOptions, serializer
  * Same as serialize but returns a ready to use function. Used to improve performance.
  */
 export function serializeFunction<T>(serializerToUse: Serializer = serializer, namingStrategy?: NamingStrategy, type?: ReceiveType<T>): SerializeFunction<T> {
-    return getSerializeFunction(resolveReceiveType(type), serializerToUse.serializeRegistry, namingStrategy);
+    return getSerializeFunction(resolveReceiveType(type), serializerToUse.serializeRegistry, namingStrategy, undefined, undefined, serializerToUse.options.emitErrors);
 }
 
 /**
@@ -196,8 +196,8 @@ export function serializeFunction<T>(serializerToUse: Serializer = serializer, n
 export function cloneClass<T>(target: T, options?: SerializationOptions): T {
     const classType = getClassTypeFromInstance(target);
     const type = typeInfer(classType);
-    const serialize = getSerializeFunction(type, serializer.serializeRegistry);
-    const deserialize = getSerializeFunction(type, serializer.deserializeRegistry);
+    const serialize = getSerializeFunction(type, serializer.serializeRegistry, undefined, undefined, undefined, serializer.options.emitErrors);
+    const deserialize = getSerializeFunction(type, serializer.deserializeRegistry, undefined, undefined, undefined, serializer.options.emitErrors);
     return deserialize(serialize(target, options));
 }
 
@@ -209,7 +209,7 @@ export function cloneClass<T>(target: T, options?: SerializationOptions): T {
  * @throws ValidationError when serialization or validation fails.
  */
 export function validatedDeserialize<T>(data: any, options?: SerializationOptions, serializerToUse: Serializer = serializer, namingStrategy?: NamingStrategy, type?: ReceiveType<T>) {
-    const fn = getSerializeFunction(resolveReceiveType(type), serializerToUse.deserializeRegistry, namingStrategy);
+    const fn = getSerializeFunction(resolveReceiveType(type), serializerToUse.deserializeRegistry, namingStrategy, undefined, undefined, serializerToUse.options.emitErrors);
     const item = fn(data, options) as T;
     assert(item, undefined, type);
     return item;

--- a/packages/type/src/serializer.ts
+++ b/packages/type/src/serializer.ts
@@ -873,13 +873,13 @@ export function createConverterJSForMember(
     // }
 
     //note: this code is only reached when ${accessor} was actually defined checked by the 'in' operator.
-    //null acts on transport layer as telling an explicitly set undefined
-    //this is to support actual undefined as value across a transport layer. Otherwise it
-    //would be impossible to set a already set value to undefined back or override default value (since JSON.stringify() omits that information)
     const explicitUndefinedBlock = setExplicitUndefined ? undefinedSetterCode : '';
     const nullableBlock = nullable ? nullSetterCode : explicitUndefinedBlock;
     if (opts.unpopulatedProps) state.setContext({ unpopulatedSymbol });
 
+    //null acts on transport layer as telling an explicitly set undefined
+    //this is to support actual undefined as value across a transport layer. Otherwise it
+    //would be impossible to set a already set value to undefined back or override default value (since JSON.stringify() omits that information)
     if (explicitUndefinedBlock || nullableBlock) {
         return `
             if (${state.accessor} === undefined) {
@@ -887,15 +887,15 @@ export function createConverterJSForMember(
             } else if (${state.accessor} === null) {
                 ${nullableBlock}
             } else ${opts.unpopulatedProps ? `if (${state.accessor} !== unpopulatedSymbol)` : ''} {
-                ${convert};
-                ${postTransform};
+                ${convert}
+                ${postTransform}
             }
         `;
     } else {
         return `
         if (${state.accessor} !== undefined && ${state.accessor} !== null ${opts.unpopulatedProps ? `&& ${state.accessor} !== unpopulatedSymbol` : ''}) {
-            ${convert};
-            ${postTransform};
+            ${convert}
+            ${postTransform}
         }`;
     }
 }
@@ -1173,8 +1173,7 @@ export function serializeObjectLiteral(type: TypeObjectLiteral | TypeClass, stat
                     ${argumentName} = undefined;
                     if (${inAccessor(propertyState.accessor as ContainerAccessor)} ${allowGroupsCheck}) {
                         ${createConverterJSForMember(property, propertyState, opts)}
-                    } ${elseGroup}
-                `);
+                    } ${elseGroup}`);
                 }
 
                 constructorArguments.push(argumentName);
@@ -1204,11 +1203,9 @@ export function serializeObjectLiteral(type: TypeObjectLiteral | TypeClass, stat
             } else {
                 const allowGroupsCheck = opts.allowGroups ? `&& ${groupFilter(member.type)}` : '';
                 const elseGroup = staticDefault ? ` else {\n${staticDefault}\n}` : '';
-                lines.push(`
-                if (${readName} in ${state.accessor} ${allowGroupsCheck}) {
+                lines.push(`if (${readName} in ${state.accessor} ${allowGroupsCheck}) {
                     ${createConverterJSForMember(member, propertyState, opts)}
-                } ${elseGroup}
-            `);
+                } ${elseGroup}`);
             }
         }
     }

--- a/packages/type/src/serializer.ts
+++ b/packages/type/src/serializer.ts
@@ -877,22 +877,16 @@ export function createConverterJSForMember(
 
     //note: this code is only reached when ${accessor} was actually defined checked by the 'in' operator.
     const unpopulatedIf = opts.unpopulatedProps ? `if (${state.accessor} !== unpopulatedSymbol)` : '';
+    const explicitUndefinedBlock = setExplicitUndefined ? undefinedSetterCode : '';
+    //null acts on transport layer as telling an explicitly set undefined
+    //this is to support actual undefined as value across a transport layer. Otherwise it
+    //would be impossible to set a already set value to undefined back or override default value (since JSON.stringify() omits that information)
+    const nullableBlock = nullable ? nullSetterCode : explicitUndefinedBlock;
     return `
         if (${state.accessor} === undefined) {
-            if (${setExplicitUndefined}) {
-                ${undefinedSetterCode}
-            }
+            ${explicitUndefinedBlock}
         } else if (${state.accessor} === null) {
-            //null acts on transport layer as telling an explicitly set undefined
-            //this is to support actual undefined as value across a transport layer. Otherwise it
-            //would be impossible to set a already set value to undefined back or override default value (since JSON.stringify() omits that information)
-            if (${nullable}) {
-                ${nullSetterCode}
-            } else {
-                if (${setExplicitUndefined}) {
-                    ${undefinedSetterCode}
-                }
-            }
+            ${nullableBlock}
         } else ${unpopulatedIf} {
             ${convert}
             ${postTransform}

--- a/packages/type/tests/serializer.spec.ts
+++ b/packages/type/tests/serializer.spec.ts
@@ -7,7 +7,7 @@
  *
  * You should have received a copy of the MIT License along with this program.
  */
-import { expect, test } from '@jest/globals';
+import { expect, test, describe } from '@jest/globals';
 import { reflect, ReflectionClass, ReflectionFunction, typeOf } from '../src/reflection/reflection.js';
 import {
     assertType,
@@ -43,12 +43,9 @@ import { isReferenceInstance } from '../src/reference.js';
 import { ChangesInterface, DeepPartial } from '../src/changes.js';
 import { inspect } from 'util';
 
-serializerSuit(serializer, 'serializer');
-serializerSuit(quickSerializer, 'Quick');
 
-function serializerSuit(testSerializer: Serializer, name: string) {
-    const sfx = ` ==> ${name}`;
-    test('deserializer' + sfx, () => {
+describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']])('serializer suit', (testSerializer, name) => {
+    test(`deserializer ${name}`, () => {
         class User {
             username!: string;
             created!: Date;
@@ -62,7 +59,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         });
     });
 
-    test('cast interface' + sfx, () => {
+    test(`cast interface ${name}`, () => {
         interface User {
             username: string;
             created: Date;
@@ -75,7 +72,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         });
     });
 
-    test('cast class' + sfx, () => {
+    test(`cast class ${name}`, () => {
         class User {
             created: Date = new Date;
 
@@ -91,7 +88,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         });
     });
 
-    test('groups' + sfx, () => {
+    test(`groups ${name}`, () => {
         class Settings {
             weight: string & Group<'privateSettings'> = '12g';
             color: string = 'red';
@@ -116,7 +113,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(serialize<User>(user, { groupsExclude: ['privateSettings'] })).toEqual({ id: 0, username: 'peter', password: '', settings: { color: 'red' } });
     });
 
-    test('default value' + sfx, () => {
+    test(`default value ${name}`, () => {
         class User {
             logins: number = 0;
         }
@@ -137,7 +134,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         }
     });
 
-    test('optional value' + sfx, () => {
+    test(`optional value ${name}`, () => {
         class User {
             logins?: number;
         }
@@ -157,7 +154,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         }
     });
 
-    test('optional default value' + sfx, () => {
+    test(`optional default value ${name}`, () => {
         class User {
             logins?: number = 2;
         }
@@ -191,7 +188,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         }
     });
 
-    test('optional literal' + sfx, () => {
+    test(`optional literal ${name}`, () => {
         interface LoginInput {
             mechanism?: 'cookie';
         }
@@ -211,7 +208,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         }
     });
 
-    test('cast primitives' + sfx, () => {
+    test(`cast primitives ${name}`, () => {
         expect(cast<string>('123')).toBe('123');
         expect(cast<string>(123)).toBe('123');
         expect(cast<number>(123)).toBe(123);
@@ -221,17 +218,17 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(serialize<Date>(new Date('2021-10-19T00:22:58.257Z'))).toEqual('2021-10-19T00:22:58.257Z');
     });
 
-    test('cast integer' + sfx, () => {
+    test(`cast integer ${name}`, () => {
         expect(cast<integer>(123.456)).toBe(123);
         expect(cast<int8>(1000)).toBe(127);
     });
 
-    test('tuple 2' + sfx, () => {
+    test(`tuple 2 ${name}`, () => {
         const value = cast<[string, number]>([12, '13']);
         expect(value).toEqual(['12', 13]);
     });
 
-    test('tuple rest' + sfx, () => {
+    test(`tuple rest ${name}`, () => {
         {
             const value = cast<[...string[], number]>([12, '13']);
             expect(value).toEqual(['12', 13]);
@@ -254,7 +251,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         }
     });
 
-    test('set' + sfx, () => {
+    test(`set ${name}`, () => {
         {
             const value = cast<Set<string>>(['a', 'a', 'b']);
             expect(value).toEqual(new Set(['a', 'b']));
@@ -269,7 +266,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         }
     });
 
-    test('map' + sfx, () => {
+    test(`map ${name}`, () => {
         {
             const value = cast<Map<string, number>>([['a', 1], ['a', 2], ['b', 3]]);
             expect(value).toEqual(new Map([['a', 2], ['b', 3]]));
@@ -284,7 +281,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         }
     });
 
-    test('number' + sfx, () => {
+    test(`number ${name}`, () => {
         expect(cast<number>(1)).toBe(1);
         expect(cast<number>(-1)).toBe(-1);
         expect(cast<number>(true)).toBe(1);
@@ -293,7 +290,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(cast<number>('-1')).toBe(-1);
     });
 
-    test('union string number' + sfx, () => {
+    test(`union string number ${name}`, () => {
         expect(cast<string | number>('a')).toEqual('a');
         expect(cast<string | number>(2)).toEqual(2);
 
@@ -309,7 +306,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(cast<string | integer>(true)).toEqual('true');
     });
 
-    test('union boolean number' + sfx, () => {
+    test(`union boolean number ${name}`, () => {
         expect(cast<boolean | number>(2)).toEqual(2);
         expect(cast<boolean | number>(1)).toEqual(1);
         expect(cast<boolean | number>(0)).toEqual(0);
@@ -317,7 +314,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(cast<boolean | number>(true)).toEqual(true);
     });
 
-    test('disabled loosely throws for primitives' + sfx, () => {
+    test(`disabled loosely throws for primitives ${name}`, () => {
         expect(cast<string>(23)).toEqual('23');
         expect(cast<string>(23)).toEqual('23');
         expect(() => cast<string>(23, { loosely: false })).toThrow('Validation error');
@@ -331,7 +328,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(() => cast<boolean>(1, { loosely: false })).toThrow('Validation error');
     });
 
-    test('union loose string number' + sfx, () => {
+    test(`union loose string number ${name}`, () => {
         expect(cast<string | number>('a')).toEqual('a');
         expect(cast<string | number>(2)).toEqual(2);
         expect(cast<string | number>(-2)).toEqual(-2);
@@ -346,7 +343,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(cast<string | integer>(true)).toEqual('true');
     });
 
-    test('union loose string boolean' + sfx, () => {
+    test(`union loose string boolean ${name}`, () => {
         expect(cast<string | boolean>('a')).toEqual('a');
         expect(cast<string | boolean>(1)).toEqual(true);
         expect(cast<string | boolean>(0)).toEqual(false);
@@ -356,7 +353,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(cast<string | boolean>('true2')).toEqual('true2');
     });
 
-    test('union loose number boolean' + sfx, () => {
+    test(`union loose number boolean ${name}`, () => {
         expect(() => cast<number | boolean>('a')).toThrow('Validation error for type');
         expect(deserialize<number | boolean>('a')).toEqual(undefined);
         expect(cast<string | boolean>(1)).toEqual(true);
@@ -375,7 +372,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(deserialize<number | boolean>('true2')).toEqual(undefined);
     });
 
-    test('union string date' + sfx, () => {
+    test(`union string date ${name}`, () => {
         expect(cast<string | Date>('a')).toEqual('a');
         expect(cast<string | Date>('2021-11-24T16:21:13.425Z')).toBeInstanceOf(Date);
         expect(cast<string | Date>(1637781902866)).toBeInstanceOf(Date);
@@ -383,7 +380,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(cast<(string | Date)[]>(['2021-11-24T16:21:13.425Z'])[0]).toBeInstanceOf(Date);
     });
 
-    test('union string bigint' + sfx, () => {
+    test(`union string bigint ${name}`, () => {
         expect(cast<string | bigint>('a')).toEqual('a');
         expect(cast<string | bigint>(2n)).toEqual(2n);
         expect(cast<string | bigint>(2)).toEqual(2n);
@@ -392,7 +389,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(cast<string | bigint>('2a')).toEqual('2a');
     });
 
-    test('union loose string bigint' + sfx, () => {
+    test(`union loose string bigint ${name}`, () => {
         expect(cast<string | bigint>('a')).toEqual('a');
         expect(cast<string | bigint>(2n)).toEqual(2n);
         expect(cast<string | bigint>(2)).toEqual(2n);
@@ -400,7 +397,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(cast<string | bigint>('2a')).toEqual('2a');
     });
 
-    test('BinaryBigInt' + sfx, () => {
+    test(`BinaryBigInt ${name}`, () => {
         expect(serialize<bigint>(24n)).toBe('24');
         expect(serialize<BinaryBigInt>(24n)).toBe('24');
         expect(serialize<BinaryBigInt>(-4n)).toBe('0');
@@ -418,7 +415,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(deserialize<SignedBinaryBigInt>('-4')).toBe(-4n);
     });
 
-    test('literal' + sfx, () => {
+    test(`literal ${name}`, () => {
         expect(cast<'a'>('a')).toEqual('a');
         expect(serialize<'a'>('a')).toEqual('a');
         expect(cast<'a'>('b')).toEqual('a');
@@ -432,14 +429,14 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(serialize<1n>(1n)).toEqual(1n);
     });
 
-    test('cast runs validators' + sfx, () => {
+    test(`cast runs validators ${name}`, () => {
         type Username = string & MinLength<3> & MaxLength<23> & Alphanumeric;
         expect(() => cast<Username>('ab')).toThrow('Validation error for type');
         expect(() => cast<Username>('$ab')).toThrow('Validation error for type');
         expect(cast<Username>('Peter')).toBe('Peter');
     });
 
-    test('union literal' + sfx, () => {
+    test(`union literal ${name}`, () => {
         expect(cast<'a' | number>('a')).toEqual('a');
         expect(cast<'a' | number>(23)).toEqual(23);
         expect(serialize<'a' | number>('a')).toEqual('a');
@@ -457,7 +454,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(cast<false | boolean>(false)).toEqual(false);
     });
 
-    test('union primitive and class' + sfx, () => {
+    test(`union primitive and class ${name}`, () => {
         class User {
             id!: number;
         }
@@ -473,7 +470,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(serialize<number | User>({ id: 23 })).toBeInstanceOf(Object);
     });
 
-    test('union multiple classes' + sfx, () => {
+    test(`union multiple classes ${name}`, () => {
         class User {
             id!: number;
             username!: string;
@@ -504,14 +501,14 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(serialize<number | User>({ id: 23, username: 'peter' })).toEqual({ id: 23, username: 'peter' });
     });
 
-    test('brands' + sfx, () => {
+    test(`brands ${name}`, () => {
         expect(cast<number & PrimaryKey>(2)).toEqual(2);
         expect(cast<number & PrimaryKey>('2')).toEqual(2);
 
         expect(serialize<number & PrimaryKey>(2)).toEqual(2);
     });
 
-    test('throw' + sfx, () => {
+    test(`throw ${name}`, () => {
         expect(() => cast<number>('123abc')).toThrow('Cannot convert 123abc to number');
         expect(() => cast<{ a: string }>(false)).toThrow('Cannot convert false to {a: string}');
         expect(() => cast<{ a: number }>({ a: 'abc' })).toThrow('Cannot convert abc to number');
@@ -519,7 +516,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(() => cast<{ a: { b: number } }>({ a: { b: 'abc' } })).toThrow('Cannot convert abc to number');
     });
 
-    test('index signature ' + sfx, () => {
+    test(`index signature  ${name}`, () => {
         interface BagOfNumbers {
             [name: string]: number;
         }
@@ -545,7 +542,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(serialize<BagOfStrings>({ a: '1' })).toEqual({ a: '1' });
     });
 
-    test('exclude' + sfx, () => {
+    test(`exclude ${name}`, () => {
         class User {
             username!: string;
 
@@ -559,26 +556,26 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(serialize<User>({ username: 'peter', password: 'nope' })).toEqual({ username: 'peter', password: undefined });
     });
 
-    test('regexp direct' + sfx, () => {
+    test(`regexp direct ${name}`, () => {
         expect(cast<RegExp>(/abc/).toString()).toEqual('/abc/');
         expect(cast<RegExp>('/abc/').toString()).toEqual('/abc/');
         expect(cast<RegExp>('abc').toString()).toEqual('/abc/');
         expect(serialize<RegExp>(/abc/).toString()).toEqual('/abc/');
     });
 
-    test('regexp union' + sfx, () => {
+    test(`regexp union ${name}`, () => {
         expect(cast<string | { $regex: RegExp }>({ $regex: /abc/ })).toEqual({ $regex: /abc/ });
         expect(cast<Record<string, string | { $regex: RegExp }>>({ a: { $regex: /abc/ } })).toEqual({ a: { $regex: /abc/ } });
     });
 
-    test('index signature with template literal' + sfx, () => {
+    test(`index signature with template literal ${name}`, () => {
         type a1 = { [index: `a${number}`]: number };
         expect(cast<a1>({ a123: '123' })).toEqual({ a123: 123 });
         expect(cast<a1>({ a123: '123', b: 123 })).toEqual({ a123: 123, b: undefined });
         expect(cast<a1>({ a123: '123', a124: 123 })).toEqual({ a123: 123, a124: 123 });
     });
 
-    test('class circular reference' + sfx, () => {
+    test(`class circular reference ${name}`, () => {
         class User {
             constructor(public username: string) {
             }
@@ -592,7 +589,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(res.manager).toBeInstanceOf(User);
     });
 
-    test('class with reference' + sfx, () => {
+    test(`class with reference ${name}`, () => {
         class User {
             id: number & PrimaryKey = 0;
 
@@ -632,7 +629,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         }
     });
 
-    test('class with back reference' + sfx, () => {
+    test(`class with back reference ${name}`, () => {
         class User {
             id: number & PrimaryKey = 0;
 
@@ -649,7 +646,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(res.leads[0]).toBeInstanceOf(User);
     });
 
-    test('embedded single' + sfx, () => {
+    test(`embedded single ${name}`, () => {
         class Price {
             constructor(public amount: integer) {
             }
@@ -699,7 +696,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
 
     });
 
-    test('embedded single optional' + sfx, () => {
+    test(`embedded single optional ${name}`, () => {
         class Price {
             constructor(public amount: integer) {
             }
@@ -745,7 +742,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(deserialize<Product4>({ price: null })).toEqual({ price: null });
     });
 
-    test('embedded multi parameter' + sfx, () => {
+    test(`embedded multi parameter ${name}`, () => {
         class Price {
             constructor(public amount: integer, public currency: string = 'EUR') {
             }
@@ -797,7 +794,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(deserialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ v: '34' })).toEqual({ v: '34' });
     });
 
-    test('class inheritance' + sfx, () => {
+    test(`class inheritance ${name}`, () => {
         abstract class Person {
             id: number & PrimaryKey & AutoIncrement = 0;
             firstName?: string;
@@ -822,7 +819,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(scopeSerializer({ type: 'employee', firstName: 'Peter', email: 'test@example.com' })).toEqual({ type: 'employee', firstName: 'Peter', email: 'test@example.com' });
     });
 
-    test('class with union literal' + sfx, () => {
+    test(`class with union literal ${name}`, () => {
         class ConnectionOptions {
             readConcernLevel: 'local' | 'majority' | 'linearizable' | 'available' = 'majority';
         }
@@ -832,12 +829,12 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(cast<ConnectionOptions>({ readConcernLevel: 'unknown' })).toEqual({ readConcernLevel: 'majority' });
     });
 
-    test('named tuple in error message' + sfx, () => {
+    test(`named tuple in error message ${name}`, () => {
         expect(cast<[age: number]>([23])).toEqual([23]);
         expect(() => cast<{ v: [age: number] }>({ v: ['123abc'] })).toThrow('v.age(type): Cannot convert 123abc to number');
     });
 
-    test('intersected mapped type key' + sfx, () => {
+    test(`intersected mapped type key ${name}`, () => {
         type SORT_ORDER = 'asc' | 'desc' | any;
         type Sort<T, ORDER extends SORT_ORDER = SORT_ORDER> = { [P in keyof T & string]?: ORDER };
 
@@ -856,7 +853,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(cast<sortAny>({ id: 'desc', username: 'asc' })).toEqual({ id: 'desc', username: 'asc' });
     });
 
-    test('wild property names' + sfx, () => {
+    test(`wild property names ${name}`, () => {
         interface A {
             ['asd-344']: string;
             ['#$%^^x']: number;
@@ -865,7 +862,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(deserialize<A>({ 'asd-344': 'abc', '#$%^^x': 3 })).toEqual({ 'asd-344': 'abc', '#$%^^x': 3 });
     });
 
-    test('embedded with lots of properties' + sfx, () => {
+    test(`embedded with lots of properties ${name}`, () => {
         interface LotsOfIt {
             a?: string;
             lot?: string;
@@ -890,7 +887,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(back2.options).toEqual({ a: 'abc', lot: 'string' });
     });
 
-    test('embedded in super class' + sfx, () => {
+    test(`embedded in super class ${name}`, () => {
         class Thread {
             public parentThreadId?: string;
             public senderOrder?: number;
@@ -920,7 +917,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(plain).toEqual({ type: Message.type, parentThreadId: null, senderOrder: null, '~thread': 'foo' });
     });
 
-    test('disabled constructor' + sfx, () => {
+    test(`disabled constructor ${name}`, () => {
         let called = false;
 
         @entity.disableConstructor()
@@ -941,7 +938,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(user).toEqual({ id: 0, title: 'id:' + 0, type: 'nix' });
     });
 
-    test('readonly constructor properties' + sfx, () => {
+    test(`readonly constructor properties ${name}`, () => {
         class Pilot {
             constructor(readonly name: string, readonly age: number) {
             }
@@ -951,7 +948,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(cast<Pilot>({ name: 'Peter', age: '32' })).toEqual({ name: 'Peter', age: 32 });
     });
 
-    test('naming strategy prefix' + sfx, () => {
+    test(`naming strategy prefix ${name}`, () => {
         class MyNamingStrategy extends NamingStrategy {
             constructor() {
                 super('my');
@@ -983,7 +980,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         }
     });
 
-    test('naming strategy camel case' + sfx, () => {
+    test(`naming strategy camel case ${name}`, () => {
         const camelCaseToSnakeCase = (str: string) =>
             str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
 
@@ -1022,7 +1019,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         }
     });
 
-    test('enum union' + sfx, () => {
+    test(`enum union ${name}`, () => {
         enum StatEnginePowerUnit {
             Hp = 'hp',
         }
@@ -1042,7 +1039,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(deserialize<StatMeasurementUnit>(StatEnginePowerUnit.Hp)).toBe(StatEnginePowerUnit.Hp);
     });
 
-    test('union literals in union' + sfx, () => {
+    test(`union literals in union ${name}`, () => {
         type StatWeightUnit = 'lbs' | 'kg';
         type StatEnginePowerUnit = 'hp';
 
@@ -1056,7 +1053,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(deserialize<StatMeasurementUnit>('hp')).toBe('hp');
     });
 
-    test('union literals in union imported' + sfx, () => {
+    test(`union literals in union imported ${name}`, () => {
         type StatMeasurementUnit = StatEnginePowerUnit | StatWeightUnit;
         const type = typeOf<StatMeasurementUnit>();
         assertType(type, ReflectionKind.union);
@@ -1067,7 +1064,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(deserialize<StatMeasurementUnit>('hp')).toBe('hp');
     });
 
-    test('function rest parameters' + sfx, () => {
+    test(`function rest parameters ${name}`, () => {
         type t = (start: number, ...rest: string[]) => void;
         const fn = typeOf<t>();
         assertType(fn, ReflectionKind.function);
@@ -1081,7 +1078,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         }
     });
 
-    test('discriminated union with string date in type guard' + sfx, () => {
+    test(`discriminated union with string date in type guard ${name}`, () => {
         expect(is<number | string>(12)).toBe(true);
         expect(is<number | string>('abc')).toBe(true);
         expect(is<number | string>(false)).toBe(false);
@@ -1120,13 +1117,13 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         }
     });
 
-    test('date format' + sfx, () => {
+    test(`date format ${name}`, () => {
         const date = cast<number | Date>('2020-07-02T12:00:00Z');
         expect(date).toEqual(new Date('2020-07-02T12:00:00Z'));
     });
 
 
-    test('patch' + sfx, () => {
+    test(`patch ${name}`, () => {
         class Address {
             street!: string & MinLength<3>;
             streetNo!: string;
@@ -1155,7 +1152,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         }
     });
 
-    test('extend with custom type' + sfx, () => {
+    test(`extend with custom type ${name}`, () => {
         type StringifyTransport = { __meta?: never & ['stringifyTransport'] };
 
         function isStringifyTransportType(type: Type): boolean {
@@ -1186,7 +1183,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(d.obj).toEqual({ test: 'abc' });
     });
 
-    test('issue-415: serialize literal types in union' + sfx, () => {
+    test(`issue-415: serialize literal types in union ${name}`, () => {
         enum MyEnum {
             VALUE_0 = 0,
             VALUE_180 = 180
@@ -1202,4 +1199,4 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(deserialize<Data>({ rotate: '180' }, { loosely: true }).rotate).toBe(180);
         expect(deserialize<Data>({ rotate: 123456 }, { loosely: true }).rotate).toBe(0);
     });
-}
+});

--- a/packages/type/tests/serializer.spec.ts
+++ b/packages/type/tests/serializer.spec.ts
@@ -31,7 +31,7 @@ import {
     TypePropertySignature
 } from '../src/reflection/type.js';
 import { createSerializeFunction, getSerializeFunction, NamingStrategy, serializer, quickSerializer, underscoreNamingStrategy } from '../src/serializer.js';
-import type { Serializer} from '../src/serializer.js';
+import type { Serializer } from '../src/serializer.js';
 import { cast, deserialize, patch, serialize } from '../src/serializer-facade.js';
 import { getClassName } from '@deepkit/core';
 import { entity, t } from '../src/decorator.js';
@@ -44,8 +44,8 @@ import { ChangesInterface, DeepPartial } from '../src/changes.js';
 import { inspect } from 'util';
 
 
-describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']])('serializer suit', (testSerializer, name) => {
-    test(`deserializer ${name}`, () => {
+describe.each([serializer, quickSerializer])('', (testSerializer, name) => {
+    test('deserializer', () => {
         class User {
             username!: string;
             created!: Date;
@@ -59,7 +59,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         });
     });
 
-    test(`cast interface ${name}`, () => {
+    test('cast interface', () => {
         interface User {
             username: string;
             created: Date;
@@ -72,7 +72,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         });
     });
 
-    test(`cast class ${name}`, () => {
+    test('cast class', () => {
         class User {
             created: Date = new Date;
 
@@ -88,7 +88,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         });
     });
 
-    test(`groups ${name}`, () => {
+    test('groups', () => {
         class Settings {
             weight: string & Group<'privateSettings'> = '12g';
             color: string = 'red';
@@ -113,7 +113,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(serialize<User>(user, { groupsExclude: ['privateSettings'] })).toEqual({ id: 0, username: 'peter', password: '', settings: { color: 'red' } });
     });
 
-    test(`default value ${name}`, () => {
+    test('default value', () => {
         class User {
             logins: number = 0;
         }
@@ -134,7 +134,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         }
     });
 
-    test(`optional value ${name}`, () => {
+    test('optional value', () => {
         class User {
             logins?: number;
         }
@@ -154,7 +154,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         }
     });
 
-    test(`optional default value ${name}`, () => {
+    test('optional default value', () => {
         class User {
             logins?: number = 2;
         }
@@ -188,7 +188,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         }
     });
 
-    test(`optional literal ${name}`, () => {
+    test('optional literal', () => {
         interface LoginInput {
             mechanism?: 'cookie';
         }
@@ -208,7 +208,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         }
     });
 
-    test(`cast primitives ${name}`, () => {
+    test('cast primitives', () => {
         expect(cast<string>('123')).toBe('123');
         expect(cast<string>(123)).toBe('123');
         expect(cast<number>(123)).toBe(123);
@@ -218,17 +218,17 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(serialize<Date>(new Date('2021-10-19T00:22:58.257Z'))).toEqual('2021-10-19T00:22:58.257Z');
     });
 
-    test(`cast integer ${name}`, () => {
+    test('cast integer', () => {
         expect(cast<integer>(123.456)).toBe(123);
         expect(cast<int8>(1000)).toBe(127);
     });
 
-    test(`tuple 2 ${name}`, () => {
+    test('tuple 2', () => {
         const value = cast<[string, number]>([12, '13']);
         expect(value).toEqual(['12', 13]);
     });
 
-    test(`tuple rest ${name}`, () => {
+    test('tuple rest', () => {
         {
             const value = cast<[...string[], number]>([12, '13']);
             expect(value).toEqual(['12', 13]);
@@ -251,7 +251,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         }
     });
 
-    test(`set ${name}`, () => {
+    test('set', () => {
         {
             const value = cast<Set<string>>(['a', 'a', 'b']);
             expect(value).toEqual(new Set(['a', 'b']));
@@ -266,7 +266,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         }
     });
 
-    test(`map ${name}`, () => {
+    test('map', () => {
         {
             const value = cast<Map<string, number>>([['a', 1], ['a', 2], ['b', 3]]);
             expect(value).toEqual(new Map([['a', 2], ['b', 3]]));
@@ -281,7 +281,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         }
     });
 
-    test(`number ${name}`, () => {
+    test('number', () => {
         expect(cast<number>(1)).toBe(1);
         expect(cast<number>(-1)).toBe(-1);
         expect(cast<number>(true)).toBe(1);
@@ -290,7 +290,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(cast<number>('-1')).toBe(-1);
     });
 
-    test(`union string number ${name}`, () => {
+    test('union string number', () => {
         expect(cast<string | number>('a')).toEqual('a');
         expect(cast<string | number>(2)).toEqual(2);
 
@@ -306,7 +306,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(cast<string | integer>(true)).toEqual('true');
     });
 
-    test(`union boolean number ${name}`, () => {
+    test('union boolean number', () => {
         expect(cast<boolean | number>(2)).toEqual(2);
         expect(cast<boolean | number>(1)).toEqual(1);
         expect(cast<boolean | number>(0)).toEqual(0);
@@ -314,7 +314,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(cast<boolean | number>(true)).toEqual(true);
     });
 
-    test(`disabled loosely throws for primitives ${name}`, () => {
+    test('disabled loosely throws for primitives', () => {
         expect(cast<string>(23)).toEqual('23');
         expect(cast<string>(23)).toEqual('23');
         expect(() => cast<string>(23, { loosely: false })).toThrow('Validation error');
@@ -328,7 +328,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(() => cast<boolean>(1, { loosely: false })).toThrow('Validation error');
     });
 
-    test(`union loose string number ${name}`, () => {
+    test('union loose string number', () => {
         expect(cast<string | number>('a')).toEqual('a');
         expect(cast<string | number>(2)).toEqual(2);
         expect(cast<string | number>(-2)).toEqual(-2);
@@ -343,7 +343,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(cast<string | integer>(true)).toEqual('true');
     });
 
-    test(`union loose string boolean ${name}`, () => {
+    test('union loose string boolean', () => {
         expect(cast<string | boolean>('a')).toEqual('a');
         expect(cast<string | boolean>(1)).toEqual(true);
         expect(cast<string | boolean>(0)).toEqual(false);
@@ -353,7 +353,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(cast<string | boolean>('true2')).toEqual('true2');
     });
 
-    test(`union loose number boolean ${name}`, () => {
+    test('union loose number boolean', () => {
         expect(() => cast<number | boolean>('a')).toThrow('Validation error for type');
         expect(deserialize<number | boolean>('a')).toEqual(undefined);
         expect(cast<string | boolean>(1)).toEqual(true);
@@ -372,7 +372,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(deserialize<number | boolean>('true2')).toEqual(undefined);
     });
 
-    test(`union string date ${name}`, () => {
+    test('union string date', () => {
         expect(cast<string | Date>('a')).toEqual('a');
         expect(cast<string | Date>('2021-11-24T16:21:13.425Z')).toBeInstanceOf(Date);
         expect(cast<string | Date>(1637781902866)).toBeInstanceOf(Date);
@@ -380,7 +380,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(cast<(string | Date)[]>(['2021-11-24T16:21:13.425Z'])[0]).toBeInstanceOf(Date);
     });
 
-    test(`union string bigint ${name}`, () => {
+    test('union string bigint', () => {
         expect(cast<string | bigint>('a')).toEqual('a');
         expect(cast<string | bigint>(2n)).toEqual(2n);
         expect(cast<string | bigint>(2)).toEqual(2n);
@@ -389,7 +389,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(cast<string | bigint>('2a')).toEqual('2a');
     });
 
-    test(`union loose string bigint ${name}`, () => {
+    test('union loose string bigint', () => {
         expect(cast<string | bigint>('a')).toEqual('a');
         expect(cast<string | bigint>(2n)).toEqual(2n);
         expect(cast<string | bigint>(2)).toEqual(2n);
@@ -397,7 +397,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(cast<string | bigint>('2a')).toEqual('2a');
     });
 
-    test(`BinaryBigInt ${name}`, () => {
+    test('BinaryBigInt', () => {
         expect(serialize<bigint>(24n)).toBe('24');
         expect(serialize<BinaryBigInt>(24n)).toBe('24');
         expect(serialize<BinaryBigInt>(-4n)).toBe('0');
@@ -415,7 +415,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(deserialize<SignedBinaryBigInt>('-4')).toBe(-4n);
     });
 
-    test(`literal ${name}`, () => {
+    test('literal', () => {
         expect(cast<'a'>('a')).toEqual('a');
         expect(serialize<'a'>('a')).toEqual('a');
         expect(cast<'a'>('b')).toEqual('a');
@@ -429,14 +429,14 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(serialize<1n>(1n)).toEqual(1n);
     });
 
-    test(`cast runs validators ${name}`, () => {
+    test('cast runs validators', () => {
         type Username = string & MinLength<3> & MaxLength<23> & Alphanumeric;
         expect(() => cast<Username>('ab')).toThrow('Validation error for type');
         expect(() => cast<Username>('$ab')).toThrow('Validation error for type');
         expect(cast<Username>('Peter')).toBe('Peter');
     });
 
-    test(`union literal ${name}`, () => {
+    test('union literal', () => {
         expect(cast<'a' | number>('a')).toEqual('a');
         expect(cast<'a' | number>(23)).toEqual(23);
         expect(serialize<'a' | number>('a')).toEqual('a');
@@ -454,7 +454,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(cast<false | boolean>(false)).toEqual(false);
     });
 
-    test(`union primitive and class ${name}`, () => {
+    test('union primitive and class', () => {
         class User {
             id!: number;
         }
@@ -470,7 +470,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(serialize<number | User>({ id: 23 })).toBeInstanceOf(Object);
     });
 
-    test(`union multiple classes ${name}`, () => {
+    test('union multiple classes', () => {
         class User {
             id!: number;
             username!: string;
@@ -501,14 +501,14 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(serialize<number | User>({ id: 23, username: 'peter' })).toEqual({ id: 23, username: 'peter' });
     });
 
-    test(`brands ${name}`, () => {
+    test('brands', () => {
         expect(cast<number & PrimaryKey>(2)).toEqual(2);
         expect(cast<number & PrimaryKey>('2')).toEqual(2);
 
         expect(serialize<number & PrimaryKey>(2)).toEqual(2);
     });
 
-    test(`throw ${name}`, () => {
+    test('throw', () => {
         expect(() => cast<number>('123abc')).toThrow('Cannot convert 123abc to number');
         expect(() => cast<{ a: string }>(false)).toThrow('Cannot convert false to {a: string}');
         expect(() => cast<{ a: number }>({ a: 'abc' })).toThrow('Cannot convert abc to number');
@@ -516,7 +516,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(() => cast<{ a: { b: number } }>({ a: { b: 'abc' } })).toThrow('Cannot convert abc to number');
     });
 
-    test(`index signature  ${name}`, () => {
+    test('index signature ', () => {
         interface BagOfNumbers {
             [name: string]: number;
         }
@@ -542,7 +542,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(serialize<BagOfStrings>({ a: '1' })).toEqual({ a: '1' });
     });
 
-    test(`exclude ${name}`, () => {
+    test('exclude', () => {
         class User {
             username!: string;
 
@@ -556,26 +556,26 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(serialize<User>({ username: 'peter', password: 'nope' })).toEqual({ username: 'peter', password: undefined });
     });
 
-    test(`regexp direct ${name}`, () => {
+    test('regexp direct', () => {
         expect(cast<RegExp>(/abc/).toString()).toEqual('/abc/');
         expect(cast<RegExp>('/abc/').toString()).toEqual('/abc/');
         expect(cast<RegExp>('abc').toString()).toEqual('/abc/');
         expect(serialize<RegExp>(/abc/).toString()).toEqual('/abc/');
     });
 
-    test(`regexp union ${name}`, () => {
+    test('regexp union', () => {
         expect(cast<string | { $regex: RegExp }>({ $regex: /abc/ })).toEqual({ $regex: /abc/ });
         expect(cast<Record<string, string | { $regex: RegExp }>>({ a: { $regex: /abc/ } })).toEqual({ a: { $regex: /abc/ } });
     });
 
-    test(`index signature with template literal ${name}`, () => {
+    test('index signature with template literal', () => {
         type a1 = { [index: `a${number}`]: number };
         expect(cast<a1>({ a123: '123' })).toEqual({ a123: 123 });
         expect(cast<a1>({ a123: '123', b: 123 })).toEqual({ a123: 123, b: undefined });
         expect(cast<a1>({ a123: '123', a124: 123 })).toEqual({ a123: 123, a124: 123 });
     });
 
-    test(`class circular reference ${name}`, () => {
+    test('class circular reference', () => {
         class User {
             constructor(public username: string) {
             }
@@ -589,7 +589,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(res.manager).toBeInstanceOf(User);
     });
 
-    test(`class with reference ${name}`, () => {
+    test('class with reference', () => {
         class User {
             id: number & PrimaryKey = 0;
 
@@ -629,7 +629,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         }
     });
 
-    test(`class with back reference ${name}`, () => {
+    test('class with back reference', () => {
         class User {
             id: number & PrimaryKey = 0;
 
@@ -646,7 +646,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(res.leads[0]).toBeInstanceOf(User);
     });
 
-    test(`embedded single ${name}`, () => {
+    test('embedded single', () => {
         class Price {
             constructor(public amount: integer) {
             }
@@ -696,7 +696,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
 
     });
 
-    test(`embedded single optional ${name}`, () => {
+    test('embedded single optional', () => {
         class Price {
             constructor(public amount: integer) {
             }
@@ -742,7 +742,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(deserialize<Product4>({ price: null })).toEqual({ price: null });
     });
 
-    test(`embedded multi parameter ${name}`, () => {
+    test('embedded multi parameter', () => {
         class Price {
             constructor(public amount: integer, public currency: string = 'EUR') {
             }
@@ -794,7 +794,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(deserialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ v: '34' })).toEqual({ v: '34' });
     });
 
-    test(`class inheritance ${name}`, () => {
+    test('class inheritance', () => {
         abstract class Person {
             id: number & PrimaryKey & AutoIncrement = 0;
             firstName?: string;
@@ -819,7 +819,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(scopeSerializer({ type: 'employee', firstName: 'Peter', email: 'test@example.com' })).toEqual({ type: 'employee', firstName: 'Peter', email: 'test@example.com' });
     });
 
-    test(`class with union literal ${name}`, () => {
+    test('class with union literal', () => {
         class ConnectionOptions {
             readConcernLevel: 'local' | 'majority' | 'linearizable' | 'available' = 'majority';
         }
@@ -829,12 +829,12 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(cast<ConnectionOptions>({ readConcernLevel: 'unknown' })).toEqual({ readConcernLevel: 'majority' });
     });
 
-    test(`named tuple in error message ${name}`, () => {
+    test('named tuple in error message', () => {
         expect(cast<[age: number]>([23])).toEqual([23]);
         expect(() => cast<{ v: [age: number] }>({ v: ['123abc'] })).toThrow('v.age(type): Cannot convert 123abc to number');
     });
 
-    test(`intersected mapped type key ${name}`, () => {
+    test('intersected mapped type key', () => {
         type SORT_ORDER = 'asc' | 'desc' | any;
         type Sort<T, ORDER extends SORT_ORDER = SORT_ORDER> = { [P in keyof T & string]?: ORDER };
 
@@ -853,7 +853,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(cast<sortAny>({ id: 'desc', username: 'asc' })).toEqual({ id: 'desc', username: 'asc' });
     });
 
-    test(`wild property names ${name}`, () => {
+    test('wild property names', () => {
         interface A {
             ['asd-344']: string;
             ['#$%^^x']: number;
@@ -862,7 +862,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(deserialize<A>({ 'asd-344': 'abc', '#$%^^x': 3 })).toEqual({ 'asd-344': 'abc', '#$%^^x': 3 });
     });
 
-    test(`embedded with lots of properties ${name}`, () => {
+    test('embedded with lots of properties', () => {
         interface LotsOfIt {
             a?: string;
             lot?: string;
@@ -887,7 +887,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(back2.options).toEqual({ a: 'abc', lot: 'string' });
     });
 
-    test(`embedded in super class ${name}`, () => {
+    test('embedded in super class', () => {
         class Thread {
             public parentThreadId?: string;
             public senderOrder?: number;
@@ -917,7 +917,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(plain).toEqual({ type: Message.type, parentThreadId: null, senderOrder: null, '~thread': 'foo' });
     });
 
-    test(`disabled constructor ${name}`, () => {
+    test('disabled constructor', () => {
         let called = false;
 
         @entity.disableConstructor()
@@ -938,7 +938,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(user).toEqual({ id: 0, title: 'id:' + 0, type: 'nix' });
     });
 
-    test(`readonly constructor properties ${name}`, () => {
+    test('readonly constructor properties', () => {
         class Pilot {
             constructor(readonly name: string, readonly age: number) {
             }
@@ -948,7 +948,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(cast<Pilot>({ name: 'Peter', age: '32' })).toEqual({ name: 'Peter', age: 32 });
     });
 
-    test(`naming strategy prefix ${name}`, () => {
+    test('naming strategy prefix', () => {
         class MyNamingStrategy extends NamingStrategy {
             constructor() {
                 super('my');
@@ -980,7 +980,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         }
     });
 
-    test(`naming strategy camel case ${name}`, () => {
+    test('naming strategy camel case', () => {
         const camelCaseToSnakeCase = (str: string) =>
             str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
 
@@ -1019,7 +1019,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         }
     });
 
-    test(`enum union ${name}`, () => {
+    test('enum union', () => {
         enum StatEnginePowerUnit {
             Hp = 'hp',
         }
@@ -1039,7 +1039,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(deserialize<StatMeasurementUnit>(StatEnginePowerUnit.Hp)).toBe(StatEnginePowerUnit.Hp);
     });
 
-    test(`union literals in union ${name}`, () => {
+    test('union literals in union', () => {
         type StatWeightUnit = 'lbs' | 'kg';
         type StatEnginePowerUnit = 'hp';
 
@@ -1053,7 +1053,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(deserialize<StatMeasurementUnit>('hp')).toBe('hp');
     });
 
-    test(`union literals in union imported ${name}`, () => {
+    test('union literals in union imported', () => {
         type StatMeasurementUnit = StatEnginePowerUnit | StatWeightUnit;
         const type = typeOf<StatMeasurementUnit>();
         assertType(type, ReflectionKind.union);
@@ -1064,7 +1064,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(deserialize<StatMeasurementUnit>('hp')).toBe('hp');
     });
 
-    test(`function rest parameters ${name}`, () => {
+    test('function rest parameters', () => {
         type t = (start: number, ...rest: string[]) => void;
         const fn = typeOf<t>();
         assertType(fn, ReflectionKind.function);
@@ -1078,7 +1078,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         }
     });
 
-    test(`discriminated union with string date in type guard ${name}`, () => {
+    test('discriminated union with string date in type guard', () => {
         expect(is<number | string>(12)).toBe(true);
         expect(is<number | string>('abc')).toBe(true);
         expect(is<number | string>(false)).toBe(false);
@@ -1117,13 +1117,13 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         }
     });
 
-    test(`date format ${name}`, () => {
+    test('date format', () => {
         const date = cast<number | Date>('2020-07-02T12:00:00Z');
         expect(date).toEqual(new Date('2020-07-02T12:00:00Z'));
     });
 
 
-    test(`patch ${name}`, () => {
+    test('patch', () => {
         class Address {
             street!: string & MinLength<3>;
             streetNo!: string;
@@ -1152,7 +1152,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         }
     });
 
-    test(`extend with custom type ${name}`, () => {
+    test('extend with custom type', () => {
         type StringifyTransport = { __meta?: never & ['stringifyTransport'] };
 
         function isStringifyTransportType(type: Type): boolean {
@@ -1183,7 +1183,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(d.obj).toEqual({ test: 'abc' });
     });
 
-    test(`issue-415: serialize literal types in union ${name}`, () => {
+    test('issue-415: serialize literal types in union', () => {
         enum MyEnum {
             VALUE_0 = 0,
             VALUE_180 = 180

--- a/packages/type/tests/serializer.spec.ts
+++ b/packages/type/tests/serializer.spec.ts
@@ -30,7 +30,8 @@ import {
     TypeProperty,
     TypePropertySignature
 } from '../src/reflection/type.js';
-import { createSerializeFunction, getSerializeFunction, NamingStrategy, serializer, underscoreNamingStrategy } from '../src/serializer.js';
+import { createSerializeFunction, getSerializeFunction, NamingStrategy, serializer, quickSerializer, underscoreNamingStrategy } from '../src/serializer.js';
+import type { Serializer} from '../src/serializer.js';
 import { cast, deserialize, patch, serialize } from '../src/serializer-facade.js';
 import { getClassName } from '@deepkit/core';
 import { entity, t } from '../src/decorator.js';
@@ -42,1157 +43,1163 @@ import { isReferenceInstance } from '../src/reference.js';
 import { ChangesInterface, DeepPartial } from '../src/changes.js';
 import { inspect } from 'util';
 
-test('deserializer', () => {
-    class User {
-        username!: string;
-        created!: Date;
-    }
+serializerSuit(serializer, 'serializer');
+serializerSuit(quickSerializer, 'Quick');
 
-    const fn = createSerializeFunction(reflect(User), serializer.deserializeRegistry);
-    const o = fn({ username: 'Peter', created: '2021-10-19T00:22:58.257Z' });
-    expect(o).toEqual({
-        username: 'Peter',
-        created: new Date('2021-10-19T00:22:58.257Z')
-    });
-});
-
-test('cast interface', () => {
-    interface User {
-        username: string;
-        created: Date;
-    }
-
-    const user = cast<User>({ username: 'Peter', created: '2021-10-19T00:22:58.257Z' });
-    expect(user).toEqual({
-        username: 'Peter',
-        created: new Date('2021-10-19T00:22:58.257Z')
-    });
-});
-
-test('cast class', () => {
-    class User {
-        created: Date = new Date;
-
-        constructor(public username: string) {
-        }
-    }
-
-    const user = cast<User>({ username: 'Peter', created: '2021-10-19T00:22:58.257Z' });
-    expect(user).toBeInstanceOf(User);
-    expect(user).toEqual({
-        username: 'Peter',
-        created: new Date('2021-10-19T00:22:58.257Z')
-    });
-});
-
-test('groups', () => {
-    class Settings {
-        weight: string & Group<'privateSettings'> = '12g';
-        color: string = 'red';
-    }
-
-    class User {
-        id: number = 0;
-        password: string & Group<'b'> = '';
-        settings: Settings = new Settings;
-
-        constructor(public username: string & Group<'a'>) {
+function serializerSuit(testSerializer: Serializer, name: string) {
+    const sfx = ` ==> ${name}`;
+    test('deserializer' + sfx, () => {
+        class User {
+            username!: string;
+            created!: Date;
         }
 
-    }
+        const fn = createSerializeFunction(reflect(User), testSerializer.deserializeRegistry);
+        const o = fn({ username: 'Peter', created: '2021-10-19T00:22:58.257Z' });
+        expect(o).toEqual({
+            username: 'Peter',
+            created: new Date('2021-10-19T00:22:58.257Z')
+        });
+    });
 
-    const user = new User('peter');
-    expect(serialize<User>(user)).toEqual({ id: 0, username: 'peter', password: '', settings: { weight: '12g', color: 'red' } });
-    expect(serialize<User>(user, { groups: ['a'] })).toEqual({ username: 'peter' });
-    expect(serialize<User>(user, { groups: ['b'] })).toEqual({ password: '' });
-    expect(serialize<User>(user, { groups: ['a', 'b'] })).toEqual({ username: 'peter', password: '' });
-    expect(serialize<User>(user, { groupsExclude: ['b'] })).toEqual({ id: 0, username: 'peter', settings: { weight: '12g', color: 'red' } });
-    expect(serialize<User>(user, { groupsExclude: ['privateSettings'] })).toEqual({ id: 0, username: 'peter', password: '', settings: { color: 'red' } });
-});
+    test('cast interface' + sfx, () => {
+        interface User {
+            username: string;
+            created: Date;
+        }
 
-test('default value', () => {
-    class User {
-        logins: number = 0;
-    }
+        const user = cast<User>({ username: 'Peter', created: '2021-10-19T00:22:58.257Z' });
+        expect(user).toEqual({
+            username: 'Peter',
+            created: new Date('2021-10-19T00:22:58.257Z')
+        });
+    });
 
-    {
-        const user = cast<User>({});
+    test('cast class' + sfx, () => {
+        class User {
+            created: Date = new Date;
+
+            constructor(public username: string) {
+            }
+        }
+
+        const user = cast<User>({ username: 'Peter', created: '2021-10-19T00:22:58.257Z' });
         expect(user).toBeInstanceOf(User);
         expect(user).toEqual({
-            logins: 0
+            username: 'Peter',
+            created: new Date('2021-10-19T00:22:58.257Z')
         });
-    }
+    });
 
-    {
-        const user = cast<User>({ logins: 2 });
-        expect(user).toEqual({
-            logins: 2
-        });
-    }
-});
+    test('groups' + sfx, () => {
+        class Settings {
+            weight: string & Group<'privateSettings'> = '12g';
+            color: string = 'red';
+        }
 
-test('optional value', () => {
-    class User {
-        logins?: number;
-    }
+        class User {
+            id: number = 0;
+            password: string & Group<'b'> = '';
+            settings: Settings = new Settings;
 
-    {
-        const user = cast<User>({});
-        expect(user).toEqual({
-            logins: undefined
-        });
-    }
+            constructor(public username: string & Group<'a'>) {
+            }
 
-    {
-        const user = cast<User>({ logins: 2 });
-        expect(user).toEqual({
-            logins: 2
-        });
-    }
-});
+        }
 
-test('optional default value', () => {
-    class User {
-        logins?: number = 2;
-    }
+        const user = new User('peter');
+        expect(serialize<User>(user)).toEqual({ id: 0, username: 'peter', password: '', settings: { weight: '12g', color: 'red' } });
+        expect(serialize<User>(user, { groups: ['a'] })).toEqual({ username: 'peter' });
+        expect(serialize<User>(user, { groups: ['b'] })).toEqual({ password: '' });
+        expect(serialize<User>(user, { groups: ['a', 'b'] })).toEqual({ username: 'peter', password: '' });
+        expect(serialize<User>(user, { groupsExclude: ['b'] })).toEqual({ id: 0, username: 'peter', settings: { weight: '12g', color: 'red' } });
+        expect(serialize<User>(user, { groupsExclude: ['privateSettings'] })).toEqual({ id: 0, username: 'peter', password: '', settings: { color: 'red' } });
+    });
 
-    {
-        const user = cast<User>({});
-        expect(user).toEqual({
-            logins: 2
-        });
-    }
+    test('default value' + sfx, () => {
+        class User {
+            logins: number = 0;
+        }
 
-    {
-        const user = cast<User>({ logins: 2 });
-        expect(user).toEqual({
-            logins: 2
-        });
-    }
+        {
+            const user = cast<User>({});
+            expect(user).toBeInstanceOf(User);
+            expect(user).toEqual({
+                logins: 0
+            });
+        }
 
-    {
-        const user = cast<User>({ logins: null });
-        expect(user).toEqual({
-            logins: undefined
-        });
-    }
+        {
+            const user = cast<User>({ logins: 2 });
+            expect(user).toEqual({
+                logins: 2
+            });
+        }
+    });
 
-    {
-        const user = cast<User>({ logins: undefined });
-        expect(user).toEqual({
-            logins: undefined
-        });
-    }
-});
+    test('optional value' + sfx, () => {
+        class User {
+            logins?: number;
+        }
 
-test('optional literal', () => {
-    interface LoginInput {
-        mechanism?: 'cookie';
-    }
+        {
+            const user = cast<User>({});
+            expect(user).toEqual({
+                logins: undefined
+            });
+        }
 
-    {
-        const input = cast<LoginInput>({});
-        expect(input).toEqual({
-            mechanism: undefined
-        });
-    }
+        {
+            const user = cast<User>({ logins: 2 });
+            expect(user).toEqual({
+                logins: 2
+            });
+        }
+    });
 
-    {
-        const input = cast<LoginInput>({ mechanism: 'cookie' });
-        expect(input).toEqual({
-            mechanism: 'cookie'
-        });
-    }
-});
+    test('optional default value' + sfx, () => {
+        class User {
+            logins?: number = 2;
+        }
 
-test('cast primitives', () => {
-    expect(cast<string>('123')).toBe('123');
-    expect(cast<string>(123)).toBe('123');
-    expect(cast<number>(123)).toBe(123);
-    expect(cast<number>('123')).toBe(123);
+        {
+            const user = cast<User>({});
+            expect(user).toEqual({
+                logins: 2
+            });
+        }
 
-    expect(cast<Date>('2021-10-19T00:22:58.257Z')).toEqual(new Date('2021-10-19T00:22:58.257Z'));
-    expect(serialize<Date>(new Date('2021-10-19T00:22:58.257Z'))).toEqual('2021-10-19T00:22:58.257Z');
-});
+        {
+            const user = cast<User>({ logins: 2 });
+            expect(user).toEqual({
+                logins: 2
+            });
+        }
 
-test('cast integer', () => {
-    expect(cast<integer>(123.456)).toBe(123);
-    expect(cast<int8>(1000)).toBe(127);
-});
+        {
+            const user = cast<User>({ logins: null });
+            expect(user).toEqual({
+                logins: undefined
+            });
+        }
 
-test('tuple 2', () => {
-    const value = cast<[string, number]>([12, '13']);
-    expect(value).toEqual(['12', 13]);
-});
+        {
+            const user = cast<User>({ logins: undefined });
+            expect(user).toEqual({
+                logins: undefined
+            });
+        }
+    });
 
-test('tuple rest', () => {
-    {
-        const value = cast<[...string[], number]>([12, '13']);
+    test('optional literal' + sfx, () => {
+        interface LoginInput {
+            mechanism?: 'cookie';
+        }
+
+        {
+            const input = cast<LoginInput>({});
+            expect(input).toEqual({
+                mechanism: undefined
+            });
+        }
+
+        {
+            const input = cast<LoginInput>({ mechanism: 'cookie' });
+            expect(input).toEqual({
+                mechanism: 'cookie'
+            });
+        }
+    });
+
+    test('cast primitives' + sfx, () => {
+        expect(cast<string>('123')).toBe('123');
+        expect(cast<string>(123)).toBe('123');
+        expect(cast<number>(123)).toBe(123);
+        expect(cast<number>('123')).toBe(123);
+
+        expect(cast<Date>('2021-10-19T00:22:58.257Z')).toEqual(new Date('2021-10-19T00:22:58.257Z'));
+        expect(serialize<Date>(new Date('2021-10-19T00:22:58.257Z'))).toEqual('2021-10-19T00:22:58.257Z');
+    });
+
+    test('cast integer' + sfx, () => {
+        expect(cast<integer>(123.456)).toBe(123);
+        expect(cast<int8>(1000)).toBe(127);
+    });
+
+    test('tuple 2' + sfx, () => {
+        const value = cast<[string, number]>([12, '13']);
         expect(value).toEqual(['12', 13]);
-    }
-    {
-        const value = cast<[...string[], number]>([12, 13, '14']);
-        expect(value).toEqual(['12', '13', 14]);
-    }
-    {
-        const value = cast<[boolean, ...string[], number]>([1, 12, '13']);
-        expect(value).toEqual([true, '12', 13]);
-    }
-    {
-        const value = cast<[boolean, ...string[], number]>([1, 12, 13, '14']);
-        expect(value).toEqual([true, '12', '13', 14]);
-    }
-    {
-        const value = serialize<[boolean, ...string[], number]>([true, '12', 13]);
-        expect(value).toEqual([true, '12', 13]);
-    }
-});
-
-test('set', () => {
-    {
-        const value = cast<Set<string>>(['a', 'a', 'b']);
-        expect(value).toEqual(new Set(['a', 'b']));
-    }
-    {
-        const value = cast<Set<string>>(['a', 2, 'b']);
-        expect(value).toEqual(new Set(['a', '2', 'b']));
-    }
-    {
-        const value = serialize<Set<string>>(new Set(['a', 'b']));
-        expect(value).toEqual(['a', 'b']);
-    }
-});
-
-test('map', () => {
-    {
-        const value = cast<Map<string, number>>([['a', 1], ['a', 2], ['b', 3]]);
-        expect(value).toEqual(new Map([['a', 2], ['b', 3]]));
-    }
-    {
-        const value = cast<Map<string, number>>([['a', 1], [2, '2'], ['b', 3]]);
-        expect(value).toEqual(new Map([['a', 1], ['2', 2], ['b', 3]]));
-    }
-    {
-        const value = serialize<Map<string, number>>(new Map([['a', 2], ['b', 3]]));
-        expect(value).toEqual([['a', 2], ['b', 3]]);
-    }
-});
-
-test('number', () => {
-    expect(cast<number>(1)).toBe(1);
-    expect(cast<number>(-1)).toBe(-1);
-    expect(cast<number>(true)).toBe(1);
-    expect(cast<number>(false)).toBe(0);
-    expect(cast<number>('1')).toBe(1);
-    expect(cast<number>('-1')).toBe(-1);
-});
-
-test('union string number', () => {
-    expect(cast<string | number>('a')).toEqual('a');
-    expect(cast<string | number>(2)).toEqual(2);
-
-    expect(cast<string | integer>(2)).toEqual(2);
-    expect(cast<string | integer>('3', { loosely: false })).toEqual('3');
-    expect(cast<string | integer>('3')).toEqual(3);
-
-    expect(cast<string | integer>(2.2)).toEqual(2);
-    expect(cast<string | integer>('2.2', { loosely: false })).toEqual('2.2');
-    expect(cast<string | integer>('2.2')).toEqual(2);
-
-    expect(cast<string | integer>(false)).toEqual('false');
-    expect(cast<string | integer>(true)).toEqual('true');
-});
-
-test('union boolean number', () => {
-    expect(cast<boolean | number>(2)).toEqual(2);
-    expect(cast<boolean | number>(1)).toEqual(1);
-    expect(cast<boolean | number>(0)).toEqual(0);
-    expect(cast<boolean | number>(false)).toEqual(false);
-    expect(cast<boolean | number>(true)).toEqual(true);
-});
-
-test('disabled loosely throws for primitives', () => {
-    expect(cast<string>(23)).toEqual('23');
-    expect(cast<string>(23)).toEqual('23');
-    expect(() => cast<string>(23, { loosely: false })).toThrow('Validation error');
-
-    expect(cast<number>('23')).toEqual(23);
-    expect(cast<number>('23')).toEqual(23);
-    expect(() => cast<number>('23', { loosely: false })).toThrow('Validation error');
-
-    expect(cast<boolean>(1)).toEqual(true);
-    expect(cast<boolean>(1)).toEqual(true);
-    expect(() => cast<boolean>(1, { loosely: false })).toThrow('Validation error');
-});
-
-test('union loose string number', () => {
-    expect(cast<string | number>('a')).toEqual('a');
-    expect(cast<string | number>(2)).toEqual(2);
-    expect(cast<string | number>(-2)).toEqual(-2);
-
-    expect(cast<string | integer>(2)).toEqual(2);
-    expect(cast<string | integer>('3')).toEqual(3);
-
-    expect(cast<string | integer>(2.2)).toEqual(2);
-    expect(cast<string | integer>(-2.2)).toEqual(-2);
-    expect(cast<string | integer>('2.2')).toEqual(2);
-    expect(cast<string | integer>(false)).toEqual('false');
-    expect(cast<string | integer>(true)).toEqual('true');
-});
-
-test('union loose string boolean', () => {
-    expect(cast<string | boolean>('a')).toEqual('a');
-    expect(cast<string | boolean>(1)).toEqual(true);
-    expect(cast<string | boolean>(0)).toEqual(false);
-    expect(cast<string | boolean>(-1)).toEqual('-1');
-    expect(cast<string | boolean>(2)).toEqual('2');
-    expect(cast<string | boolean>('true')).toEqual(true);
-    expect(cast<string | boolean>('true2')).toEqual('true2');
-});
-
-test('union loose number boolean', () => {
-    expect(() => cast<number | boolean>('a')).toThrow('Validation error for type');
-    expect(deserialize<number | boolean>('a')).toEqual(undefined);
-    expect(cast<string | boolean>(1)).toEqual(true);
-    expect(cast<number | boolean>(1)).toEqual(1);
-    expect(cast<string | boolean>('1')).toEqual(true);
-    expect(cast<number | boolean>('1')).toEqual(1);
-    expect(cast<number | boolean>('1')).toEqual(1);
-    expect(cast<string | boolean>(0)).toEqual(false);
-    expect(cast<number | boolean>(0)).toEqual(0);
-    expect(cast<number | boolean>(-1)).toEqual(-1);
-    expect(cast<number | boolean>(2)).toEqual(2);
-    expect(cast<number | boolean>('2')).toEqual(2);
-    expect(cast<number | boolean>('true')).toEqual(true);
-    expect(() => cast<number | boolean>('true', { loosely: false })).toThrow('Validation error for type');
-    expect(() => cast<number | boolean>('true2', { loosely: false })).toThrow('Validation error for type');
-    expect(deserialize<number | boolean>('true2')).toEqual(undefined);
-});
-
-test('union string date', () => {
-    expect(cast<string | Date>('a')).toEqual('a');
-    expect(cast<string | Date>('2021-11-24T16:21:13.425Z')).toBeInstanceOf(Date);
-    expect(cast<string | Date>(1637781902866)).toBeInstanceOf(Date);
-    expect(cast<string | Date>('1637781902866')).toBe('1637781902866');
-    expect(cast<(string | Date)[]>(['2021-11-24T16:21:13.425Z'])[0]).toBeInstanceOf(Date);
-});
-
-test('union string bigint', () => {
-    expect(cast<string | bigint>('a')).toEqual('a');
-    expect(cast<string | bigint>(2n)).toEqual(2n);
-    expect(cast<string | bigint>(2)).toEqual(2n);
-    expect(cast<string | bigint>('2', { loosely: false })).toEqual('2');
-    expect(cast<string | bigint>('2')).toEqual(2n);
-    expect(cast<string | bigint>('2a')).toEqual('2a');
-});
-
-test('union loose string bigint', () => {
-    expect(cast<string | bigint>('a')).toEqual('a');
-    expect(cast<string | bigint>(2n)).toEqual(2n);
-    expect(cast<string | bigint>(2)).toEqual(2n);
-    expect(cast<string | bigint>('2')).toEqual(2n);
-    expect(cast<string | bigint>('2a')).toEqual('2a');
-});
-
-test('BinaryBigInt', () => {
-    expect(serialize<bigint>(24n)).toBe('24');
-    expect(serialize<BinaryBigInt>(24n)).toBe('24');
-    expect(serialize<BinaryBigInt>(-4n)).toBe('0');
-
-    expect(deserialize<BinaryBigInt>(24n)).toBe(24n);
-    expect(deserialize<BinaryBigInt>('24')).toBe(24n);
-    expect(deserialize<BinaryBigInt>(-4n)).toBe(0n);
-    expect(deserialize<BinaryBigInt>('-4')).toBe(0n);
-
-    expect(serialize<SignedBinaryBigInt>(24n)).toBe('24');
-    expect(serialize<SignedBinaryBigInt>(-4n)).toBe('-4');
-    expect(deserialize<SignedBinaryBigInt>(24n)).toBe(24n);
-    expect(deserialize<SignedBinaryBigInt>('24')).toBe(24n);
-    expect(deserialize<SignedBinaryBigInt>(-4n)).toBe(-4n);
-    expect(deserialize<SignedBinaryBigInt>('-4')).toBe(-4n);
-});
-
-test('literal', () => {
-    expect(cast<'a'>('a')).toEqual('a');
-    expect(serialize<'a'>('a')).toEqual('a');
-    expect(cast<'a'>('b')).toEqual('a');
-    expect(cast<'a'>(123)).toEqual('a');
-    expect(cast<1>(123)).toEqual(1);
-    expect(cast<1>('123')).toEqual(1);
-    expect(cast<true>('123')).toEqual(true);
-    expect(cast<1n>('123')).toEqual(1n);
-    expect(cast<1n>('123')).toEqual(1n);
-
-    expect(serialize<1n>(1n)).toEqual(1n);
-});
-
-test('cast runs validators', () => {
-    type Username = string & MinLength<3> & MaxLength<23> & Alphanumeric;
-    expect(() => cast<Username>('ab')).toThrow('Validation error for type');
-    expect(() => cast<Username>('$ab')).toThrow('Validation error for type');
-    expect(cast<Username>('Peter')).toBe('Peter');
-});
-
-test('union literal', () => {
-    expect(cast<'a' | number>('a')).toEqual('a');
-    expect(cast<'a' | number>(23)).toEqual(23);
-    expect(serialize<'a' | number>('a')).toEqual('a');
-    expect(serialize<'a' | number>(23)).toEqual(23);
-
-    expect(cast<3 | number>(23)).toEqual(23);
-    expect(cast<3 | number>(3)).toEqual(3);
-    expect(serialize<3 | number>(23)).toEqual(23);
-    expect(serialize<3 | number>(3)).toEqual(3);
-
-    expect(cast<3 | boolean>(3)).toEqual(3);
-    expect(cast<true | boolean>(true)).toEqual(true);
-    expect(cast<true | boolean>(false)).toEqual(false);
-    expect(cast<false | boolean>(true)).toEqual(true);
-    expect(cast<false | boolean>(false)).toEqual(false);
-});
-
-test('union primitive and class', () => {
-    class User {
-        id!: number;
-    }
-
-    expect(cast<number | User>(2)).toEqual(2);
-    expect(cast<number | User>('2')).toEqual(2);
-    expect(cast<number | User>({ id: 23 })).toEqual({ id: 23 });
-    expect(cast<number | User>({ id: 23 })).toBeInstanceOf(User);
-    expect(() => cast<number | User>('2asd')).toThrow('Validation error for type');
-
-    expect(serialize<number | User>(2)).toEqual(2);
-    expect(serialize<number | User>({ id: 23 })).toEqual({ id: 23 });
-    expect(serialize<number | User>({ id: 23 })).toBeInstanceOf(Object);
-});
-
-test('union multiple classes', () => {
-    class User {
-        id!: number;
-        username!: string;
-    }
-
-    class Picture {
-        id!: number;
-        path!: string;
-    }
-
-    expect(cast<Picture | User>({ id: 23, username: 'peter' })).toEqual({ id: 23, username: 'peter' });
-    expect(cast<Picture | User>({ id: 23, username: 'peter' })).toBeInstanceOf(User);
-
-    expect(cast<Picture | User>({ id: 23, path: 'src/path' })).toEqual({ id: 23, path: 'src/path' });
-    expect(cast<Picture | User>({ id: 23, path: 'src/path' })).toBeInstanceOf(Picture);
-
-    expect(cast<number | User>(23)).toEqual(23);
-    expect(cast<number | User>({ id: 23, username: 'peter' })).toBeInstanceOf(User);
-
-    expect(serialize<Picture | User>({ id: 23, username: 'peter' })).toEqual({ id: 23, username: 'peter' });
-    expect(serialize<Picture | User>({ id: 23, username: 'peter' })).toBeInstanceOf(Object);
-
-    expect(serialize<Picture | User>({ id: 23, path: 'src/path' })).toEqual({ id: 23, path: 'src/path' });
-    expect(serialize<Picture | User>({ id: 23, path: 'src/path' })).toBeInstanceOf(Object);
-
-    expect(serialize<number | User>(23)).toEqual(23);
-    expect(serialize<number | User>({ id: 23, username: 'peter' })).toBeInstanceOf(Object);
-    expect(serialize<number | User>({ id: 23, username: 'peter' })).toEqual({ id: 23, username: 'peter' });
-});
-
-test('brands', () => {
-    expect(cast<number & PrimaryKey>(2)).toEqual(2);
-    expect(cast<number & PrimaryKey>('2')).toEqual(2);
-
-    expect(serialize<number & PrimaryKey>(2)).toEqual(2);
-});
-
-test('throw', () => {
-    expect(() => cast<number>('123abc')).toThrow('Cannot convert 123abc to number');
-    expect(() => cast<{ a: string }>(false)).toThrow('Cannot convert false to {a: string}');
-    expect(() => cast<{ a: number }>({ a: 'abc' })).toThrow('Cannot convert abc to number');
-    expect(() => cast<{ a: { b: number } }>({ a: 'abc' })).toThrow('Cannot convert abc to {b: number}');
-    expect(() => cast<{ a: { b: number } }>({ a: { b: 'abc' } })).toThrow('Cannot convert abc to number');
-});
-
-test('index signature ', () => {
-    interface BagOfNumbers {
-        [name: string]: number;
-    }
-
-    interface BagOfStrings {
-        [name: string]: string;
-    }
-
-    expect(cast<BagOfNumbers>({ a: 1 })).toEqual({ a: 1 });
-    expect(cast<BagOfNumbers>({ a: 1, b: 2 })).toEqual({ a: 1, b: 2 });
-    expect(() => cast<BagOfNumbers>({ a: 'b' })).toThrow(ValidationError as any);
-    expect(() => cast<BagOfNumbers>({ a: 'b' })).toThrow('Cannot convert b to number');
-    expect(cast<BagOfNumbers>({ a: '1' })).toEqual({ a: 1 });
-    expect(() => cast<BagOfNumbers>({ a: 'b', b: 'c' })).toThrow(ValidationError as any);
-    expect(() => cast<BagOfNumbers>({ a: 'b', b: 'c' })).toThrow('Cannot convert b to number');
-
-    expect(cast<BagOfStrings>({ a: 1 })).toEqual({ a: '1' });
-    expect(cast<BagOfStrings>({ a: 1, b: 2 })).toEqual({ a: '1', b: '2' });
-    expect(cast<BagOfStrings>({ a: 'b' })).toEqual({ a: 'b' });
-    expect(cast<BagOfStrings>({ a: 'b', b: 'c' })).toEqual({ a: 'b', b: 'c' });
-
-    expect(serialize<BagOfNumbers>({ a: 1 })).toEqual({ a: 1 });
-    expect(serialize<BagOfStrings>({ a: '1' })).toEqual({ a: '1' });
-});
-
-test('exclude', () => {
-    class User {
-        username!: string;
-
-        password?: string & Excluded<'*'>;
-    }
-
-    const reflection = ReflectionClass.from(User);
-    expect(reflection.getProperty('password')?.getExcluded()).toEqual(['*']);
-
-    expect(cast<User>({ username: 'peter', password: 'nope' })).toEqual({ username: 'peter', password: undefined });
-    expect(serialize<User>({ username: 'peter', password: 'nope' })).toEqual({ username: 'peter', password: undefined });
-});
-
-test('regexp direct', () => {
-    expect(cast<RegExp>(/abc/).toString()).toEqual('/abc/');
-    expect(cast<RegExp>('/abc/').toString()).toEqual('/abc/');
-    expect(cast<RegExp>('abc').toString()).toEqual('/abc/');
-    expect(serialize<RegExp>(/abc/).toString()).toEqual('/abc/');
-});
-
-test('regexp union', () => {
-    expect(cast<string | { $regex: RegExp }>({ $regex: /abc/ })).toEqual({ $regex: /abc/ });
-    expect(cast<Record<string, string | { $regex: RegExp }>>({ a: { $regex: /abc/ } })).toEqual({ a: { $regex: /abc/ } });
-});
-
-test('index signature with template literal', () => {
-    type a1 = { [index: `a${number}`]: number };
-    expect(cast<a1>({ a123: '123' })).toEqual({ a123: 123 });
-    expect(cast<a1>({ a123: '123', b: 123 })).toEqual({ a123: 123, b: undefined });
-    expect(cast<a1>({ a123: '123', a124: 123 })).toEqual({ a123: 123, a124: 123 });
-});
-
-test('class circular reference', () => {
-    class User {
-        constructor(public username: string) {
-        }
-
-        manager?: User;
-    }
-
-    const res = cast<User>({ username: 'Horst', manager: { username: 'Peter' } });
-    expect(res).toEqual({ username: 'Horst', manager: { username: 'Peter' } });
-    expect(res).toBeInstanceOf(User);
-    expect(res.manager).toBeInstanceOf(User);
-});
-
-test('class with reference', () => {
-    class User {
-        id: number & PrimaryKey = 0;
-
-        constructor(public username: string) {
-        }
-    }
-
-    interface Team {
-        lead: User & Reference;
-    }
-
-    {
-        const res = cast<Team>({ lead: { id: 1, username: 'Peter' } });
-        expect(res).toEqual({ lead: { id: 1, username: 'Peter' } });
-        expect(res.lead).toBeInstanceOf(User);
-        expect(isReferenceInstance(res.lead)).toBe(false);
-    }
-
-    {
-        const res = cast<Team>({ lead: { id: 1 } });
-        expect(res).toEqual({ lead: { id: 1 } });
-        expect(res.lead).toBeInstanceOf(User);
-        expect(isReferenceInstance(res.lead)).toBe(true);
-    }
-
-    {
-        const res = cast<Team>({ lead: { username: 'Peter' } });
-        expect(res).toEqual({ lead: { id: 0, username: 'Peter' } });
-        expect(res.lead).toBeInstanceOf(User);
-    }
-
-    {
-        const res = cast<Team>({ lead: 23 });
-        expect(res).toEqual({ lead: { id: 23 } });
-        expect(res.lead).toBeInstanceOf(User);
-        expect(getClassName(res.lead)).toBe('UserReference');
-    }
-});
-
-test('class with back reference', () => {
-    class User {
-        id: number & PrimaryKey = 0;
-
-        constructor(public username: string) {
-        }
-    }
-
-    interface Team {
-        leads: User[] & BackReference;
-    }
-
-    const res = cast<Team>({ leads: [{ username: 'Peter' }] });
-    expect(res).toEqual({ leads: [{ id: 0, username: 'Peter' }] });
-    expect(res.leads[0]).toBeInstanceOf(User);
-});
-
-test('embedded single', () => {
-    class Price {
-        constructor(public amount: integer) {
-        }
-    }
-
-    class Product {
-        constructor(public title: string, public price: Embedded<Price>) {
-        }
-    }
-
-    expect(serialize<Embedded<Price>>(new Price(34))).toEqual(34);
-    expect(serialize<Embedded<Price>[]>([new Price(34)])).toEqual([34]);
-    expect(serialize<Embedded<Price, { prefix: '' }>[]>([new Price(34)])).toEqual([34]);
-    expect(serialize<Embedded<Price, { prefix: 'price_' }>[]>([new Price(34)])).toEqual([34]);
-    expect(serialize<{ a: Embedded<Price> }>({ a: new Price(34) })).toEqual({ a: 34 });
-    expect(serialize<{ a: Embedded<Price, { prefix: '' }> }>({ a: new Price(34) })).toEqual({ amount: 34 });
-    expect(serialize<{ a: Embedded<Price, { prefix: 'price_' }> }>({ a: new Price(34) })).toEqual({ price_amount: 34 });
-    expect(serialize<Product>(new Product('Brick', new Price(34)))).toEqual({ title: 'Brick', price: 34 });
-
-    expect(deserialize<Embedded<Price>>(34)).toEqual(new Price(34));
-    expect(deserialize<Embedded<Price>[]>([34])).toEqual([new Price(34)]);
-    expect(deserialize<(Embedded<Price> | string)[]>([34])).toEqual([new Price(34)]);
-    expect(deserialize<(Embedded<Price> | string)[]>(['abc'])).toEqual(['abc']);
-    expect(deserialize<Embedded<Price, { prefix: '' }>[]>([34])).toEqual([new Price(34)]);
-    expect(deserialize<Embedded<Price, { prefix: 'price_' }>[]>([34])).toEqual([new Price(34)]);
-    expect(deserialize<{ a: Embedded<Price> }>({ a: 34 })).toEqual({ a: new Price(34) });
-    expect(deserialize<{ a: Embedded<Price, { prefix: '' }> }>({ amount: 34 })).toEqual({ a: new Price(34) });
-    expect(deserialize<{ a: Embedded<Price, { prefix: 'price_' }> }>({ price_amount: 34 })).toEqual({ a: new Price(34) });
-    expect(deserialize<Product>({ title: 'Brick', price: 34 })).toEqual(new Product('Brick', new Price(34)));
-
-    // check if union works correctly
-    expect(serialize<{ v: Embedded<Price> | string }>({ v: new Price(34) })).toEqual({ v: 34 });
-    expect(serialize<{ v: Embedded<Price> | string }>({ v: '123' })).toEqual({ v: '123' });
-    expect(serialize<(Embedded<Price> | string)[]>([new Price(34)])).toEqual([34]);
-    expect(serialize<(Embedded<Price> | string)[]>(['abc'])).toEqual(['abc']);
-    expect(serialize<{ v: Embedded<Price, { prefix: '' }> | string }>({ v: new Price(34) })).toEqual({ amount: 34 });
-    expect(serialize<{ v: Embedded<Price, { prefix: '' }> | string }>({ v: '34' })).toEqual({ v: '34' });
-    expect(serialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ v: new Price(34) })).toEqual({ price_amount: 34 });
-    expect(serialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ v: '34' })).toEqual({ v: '34' });
-
-    expect(deserialize<{ v: Embedded<Price> | string }>({ v: 34 })).toEqual({ v: new Price(34) });
-    expect(deserialize<{ v: Embedded<Price> | string }>({ v: '123' })).toEqual({ v: '123' });
-    expect(deserialize<{ v: Embedded<Price, { prefix: '' }> | string }>({ amount: 34 })).toEqual({ v: new Price(34) });
-    expect(deserialize<{ v: Embedded<Price, { prefix: '' }> | string }>({ v: '34' })).toEqual({ v: '34' });
-    expect(deserialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ price_amount: 34 })).toEqual({ v: new Price(34) });
-    expect(deserialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ v: '34' })).toEqual({ v: '34' });
-
-});
-
-test('embedded single optional', () => {
-    class Price {
-        constructor(public amount: integer) {
-        }
-    }
-
-    expect(deserialize<{ v?: Embedded<Price> }>({ v: 34 })).toEqual({ v: new Price(34) });
-    expect(deserialize<{ v?: Embedded<Price> }>({})).toEqual({});
-    expect(deserialize<{ v?: Embedded<Price, { prefix: '' }> }>({ amount: 34 })).toEqual({ v: new Price(34) });
-    expect(deserialize<{ v?: Embedded<Price, { prefix: '' }> }>({})).toEqual({});
-    expect(deserialize<{ v?: Embedded<Price, { prefix: 'price_' }> }>({ price_amount: 34 })).toEqual({ v: new Price(34) });
-    expect(deserialize<{ v?: Embedded<Price, { prefix: 'price_' }> }>({})).toEqual({});
-
-    class Product1 {
-        constructor(public title: string, public price: Embedded<Price> = new Price(15)) {
-        }
-    }
-
-    class Product2 {
-        constructor(public title: string, public price?: Embedded<Price>) {
-        }
-    }
-
-    class Product3 {
-        public price: Embedded<Price> | undefined = new Price(15);
-    }
-
-    class Product4 {
-        public price: Embedded<Price> | null = new Price(15);
-    }
-
-    expect(deserialize<{ a?: Embedded<Price> }>({})).toEqual({});
-    expect(deserialize<{ a?: Embedded<Price> }>({ a: undefined })).toEqual({});
-    expect(deserialize<{ a?: Embedded<Price, { prefix: '' }> }>({})).toEqual({});
-    expect(deserialize<{ a?: Embedded<Price, { prefix: '' }> }>({ amount: undefined })).toEqual({});
-    expect(deserialize<{ a?: Embedded<Price, { prefix: 'price_' }> }>({})).toEqual({});
-    expect(deserialize<{ a?: Embedded<Price, { prefix: 'price_' }> }>({ price_amount: undefined })).toEqual({});
-    expect(deserialize<Product1>({ title: 'Brick' })).toEqual(new Product1('Brick'));
-    expect(deserialize<Product2>({ title: 'Brick' })).toEqual(new Product2('Brick'));
-    expect(deserialize<Product3>({})).toEqual({ price: new Price(15) });
-    expect(deserialize<Product3>({ price: null })).toEqual({ price: undefined });
-    expect(deserialize<Product4>({ price: undefined })).toEqual({ price: null });
-    expect(deserialize<Product4>({})).toEqual({ price: null });
-    expect(deserialize<Product4>({ price: null })).toEqual({ price: null });
-});
-
-test('embedded multi parameter', () => {
-    class Price {
-        constructor(public amount: integer, public currency: string = 'EUR') {
-        }
-    }
-
-    class Product {
-        constructor(public title: string, public price: Embedded<Price>) {
-        }
-    }
-
-    expect(serialize<Embedded<Price>>(new Price(34))).toEqual({ amount: 34, currency: 'EUR' });
-    expect(serialize<Embedded<Price>[]>([new Price(34)])).toEqual([{ amount: 34, currency: 'EUR' }]);
-    expect(serialize<Embedded<Price, { prefix: '' }>[]>([new Price(34)])).toEqual([{ amount: 34, currency: 'EUR' }]);
-    expect(serialize<Embedded<Price, { prefix: 'price_' }>[]>([new Price(34)])).toEqual([{ price_amount: 34, price_currency: 'EUR' }]);
-    expect(serialize<{ a: Embedded<Price> }>({ a: new Price(34) })).toEqual({ a_amount: 34, a_currency: 'EUR' });
-    expect(serialize<{ a: Embedded<Price, { prefix: '' }> }>({ a: new Price(34) })).toEqual({ amount: 34, currency: 'EUR' });
-    expect(serialize<{ a: Embedded<Price, { prefix: 'price_' }> }>({ a: new Price(34) })).toEqual({ price_amount: 34, price_currency: 'EUR' });
-    expect(serialize<Product>(new Product('Brick', new Price(34)))).toEqual({ title: 'Brick', price_amount: 34, price_currency: 'EUR' });
-
-    expect(deserialize<Embedded<Price>>({ amount: 34 })).toEqual(new Price(34));
-    expect(deserialize<Embedded<Price>>({ amount: 34, currency: '$' })).toEqual(new Price(34, '$'));
-    expect(deserialize<Embedded<Price>[]>([{ amount: 34 }])).toEqual([new Price(34)]);
-    expect(deserialize<Embedded<Price>[]>([{ amount: 34, currency: '$' }])).toEqual([new Price(34, '$')]);
-    expect(deserialize<Embedded<Price, { prefix: '' }>[]>([{ amount: 34 }])).toEqual([new Price(34)]);
-    expect(deserialize<Embedded<Price, { prefix: 'price_' }>[]>([{ price_amount: 34 }])).toEqual([new Price(34)]);
-    expect(deserialize<{ a: Embedded<Price> }>({ a_amount: 34 })).toEqual({ a: new Price(34) });
-    expect(deserialize<{ a: Embedded<Price, { prefix: '' }> }>({ amount: 34 })).toEqual({ a: new Price(34) });
-    expect(deserialize<{ a: Embedded<Price, { prefix: '' }> }>({ amount: 34, currency: '$' })).toEqual({ a: new Price(34, '$') });
-    expect(deserialize<{ a: Embedded<Price, { prefix: '' }> }>({ amount: 34, currency: undefined })).toEqual({ a: new Price(34) });
-    expect(deserialize<{ a: Embedded<Price, { prefix: 'price_' }> }>({ price_amount: 34 })).toEqual({ a: new Price(34) });
-    expect(deserialize<{ a: Embedded<Price, { prefix: 'price_' }> }>({ price_amount: 34, price_currency: '$' })).toEqual({ a: new Price(34, '$') });
-    expect(deserialize<Product>({ title: 'Brick', price_amount: 34 })).toEqual(new Product('Brick', new Price(34)));
-
-    //check if union works correctly
-    expect(serialize<{ v: Embedded<Price> | string }>({ v: new Price(34) })).toEqual({ v_amount: 34, v_currency: 'EUR' });
-    expect(serialize<{ v: Embedded<Price> | string }>({ v: new Price(34, '$') })).toEqual({ v_amount: 34, v_currency: '$' });
-    expect(serialize<{ v: Embedded<Price> | string }>({ v: '123' })).toEqual({ v: '123' });
-    expect(serialize<{ v: Embedded<Price, { prefix: '' }> | string }>({ v: new Price(34) })).toEqual({ amount: 34, currency: 'EUR' });
-    expect(serialize<{ v: Embedded<Price, { prefix: '' }> | string }>({ v: '34' })).toEqual({ v: '34' });
-    expect(serialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ v: new Price(34) })).toEqual({ price_amount: 34, price_currency: 'EUR' });
-    expect(serialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ v: '34' })).toEqual({ v: '34' });
-
-    expect(deserialize<{ v: Embedded<Price> | string }>({ v_amount: 34 })).toEqual({ v: new Price(34) });
-    expect(deserialize<{ v: Embedded<Price> | string }>({ v_amount: 34, v_currency: '$' })).toEqual({ v: new Price(34, '$') });
-    expect(deserialize<{ v: Embedded<Price> | string }>({ v: '123' })).toEqual({ v: '123' });
-    expect(deserialize<{ v: Embedded<Price, { prefix: '' }> | string }>({ amount: 34 })).toEqual({ v: new Price(34) });
-    expect(deserialize<{ v: Embedded<Price, { prefix: '' }> | string }>({ v: '34' })).toEqual({ v: '34' });
-    expect(deserialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ price_amount: 34 })).toEqual({ v: new Price(34) });
-    expect(deserialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ v: '34' })).toEqual({ v: '34' });
-});
-
-test('class inheritance', () => {
-    abstract class Person {
-        id: number & PrimaryKey & AutoIncrement = 0;
-        firstName?: string;
-        lastName?: string;
-        abstract type: string;
-    }
-
-    class Employee extends Person {
-        email?: string;
-        type: 'employee' = 'employee';
-    }
-
-    class Freelancer extends Person {
-        @t budget: number = 10_000;
-        type: 'freelancer' = 'freelancer';
-    }
-
-    const employee = ReflectionClass.from(Employee);
-    expect(employee.getProperty('firstName').getKind()).toBe(ReflectionKind.string);
-    const scopeSerializer = getSerializeFunction(employee.type, serializer.serializeRegistry);
-
-    expect(scopeSerializer({ type: 'employee', firstName: 'Peter', email: 'test@example.com' })).toEqual({ type: 'employee', firstName: 'Peter', email: 'test@example.com' });
-});
-
-test('class with union literal', () => {
-    class ConnectionOptions {
-        readConcernLevel: 'local' | 'majority' | 'linearizable' | 'available' = 'majority';
-    }
-
-    expect(cast<ConnectionOptions>({ readConcernLevel: 'majority' })).toEqual({ readConcernLevel: 'majority' });
-    expect(cast<ConnectionOptions>({ readConcernLevel: 'linearizable' })).toEqual({ readConcernLevel: 'linearizable' });
-    expect(cast<ConnectionOptions>({ readConcernLevel: 'unknown' })).toEqual({ readConcernLevel: 'majority' });
-});
-
-test('named tuple in error message', () => {
-    expect(cast<[age: number]>([23])).toEqual([23]);
-    expect(() => cast<{ v: [age: number] }>({ v: ['123abc'] })).toThrow('v.age(type): Cannot convert 123abc to number');
-});
-
-test('intersected mapped type key', () => {
-    type SORT_ORDER = 'asc' | 'desc' | any;
-    type Sort<T, ORDER extends SORT_ORDER = SORT_ORDER> = { [P in keyof T & string]?: ORDER };
-
-    interface A {
-        username: string;
-        id: number;
-    }
-
-    type sortA = Sort<A>;
-
-    expect(cast<sortA>({ username: 'asc' })).toEqual({ username: 'asc' });
-    expect(cast<sortA>({ id: 'desc', username: 'asc' })).toEqual({ id: 'desc', username: 'asc' });
-
-    type sortAny = Sort<any>;
-    expect(cast<sortAny>({ username: 'asc' })).toEqual({ username: 'asc' });
-    expect(cast<sortAny>({ id: 'desc', username: 'asc' })).toEqual({ id: 'desc', username: 'asc' });
-});
-
-test('wild property names', () => {
-    interface A {
-        ['asd-344']: string;
-        ['#$%^^x']: number;
-    }
-
-    expect(deserialize<A>({ 'asd-344': 'abc', '#$%^^x': 3 })).toEqual({ 'asd-344': 'abc', '#$%^^x': 3 });
-});
-
-test('embedded with lots of properties', () => {
-    interface LotsOfIt {
-        a?: string;
-        lot?: string;
-        of?: string;
-        additional?: string;
-        properties?: string;
-    }
-
-    class A {
-        constructor(public options: Embedded<LotsOfIt, { prefix: '' }> = {}) {
-        }
-    }
-
-    const back1 = deserialize<A>({ a: 'abc', lot: 'string' });
-    expect(back1.options).toEqual({ a: 'abc', lot: 'string' });
-
-    class A2 {
-        public options: Embedded<LotsOfIt, { prefix: '' }> = {};
-    }
-
-    const back2 = deserialize<A2>({ a: 'abc', lot: 'string' });
-    expect(back2.options).toEqual({ a: 'abc', lot: 'string' });
-});
-
-test('embedded in super class', () => {
-    class Thread {
-        public parentThreadId?: string;
-        public senderOrder?: number;
-
-        constructor(
-            public id: string & MapName<'~thread'>
-        ) {
-        }
-    }
-
-    class ComposedMessage {
-        thread?: Embedded<Thread, { prefix: '' }>;
-    }
-
-    class Message extends ComposedMessage {
-        public readonly type: string = Message.type;
-        public static readonly type = 'my-id';
-
-        public routingKeys?: string[];
-        public endpoint?: string;
-    }
-
-    const back1 = deserialize<Message>({ '~thread': 'foo' });
-    expect(back1).toEqual({ type: Message.type, thread: { id: 'foo' } });
-
-    const plain = serialize<Message>(back1);
-    expect(plain).toEqual({ type: Message.type, parentThreadId: null, senderOrder: null, '~thread': 'foo' });
-});
-
-test('disabled constructor', () => {
-    let called = false;
-
-    @entity.disableConstructor()
-    class User {
-        id: number = 0;
-        title: string = 'id:' + this.id;
-
-        constructor(public type: string) {
-            called = true;
-        }
-    }
-
-    expect(ReflectionClass.from(User).disableConstructor).toBe(true);
-
-    const user = deserialize<User>({ type: 'nix' });
-    expect(called).toBe(false);
-    expect(user).toBeInstanceOf(User);
-    expect(user).toEqual({ id: 0, title: 'id:' + 0, type: 'nix' });
-});
-
-test('readonly constructor properties', () => {
-    class Pilot {
-        constructor(readonly name: string, readonly age: number) {
-        }
-    }
-
-    expect(cast<Pilot>({ name: 'Peter', age: 32 })).toEqual({ name: 'Peter', age: 32 });
-    expect(cast<Pilot>({ name: 'Peter', age: '32' })).toEqual({ name: 'Peter', age: 32 });
-});
-
-test('naming strategy prefix', () => {
-    class MyNamingStrategy extends NamingStrategy {
-        constructor() {
-            super('my');
-        }
-
-        override getPropertyName(type: TypeProperty | TypePropertySignature, forSerializer: string): string | undefined {
-            return '_' + super.getPropertyName(type, forSerializer);
-        }
-    }
-
-    interface Post {
-        id: number;
-        likesCount: number;
-    }
-
-    interface User {
-        readonly id: number;
-        readonly posts: readonly Post[];
-    }
-
-    {
-        const res = serialize<User>({ id: 2, posts: [{ id: 3, likesCount: 1 }, { id: 4, likesCount: 2 }] }, undefined, undefined, new MyNamingStrategy);
-        expect(res).toEqual({ _id: 2, _posts: [{ _id: 3, _likesCount: 1 }, { _id: 4, _likesCount: 2 }] });
-    }
-
-    {
-        const res = deserialize<User>({ _id: 2, _posts: [{ _id: 3, _likesCount: 1 }, { _id: 4, _likesCount: 2 }] }, undefined, undefined, new MyNamingStrategy);
-        expect(res).toEqual({ id: 2, posts: [{ id: 3, likesCount: 1 }, { id: 4, likesCount: 2 }] });
-    }
-});
-
-test('naming strategy camel case', () => {
-    const camelCaseToSnakeCase = (str: string) =>
-        str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
-
-    class CamelCaseToSnakeCaseNamingStrategy extends NamingStrategy {
-        constructor() {
-            super('snake-case-to-camel-case');
-        }
-
-        override getPropertyName(
-            type: TypeProperty | TypePropertySignature,
-            forSerializer: string
-        ): string | undefined {
-            const propertyName = super.getPropertyName(type, forSerializer);
-            return propertyName ? camelCaseToSnakeCase(propertyName) : undefined;
-        }
-    }
-
-    interface Post {
-        id: number;
-        likesCount: number;
-    }
-
-    interface User {
-        id: number;
-        posts: Post[];
-    }
-
-    {
-        const res = serialize<User>({ id: 2, posts: [{ id: 3, likesCount: 1 }, { id: 4, likesCount: 2 }] }, undefined, undefined, new CamelCaseToSnakeCaseNamingStrategy);
-        expect(res).toEqual({ id: 2, posts: [{ id: 3, likes_count: 1 }, { id: 4, likes_count: 2 }] });
-    }
-
-    {
-        const res = deserialize<User>({ id: 2, posts: [{ id: 3, likes_count: 1 }, { id: 4, likes_count: 2 }] }, undefined, undefined, new CamelCaseToSnakeCaseNamingStrategy);
-        expect(res).toEqual({ id: 2, posts: [{ id: 3, likesCount: 1 }, { id: 4, likesCount: 2 }] });
-    }
-});
-
-test('enum union', () => {
-    enum StatEnginePowerUnit {
-        Hp = 'hp',
-    }
-
-    enum StatWeightUnit {
-        Lbs = 'lbs',
-        Kg = 'kg',
-    }
-
-    type StatMeasurementUnit = StatEnginePowerUnit | StatWeightUnit;
-    const type = typeOf<StatMeasurementUnit>();
-    assertType(type, ReflectionKind.union);
-    expect(type.types.length).toBe(2);
-
-    expect(deserialize<StatMeasurementUnit>(StatWeightUnit.Kg)).toBe(StatWeightUnit.Kg);
-    expect(deserialize<StatMeasurementUnit>(StatWeightUnit.Lbs)).toBe(StatWeightUnit.Lbs);
-    expect(deserialize<StatMeasurementUnit>(StatEnginePowerUnit.Hp)).toBe(StatEnginePowerUnit.Hp);
-});
-
-test('union literals in union', () => {
-    type StatWeightUnit = 'lbs' | 'kg';
-    type StatEnginePowerUnit = 'hp';
-
-    type StatMeasurementUnit = StatEnginePowerUnit | StatWeightUnit;
-    const type = typeOf<StatMeasurementUnit>();
-    assertType(type, ReflectionKind.union);
-    expect(type.types.length).toBe(3);
-
-    expect(deserialize<StatMeasurementUnit>('kg')).toBe('kg');
-    expect(deserialize<StatMeasurementUnit>('lbs')).toBe('lbs');
-    expect(deserialize<StatMeasurementUnit>('hp')).toBe('hp');
-});
-
-test('union literals in union imported', () => {
-    type StatMeasurementUnit = StatEnginePowerUnit | StatWeightUnit;
-    const type = typeOf<StatMeasurementUnit>();
-    assertType(type, ReflectionKind.union);
-    expect(type.types.length).toBe(3);
-
-    expect(deserialize<StatMeasurementUnit>('kg')).toBe('kg');
-    expect(deserialize<StatMeasurementUnit>('lbs')).toBe('lbs');
-    expect(deserialize<StatMeasurementUnit>('hp')).toBe('hp');
-});
-
-test('function rest parameters', () => {
-    type t = (start: number, ...rest: string[]) => void;
-    const fn = typeOf<t>();
-    assertType(fn, ReflectionKind.function);
-    {
-        const type = typeOf<Parameters<never>>([fn]); //same as Parameters<t>
-        expect(deserialize([2, '33', 44], undefined, undefined, undefined, type)).toEqual([2, '33', '44']);
-    }
-    {
-        const type = parametersToTuple(fn.parameters);
-        expect(deserialize([2, '33', 44], undefined, undefined, undefined, type)).toEqual([2, '33', '44']);
-    }
-});
-
-test('discriminated union with string date in type guard', () => {
-    expect(is<number | string>(12)).toBe(true);
-    expect(is<number | string>('abc')).toBe(true);
-    expect(is<number | string>(false)).toBe(false);
-    expect(is<number | (string | bigint)[]>([false])).toBe(false);
-
-    {
-        type ModelB = { kind: 'b', date: Date };
-        const b1 = cast<ModelB>({ kind: 'b', date: '2020-08-05T00:00:00.000Z' });
-        expect(b1).toEqual({ kind: 'b', date: new Date('2020-08-05T00:00:00.000Z') });
-    }
-
-    {
-        type ModelA = { id: number, title: string };
-        type ModelB = { id: number, date: Date };
-        type Union = ModelA | ModelB;
-
-        const b2 = cast<Union>({ id: 1, date: '2020-08-05T00:00:00.000Z' });
-        expect(b2).toEqual({ id: 1, date: new Date('2020-08-05T00:00:00.000Z') });
-    }
-
-    {
-        type ModelA = { kind: 'a', title: string };
-        type ModelB = { kind: 'b', date: Date };
-        type Union = ModelA | ModelB;
-
-        const b2 = cast<Union>({ kind: 'b', date: '2020-08-05T00:00:00.000Z' });
-        expect(b2).toEqual({ kind: 'b', date: new Date('2020-08-05T00:00:00.000Z') });
-    }
-
-    {
-        type ModelA = { kind: 'a', title: string };
-        type ModelB = { kind: 'b', date: number | Date };
-        type Union = ModelA | ModelB;
-        const b2 = cast<Union>({ kind: 'b', date: '2020-08-05T00:00:00.000Z' });
-        expect(b2).toEqual({ kind: 'b', date: new Date('2020-08-05T00:00:00.000Z') });
-    }
-});
-
-test('date format', () => {
-    const date = cast<number | Date>('2020-07-02T12:00:00Z');
-    expect(date).toEqual(new Date('2020-07-02T12:00:00Z'));
-});
-
-
-test('patch', () => {
-    class Address {
-        street!: string & MinLength<3>;
-        streetNo!: string;
-        additional: { [name: string]: string } = {};
-    }
-
-    class Order {
-        id!: number;
-        shippingAddress!: Address;
-    }
-
-    {
-        const data = patch<Order>({ id: 5, 'shippingAddress.street': 123 }, undefined, undefined, underscoreNamingStrategy);
-        expect(data).toEqual({ id: 5, 'shipping_address.street': '123' });
-    }
-
-    //no validation for the moment until object reference->primary key validation is implemented for the ORM
-    // {
-    //     expect(() => patch<Order>({ 'shippingAddress.street': 12 }, undefined, undefined, underscoreNamingStrategy)).toThrow('Min length is 3');
-    // }
-
-    {
-        //index signature are not touched by naming strategy
-        const data = patch<Order>({ id: 5, 'shippingAddress.additional.randomName': 12 }, undefined, undefined, underscoreNamingStrategy);
-        expect(data).toEqual({ id: 5, 'shipping_address.additional.randomName': '12' });
-    }
-});
-
-test('extend with custom type', () => {
-    type StringifyTransport = { __meta?: never & ['stringifyTransport'] };
-
-    function isStringifyTransportType(type: Type): boolean {
-        return !!metaAnnotation.getForName(type, 'stringifyTransport');
-    }
-
-    serializer.serializeRegistry.addPostHook((type, state) => {
-        if (!isStringifyTransportType(type)) return;
-        state.addSetter(`JSON.stringify(${state.accessor})`);
-    });
-    serializer.deserializeRegistry.addPreHook((type, state) => {
-        if (!isStringifyTransportType(type)) return;
-        state.addSetter(`JSON.parse(${state.accessor})`);
     });
 
-    class MyType {
-        test!: string;
-    }
+    test('tuple rest' + sfx, () => {
+        {
+            const value = cast<[...string[], number]>([12, '13']);
+            expect(value).toEqual(['12', 13]);
+        }
+        {
+            const value = cast<[...string[], number]>([12, 13, '14']);
+            expect(value).toEqual(['12', '13', 14]);
+        }
+        {
+            const value = cast<[boolean, ...string[], number]>([1, 12, '13']);
+            expect(value).toEqual([true, '12', 13]);
+        }
+        {
+            const value = cast<[boolean, ...string[], number]>([1, 12, 13, '14']);
+            expect(value).toEqual([true, '12', '13', 14]);
+        }
+        {
+            const value = serialize<[boolean, ...string[], number]>([true, '12', 13]);
+            expect(value).toEqual([true, '12', 13]);
+        }
+    });
 
-    class Entity {
-        obj: MyType & StringifyTransport = { test: 'abc' };
-    }
+    test('set' + sfx, () => {
+        {
+            const value = cast<Set<string>>(['a', 'a', 'b']);
+            expect(value).toEqual(new Set(['a', 'b']));
+        }
+        {
+            const value = cast<Set<string>>(['a', 2, 'b']);
+            expect(value).toEqual(new Set(['a', '2', 'b']));
+        }
+        {
+            const value = serialize<Set<string>>(new Set(['a', 'b']));
+            expect(value).toEqual(['a', 'b']);
+        }
+    });
 
-    const e = new Entity();
-    const s = serialize<Entity>(e, undefined, serializer);
-    expect(s.obj).toBe('{"test":"abc"}');
-    const d = deserialize<Entity>(s, undefined, serializer);
-    expect(d.obj).toEqual({ test: 'abc' });
-});
+    test('map' + sfx, () => {
+        {
+            const value = cast<Map<string, number>>([['a', 1], ['a', 2], ['b', 3]]);
+            expect(value).toEqual(new Map([['a', 2], ['b', 3]]));
+        }
+        {
+            const value = cast<Map<string, number>>([['a', 1], [2, '2'], ['b', 3]]);
+            expect(value).toEqual(new Map([['a', 1], ['2', 2], ['b', 3]]));
+        }
+        {
+            const value = serialize<Map<string, number>>(new Map([['a', 2], ['b', 3]]));
+            expect(value).toEqual([['a', 2], ['b', 3]]);
+        }
+    });
 
-test('issue-415: serialize literal types in union', () => {
-    enum MyEnum {
-        VALUE_0 = 0,
-        VALUE_180 = 180
-    }
+    test('number' + sfx, () => {
+        expect(cast<number>(1)).toBe(1);
+        expect(cast<number>(-1)).toBe(-1);
+        expect(cast<number>(true)).toBe(1);
+        expect(cast<number>(false)).toBe(0);
+        expect(cast<number>('1')).toBe(1);
+        expect(cast<number>('-1')).toBe(-1);
+    });
 
-    class Data {
-        rotate: MyEnum.VALUE_180 | MyEnum.VALUE_0 = MyEnum.VALUE_0;
-    }
+    test('union string number' + sfx, () => {
+        expect(cast<string | number>('a')).toEqual('a');
+        expect(cast<string | number>(2)).toEqual(2);
 
-    expect(deserialize<Data>({ rotate: 0 }, { loosely: true }).rotate).toBe(0);
-    expect(deserialize<Data>({ rotate: '0' }, { loosely: true }).rotate).toBe(0);
-    expect(deserialize<Data>({ rotate: 180 }, { loosely: true }).rotate).toBe(180);
-    expect(deserialize<Data>({ rotate: '180' }, { loosely: true }).rotate).toBe(180);
-    expect(deserialize<Data>({ rotate: 123456 }, { loosely: true }).rotate).toBe(0);
-});
+        expect(cast<string | integer>(2)).toEqual(2);
+        expect(cast<string | integer>('3', { loosely: false })).toEqual('3');
+        expect(cast<string | integer>('3')).toEqual(3);
+
+        expect(cast<string | integer>(2.2)).toEqual(2);
+        expect(cast<string | integer>('2.2', { loosely: false })).toEqual('2.2');
+        expect(cast<string | integer>('2.2')).toEqual(2);
+
+        expect(cast<string | integer>(false)).toEqual('false');
+        expect(cast<string | integer>(true)).toEqual('true');
+    });
+
+    test('union boolean number' + sfx, () => {
+        expect(cast<boolean | number>(2)).toEqual(2);
+        expect(cast<boolean | number>(1)).toEqual(1);
+        expect(cast<boolean | number>(0)).toEqual(0);
+        expect(cast<boolean | number>(false)).toEqual(false);
+        expect(cast<boolean | number>(true)).toEqual(true);
+    });
+
+    test('disabled loosely throws for primitives' + sfx, () => {
+        expect(cast<string>(23)).toEqual('23');
+        expect(cast<string>(23)).toEqual('23');
+        expect(() => cast<string>(23, { loosely: false })).toThrow('Validation error');
+
+        expect(cast<number>('23')).toEqual(23);
+        expect(cast<number>('23')).toEqual(23);
+        expect(() => cast<number>('23', { loosely: false })).toThrow('Validation error');
+
+        expect(cast<boolean>(1)).toEqual(true);
+        expect(cast<boolean>(1)).toEqual(true);
+        expect(() => cast<boolean>(1, { loosely: false })).toThrow('Validation error');
+    });
+
+    test('union loose string number' + sfx, () => {
+        expect(cast<string | number>('a')).toEqual('a');
+        expect(cast<string | number>(2)).toEqual(2);
+        expect(cast<string | number>(-2)).toEqual(-2);
+
+        expect(cast<string | integer>(2)).toEqual(2);
+        expect(cast<string | integer>('3')).toEqual(3);
+
+        expect(cast<string | integer>(2.2)).toEqual(2);
+        expect(cast<string | integer>(-2.2)).toEqual(-2);
+        expect(cast<string | integer>('2.2')).toEqual(2);
+        expect(cast<string | integer>(false)).toEqual('false');
+        expect(cast<string | integer>(true)).toEqual('true');
+    });
+
+    test('union loose string boolean' + sfx, () => {
+        expect(cast<string | boolean>('a')).toEqual('a');
+        expect(cast<string | boolean>(1)).toEqual(true);
+        expect(cast<string | boolean>(0)).toEqual(false);
+        expect(cast<string | boolean>(-1)).toEqual('-1');
+        expect(cast<string | boolean>(2)).toEqual('2');
+        expect(cast<string | boolean>('true')).toEqual(true);
+        expect(cast<string | boolean>('true2')).toEqual('true2');
+    });
+
+    test('union loose number boolean' + sfx, () => {
+        expect(() => cast<number | boolean>('a')).toThrow('Validation error for type');
+        expect(deserialize<number | boolean>('a')).toEqual(undefined);
+        expect(cast<string | boolean>(1)).toEqual(true);
+        expect(cast<number | boolean>(1)).toEqual(1);
+        expect(cast<string | boolean>('1')).toEqual(true);
+        expect(cast<number | boolean>('1')).toEqual(1);
+        expect(cast<number | boolean>('1')).toEqual(1);
+        expect(cast<string | boolean>(0)).toEqual(false);
+        expect(cast<number | boolean>(0)).toEqual(0);
+        expect(cast<number | boolean>(-1)).toEqual(-1);
+        expect(cast<number | boolean>(2)).toEqual(2);
+        expect(cast<number | boolean>('2')).toEqual(2);
+        expect(cast<number | boolean>('true')).toEqual(true);
+        expect(() => cast<number | boolean>('true', { loosely: false })).toThrow('Validation error for type');
+        expect(() => cast<number | boolean>('true2', { loosely: false })).toThrow('Validation error for type');
+        expect(deserialize<number | boolean>('true2')).toEqual(undefined);
+    });
+
+    test('union string date' + sfx, () => {
+        expect(cast<string | Date>('a')).toEqual('a');
+        expect(cast<string | Date>('2021-11-24T16:21:13.425Z')).toBeInstanceOf(Date);
+        expect(cast<string | Date>(1637781902866)).toBeInstanceOf(Date);
+        expect(cast<string | Date>('1637781902866')).toBe('1637781902866');
+        expect(cast<(string | Date)[]>(['2021-11-24T16:21:13.425Z'])[0]).toBeInstanceOf(Date);
+    });
+
+    test('union string bigint' + sfx, () => {
+        expect(cast<string | bigint>('a')).toEqual('a');
+        expect(cast<string | bigint>(2n)).toEqual(2n);
+        expect(cast<string | bigint>(2)).toEqual(2n);
+        expect(cast<string | bigint>('2', { loosely: false })).toEqual('2');
+        expect(cast<string | bigint>('2')).toEqual(2n);
+        expect(cast<string | bigint>('2a')).toEqual('2a');
+    });
+
+    test('union loose string bigint' + sfx, () => {
+        expect(cast<string | bigint>('a')).toEqual('a');
+        expect(cast<string | bigint>(2n)).toEqual(2n);
+        expect(cast<string | bigint>(2)).toEqual(2n);
+        expect(cast<string | bigint>('2')).toEqual(2n);
+        expect(cast<string | bigint>('2a')).toEqual('2a');
+    });
+
+    test('BinaryBigInt' + sfx, () => {
+        expect(serialize<bigint>(24n)).toBe('24');
+        expect(serialize<BinaryBigInt>(24n)).toBe('24');
+        expect(serialize<BinaryBigInt>(-4n)).toBe('0');
+
+        expect(deserialize<BinaryBigInt>(24n)).toBe(24n);
+        expect(deserialize<BinaryBigInt>('24')).toBe(24n);
+        expect(deserialize<BinaryBigInt>(-4n)).toBe(0n);
+        expect(deserialize<BinaryBigInt>('-4')).toBe(0n);
+
+        expect(serialize<SignedBinaryBigInt>(24n)).toBe('24');
+        expect(serialize<SignedBinaryBigInt>(-4n)).toBe('-4');
+        expect(deserialize<SignedBinaryBigInt>(24n)).toBe(24n);
+        expect(deserialize<SignedBinaryBigInt>('24')).toBe(24n);
+        expect(deserialize<SignedBinaryBigInt>(-4n)).toBe(-4n);
+        expect(deserialize<SignedBinaryBigInt>('-4')).toBe(-4n);
+    });
+
+    test('literal' + sfx, () => {
+        expect(cast<'a'>('a')).toEqual('a');
+        expect(serialize<'a'>('a')).toEqual('a');
+        expect(cast<'a'>('b')).toEqual('a');
+        expect(cast<'a'>(123)).toEqual('a');
+        expect(cast<1>(123)).toEqual(1);
+        expect(cast<1>('123')).toEqual(1);
+        expect(cast<true>('123')).toEqual(true);
+        expect(cast<1n>('123')).toEqual(1n);
+        expect(cast<1n>('123')).toEqual(1n);
+
+        expect(serialize<1n>(1n)).toEqual(1n);
+    });
+
+    test('cast runs validators' + sfx, () => {
+        type Username = string & MinLength<3> & MaxLength<23> & Alphanumeric;
+        expect(() => cast<Username>('ab')).toThrow('Validation error for type');
+        expect(() => cast<Username>('$ab')).toThrow('Validation error for type');
+        expect(cast<Username>('Peter')).toBe('Peter');
+    });
+
+    test('union literal' + sfx, () => {
+        expect(cast<'a' | number>('a')).toEqual('a');
+        expect(cast<'a' | number>(23)).toEqual(23);
+        expect(serialize<'a' | number>('a')).toEqual('a');
+        expect(serialize<'a' | number>(23)).toEqual(23);
+
+        expect(cast<3 | number>(23)).toEqual(23);
+        expect(cast<3 | number>(3)).toEqual(3);
+        expect(serialize<3 | number>(23)).toEqual(23);
+        expect(serialize<3 | number>(3)).toEqual(3);
+
+        expect(cast<3 | boolean>(3)).toEqual(3);
+        expect(cast<true | boolean>(true)).toEqual(true);
+        expect(cast<true | boolean>(false)).toEqual(false);
+        expect(cast<false | boolean>(true)).toEqual(true);
+        expect(cast<false | boolean>(false)).toEqual(false);
+    });
+
+    test('union primitive and class' + sfx, () => {
+        class User {
+            id!: number;
+        }
+
+        expect(cast<number | User>(2)).toEqual(2);
+        expect(cast<number | User>('2')).toEqual(2);
+        expect(cast<number | User>({ id: 23 })).toEqual({ id: 23 });
+        expect(cast<number | User>({ id: 23 })).toBeInstanceOf(User);
+        expect(() => cast<number | User>('2asd')).toThrow('Validation error for type');
+
+        expect(serialize<number | User>(2)).toEqual(2);
+        expect(serialize<number | User>({ id: 23 })).toEqual({ id: 23 });
+        expect(serialize<number | User>({ id: 23 })).toBeInstanceOf(Object);
+    });
+
+    test('union multiple classes' + sfx, () => {
+        class User {
+            id!: number;
+            username!: string;
+        }
+
+        class Picture {
+            id!: number;
+            path!: string;
+        }
+
+        expect(cast<Picture | User>({ id: 23, username: 'peter' })).toEqual({ id: 23, username: 'peter' });
+        expect(cast<Picture | User>({ id: 23, username: 'peter' })).toBeInstanceOf(User);
+
+        expect(cast<Picture | User>({ id: 23, path: 'src/path' })).toEqual({ id: 23, path: 'src/path' });
+        expect(cast<Picture | User>({ id: 23, path: 'src/path' })).toBeInstanceOf(Picture);
+
+        expect(cast<number | User>(23)).toEqual(23);
+        expect(cast<number | User>({ id: 23, username: 'peter' })).toBeInstanceOf(User);
+
+        expect(serialize<Picture | User>({ id: 23, username: 'peter' })).toEqual({ id: 23, username: 'peter' });
+        expect(serialize<Picture | User>({ id: 23, username: 'peter' })).toBeInstanceOf(Object);
+
+        expect(serialize<Picture | User>({ id: 23, path: 'src/path' })).toEqual({ id: 23, path: 'src/path' });
+        expect(serialize<Picture | User>({ id: 23, path: 'src/path' })).toBeInstanceOf(Object);
+
+        expect(serialize<number | User>(23)).toEqual(23);
+        expect(serialize<number | User>({ id: 23, username: 'peter' })).toBeInstanceOf(Object);
+        expect(serialize<number | User>({ id: 23, username: 'peter' })).toEqual({ id: 23, username: 'peter' });
+    });
+
+    test('brands' + sfx, () => {
+        expect(cast<number & PrimaryKey>(2)).toEqual(2);
+        expect(cast<number & PrimaryKey>('2')).toEqual(2);
+
+        expect(serialize<number & PrimaryKey>(2)).toEqual(2);
+    });
+
+    test('throw' + sfx, () => {
+        expect(() => cast<number>('123abc')).toThrow('Cannot convert 123abc to number');
+        expect(() => cast<{ a: string }>(false)).toThrow('Cannot convert false to {a: string}');
+        expect(() => cast<{ a: number }>({ a: 'abc' })).toThrow('Cannot convert abc to number');
+        expect(() => cast<{ a: { b: number } }>({ a: 'abc' })).toThrow('Cannot convert abc to {b: number}');
+        expect(() => cast<{ a: { b: number } }>({ a: { b: 'abc' } })).toThrow('Cannot convert abc to number');
+    });
+
+    test('index signature ' + sfx, () => {
+        interface BagOfNumbers {
+            [name: string]: number;
+        }
+
+        interface BagOfStrings {
+            [name: string]: string;
+        }
+
+        expect(cast<BagOfNumbers>({ a: 1 })).toEqual({ a: 1 });
+        expect(cast<BagOfNumbers>({ a: 1, b: 2 })).toEqual({ a: 1, b: 2 });
+        expect(() => cast<BagOfNumbers>({ a: 'b' })).toThrow(ValidationError as any);
+        expect(() => cast<BagOfNumbers>({ a: 'b' })).toThrow('Cannot convert b to number');
+        expect(cast<BagOfNumbers>({ a: '1' })).toEqual({ a: 1 });
+        expect(() => cast<BagOfNumbers>({ a: 'b', b: 'c' })).toThrow(ValidationError as any);
+        expect(() => cast<BagOfNumbers>({ a: 'b', b: 'c' })).toThrow('Cannot convert b to number');
+
+        expect(cast<BagOfStrings>({ a: 1 })).toEqual({ a: '1' });
+        expect(cast<BagOfStrings>({ a: 1, b: 2 })).toEqual({ a: '1', b: '2' });
+        expect(cast<BagOfStrings>({ a: 'b' })).toEqual({ a: 'b' });
+        expect(cast<BagOfStrings>({ a: 'b', b: 'c' })).toEqual({ a: 'b', b: 'c' });
+
+        expect(serialize<BagOfNumbers>({ a: 1 })).toEqual({ a: 1 });
+        expect(serialize<BagOfStrings>({ a: '1' })).toEqual({ a: '1' });
+    });
+
+    test('exclude' + sfx, () => {
+        class User {
+            username!: string;
+
+            password?: string & Excluded<'*'>;
+        }
+
+        const reflection = ReflectionClass.from(User);
+        expect(reflection.getProperty('password')?.getExcluded()).toEqual(['*']);
+
+        expect(cast<User>({ username: 'peter', password: 'nope' })).toEqual({ username: 'peter', password: undefined });
+        expect(serialize<User>({ username: 'peter', password: 'nope' })).toEqual({ username: 'peter', password: undefined });
+    });
+
+    test('regexp direct' + sfx, () => {
+        expect(cast<RegExp>(/abc/).toString()).toEqual('/abc/');
+        expect(cast<RegExp>('/abc/').toString()).toEqual('/abc/');
+        expect(cast<RegExp>('abc').toString()).toEqual('/abc/');
+        expect(serialize<RegExp>(/abc/).toString()).toEqual('/abc/');
+    });
+
+    test('regexp union' + sfx, () => {
+        expect(cast<string | { $regex: RegExp }>({ $regex: /abc/ })).toEqual({ $regex: /abc/ });
+        expect(cast<Record<string, string | { $regex: RegExp }>>({ a: { $regex: /abc/ } })).toEqual({ a: { $regex: /abc/ } });
+    });
+
+    test('index signature with template literal' + sfx, () => {
+        type a1 = { [index: `a${number}`]: number };
+        expect(cast<a1>({ a123: '123' })).toEqual({ a123: 123 });
+        expect(cast<a1>({ a123: '123', b: 123 })).toEqual({ a123: 123, b: undefined });
+        expect(cast<a1>({ a123: '123', a124: 123 })).toEqual({ a123: 123, a124: 123 });
+    });
+
+    test('class circular reference' + sfx, () => {
+        class User {
+            constructor(public username: string) {
+            }
+
+            manager?: User;
+        }
+
+        const res = cast<User>({ username: 'Horst', manager: { username: 'Peter' } });
+        expect(res).toEqual({ username: 'Horst', manager: { username: 'Peter' } });
+        expect(res).toBeInstanceOf(User);
+        expect(res.manager).toBeInstanceOf(User);
+    });
+
+    test('class with reference' + sfx, () => {
+        class User {
+            id: number & PrimaryKey = 0;
+
+            constructor(public username: string) {
+            }
+        }
+
+        interface Team {
+            lead: User & Reference;
+        }
+
+        {
+            const res = cast<Team>({ lead: { id: 1, username: 'Peter' } });
+            expect(res).toEqual({ lead: { id: 1, username: 'Peter' } });
+            expect(res.lead).toBeInstanceOf(User);
+            expect(isReferenceInstance(res.lead)).toBe(false);
+        }
+
+        {
+            const res = cast<Team>({ lead: { id: 1 } });
+            expect(res).toEqual({ lead: { id: 1 } });
+            expect(res.lead).toBeInstanceOf(User);
+            expect(isReferenceInstance(res.lead)).toBe(true);
+        }
+
+        {
+            const res = cast<Team>({ lead: { username: 'Peter' } });
+            expect(res).toEqual({ lead: { id: 0, username: 'Peter' } });
+            expect(res.lead).toBeInstanceOf(User);
+        }
+
+        {
+            const res = cast<Team>({ lead: 23 });
+            expect(res).toEqual({ lead: { id: 23 } });
+            expect(res.lead).toBeInstanceOf(User);
+            expect(getClassName(res.lead)).toBe('UserReference');
+        }
+    });
+
+    test('class with back reference' + sfx, () => {
+        class User {
+            id: number & PrimaryKey = 0;
+
+            constructor(public username: string) {
+            }
+        }
+
+        interface Team {
+            leads: User[] & BackReference;
+        }
+
+        const res = cast<Team>({ leads: [{ username: 'Peter' }] });
+        expect(res).toEqual({ leads: [{ id: 0, username: 'Peter' }] });
+        expect(res.leads[0]).toBeInstanceOf(User);
+    });
+
+    test('embedded single' + sfx, () => {
+        class Price {
+            constructor(public amount: integer) {
+            }
+        }
+
+        class Product {
+            constructor(public title: string, public price: Embedded<Price>) {
+            }
+        }
+
+        expect(serialize<Embedded<Price>>(new Price(34))).toEqual(34);
+        expect(serialize<Embedded<Price>[]>([new Price(34)])).toEqual([34]);
+        expect(serialize<Embedded<Price, { prefix: '' }>[]>([new Price(34)])).toEqual([34]);
+        expect(serialize<Embedded<Price, { prefix: 'price_' }>[]>([new Price(34)])).toEqual([34]);
+        expect(serialize<{ a: Embedded<Price> }>({ a: new Price(34) })).toEqual({ a: 34 });
+        expect(serialize<{ a: Embedded<Price, { prefix: '' }> }>({ a: new Price(34) })).toEqual({ amount: 34 });
+        expect(serialize<{ a: Embedded<Price, { prefix: 'price_' }> }>({ a: new Price(34) })).toEqual({ price_amount: 34 });
+        expect(serialize<Product>(new Product('Brick', new Price(34)))).toEqual({ title: 'Brick', price: 34 });
+
+        expect(deserialize<Embedded<Price>>(34)).toEqual(new Price(34));
+        expect(deserialize<Embedded<Price>[]>([34])).toEqual([new Price(34)]);
+        expect(deserialize<(Embedded<Price> | string)[]>([34])).toEqual([new Price(34)]);
+        expect(deserialize<(Embedded<Price> | string)[]>(['abc'])).toEqual(['abc']);
+        expect(deserialize<Embedded<Price, { prefix: '' }>[]>([34])).toEqual([new Price(34)]);
+        expect(deserialize<Embedded<Price, { prefix: 'price_' }>[]>([34])).toEqual([new Price(34)]);
+        expect(deserialize<{ a: Embedded<Price> }>({ a: 34 })).toEqual({ a: new Price(34) });
+        expect(deserialize<{ a: Embedded<Price, { prefix: '' }> }>({ amount: 34 })).toEqual({ a: new Price(34) });
+        expect(deserialize<{ a: Embedded<Price, { prefix: 'price_' }> }>({ price_amount: 34 })).toEqual({ a: new Price(34) });
+        expect(deserialize<Product>({ title: 'Brick', price: 34 })).toEqual(new Product('Brick', new Price(34)));
+
+        // check if union works correctly
+        expect(serialize<{ v: Embedded<Price> | string }>({ v: new Price(34) })).toEqual({ v: 34 });
+        expect(serialize<{ v: Embedded<Price> | string }>({ v: '123' })).toEqual({ v: '123' });
+        expect(serialize<(Embedded<Price> | string)[]>([new Price(34)])).toEqual([34]);
+        expect(serialize<(Embedded<Price> | string)[]>(['abc'])).toEqual(['abc']);
+        expect(serialize<{ v: Embedded<Price, { prefix: '' }> | string }>({ v: new Price(34) })).toEqual({ amount: 34 });
+        expect(serialize<{ v: Embedded<Price, { prefix: '' }> | string }>({ v: '34' })).toEqual({ v: '34' });
+        expect(serialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ v: new Price(34) })).toEqual({ price_amount: 34 });
+        expect(serialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ v: '34' })).toEqual({ v: '34' });
+
+        expect(deserialize<{ v: Embedded<Price> | string }>({ v: 34 })).toEqual({ v: new Price(34) });
+        expect(deserialize<{ v: Embedded<Price> | string }>({ v: '123' })).toEqual({ v: '123' });
+        expect(deserialize<{ v: Embedded<Price, { prefix: '' }> | string }>({ amount: 34 })).toEqual({ v: new Price(34) });
+        expect(deserialize<{ v: Embedded<Price, { prefix: '' }> | string }>({ v: '34' })).toEqual({ v: '34' });
+        expect(deserialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ price_amount: 34 })).toEqual({ v: new Price(34) });
+        expect(deserialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ v: '34' })).toEqual({ v: '34' });
+
+    });
+
+    test('embedded single optional' + sfx, () => {
+        class Price {
+            constructor(public amount: integer) {
+            }
+        }
+
+        expect(deserialize<{ v?: Embedded<Price> }>({ v: 34 })).toEqual({ v: new Price(34) });
+        expect(deserialize<{ v?: Embedded<Price> }>({})).toEqual({});
+        expect(deserialize<{ v?: Embedded<Price, { prefix: '' }> }>({ amount: 34 })).toEqual({ v: new Price(34) });
+        expect(deserialize<{ v?: Embedded<Price, { prefix: '' }> }>({})).toEqual({});
+        expect(deserialize<{ v?: Embedded<Price, { prefix: 'price_' }> }>({ price_amount: 34 })).toEqual({ v: new Price(34) });
+        expect(deserialize<{ v?: Embedded<Price, { prefix: 'price_' }> }>({})).toEqual({});
+
+        class Product1 {
+            constructor(public title: string, public price: Embedded<Price> = new Price(15)) {
+            }
+        }
+
+        class Product2 {
+            constructor(public title: string, public price?: Embedded<Price>) {
+            }
+        }
+
+        class Product3 {
+            public price: Embedded<Price> | undefined = new Price(15);
+        }
+
+        class Product4 {
+            public price: Embedded<Price> | null = new Price(15);
+        }
+
+        expect(deserialize<{ a?: Embedded<Price> }>({})).toEqual({});
+        expect(deserialize<{ a?: Embedded<Price> }>({ a: undefined })).toEqual({});
+        expect(deserialize<{ a?: Embedded<Price, { prefix: '' }> }>({})).toEqual({});
+        expect(deserialize<{ a?: Embedded<Price, { prefix: '' }> }>({ amount: undefined })).toEqual({});
+        expect(deserialize<{ a?: Embedded<Price, { prefix: 'price_' }> }>({})).toEqual({});
+        expect(deserialize<{ a?: Embedded<Price, { prefix: 'price_' }> }>({ price_amount: undefined })).toEqual({});
+        expect(deserialize<Product1>({ title: 'Brick' })).toEqual(new Product1('Brick'));
+        expect(deserialize<Product2>({ title: 'Brick' })).toEqual(new Product2('Brick'));
+        expect(deserialize<Product3>({})).toEqual({ price: new Price(15) });
+        expect(deserialize<Product3>({ price: null })).toEqual({ price: undefined });
+        expect(deserialize<Product4>({ price: undefined })).toEqual({ price: null });
+        expect(deserialize<Product4>({})).toEqual({ price: null });
+        expect(deserialize<Product4>({ price: null })).toEqual({ price: null });
+    });
+
+    test('embedded multi parameter' + sfx, () => {
+        class Price {
+            constructor(public amount: integer, public currency: string = 'EUR') {
+            }
+        }
+
+        class Product {
+            constructor(public title: string, public price: Embedded<Price>) {
+            }
+        }
+
+        expect(serialize<Embedded<Price>>(new Price(34))).toEqual({ amount: 34, currency: 'EUR' });
+        expect(serialize<Embedded<Price>[]>([new Price(34)])).toEqual([{ amount: 34, currency: 'EUR' }]);
+        expect(serialize<Embedded<Price, { prefix: '' }>[]>([new Price(34)])).toEqual([{ amount: 34, currency: 'EUR' }]);
+        expect(serialize<Embedded<Price, { prefix: 'price_' }>[]>([new Price(34)])).toEqual([{ price_amount: 34, price_currency: 'EUR' }]);
+        expect(serialize<{ a: Embedded<Price> }>({ a: new Price(34) })).toEqual({ a_amount: 34, a_currency: 'EUR' });
+        expect(serialize<{ a: Embedded<Price, { prefix: '' }> }>({ a: new Price(34) })).toEqual({ amount: 34, currency: 'EUR' });
+        expect(serialize<{ a: Embedded<Price, { prefix: 'price_' }> }>({ a: new Price(34) })).toEqual({ price_amount: 34, price_currency: 'EUR' });
+        expect(serialize<Product>(new Product('Brick', new Price(34)))).toEqual({ title: 'Brick', price_amount: 34, price_currency: 'EUR' });
+
+        expect(deserialize<Embedded<Price>>({ amount: 34 })).toEqual(new Price(34));
+        expect(deserialize<Embedded<Price>>({ amount: 34, currency: '$' })).toEqual(new Price(34, '$'));
+        expect(deserialize<Embedded<Price>[]>([{ amount: 34 }])).toEqual([new Price(34)]);
+        expect(deserialize<Embedded<Price>[]>([{ amount: 34, currency: '$' }])).toEqual([new Price(34, '$')]);
+        expect(deserialize<Embedded<Price, { prefix: '' }>[]>([{ amount: 34 }])).toEqual([new Price(34)]);
+        expect(deserialize<Embedded<Price, { prefix: 'price_' }>[]>([{ price_amount: 34 }])).toEqual([new Price(34)]);
+        expect(deserialize<{ a: Embedded<Price> }>({ a_amount: 34 })).toEqual({ a: new Price(34) });
+        expect(deserialize<{ a: Embedded<Price, { prefix: '' }> }>({ amount: 34 })).toEqual({ a: new Price(34) });
+        expect(deserialize<{ a: Embedded<Price, { prefix: '' }> }>({ amount: 34, currency: '$' })).toEqual({ a: new Price(34, '$') });
+        expect(deserialize<{ a: Embedded<Price, { prefix: '' }> }>({ amount: 34, currency: undefined })).toEqual({ a: new Price(34) });
+        expect(deserialize<{ a: Embedded<Price, { prefix: 'price_' }> }>({ price_amount: 34 })).toEqual({ a: new Price(34) });
+        expect(deserialize<{ a: Embedded<Price, { prefix: 'price_' }> }>({ price_amount: 34, price_currency: '$' })).toEqual({ a: new Price(34, '$') });
+        expect(deserialize<Product>({ title: 'Brick', price_amount: 34 })).toEqual(new Product('Brick', new Price(34)));
+
+        //check if union works correctly
+        expect(serialize<{ v: Embedded<Price> | string }>({ v: new Price(34) })).toEqual({ v_amount: 34, v_currency: 'EUR' });
+        expect(serialize<{ v: Embedded<Price> | string }>({ v: new Price(34, '$') })).toEqual({ v_amount: 34, v_currency: '$' });
+        expect(serialize<{ v: Embedded<Price> | string }>({ v: '123' })).toEqual({ v: '123' });
+        expect(serialize<{ v: Embedded<Price, { prefix: '' }> | string }>({ v: new Price(34) })).toEqual({ amount: 34, currency: 'EUR' });
+        expect(serialize<{ v: Embedded<Price, { prefix: '' }> | string }>({ v: '34' })).toEqual({ v: '34' });
+        expect(serialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ v: new Price(34) })).toEqual({ price_amount: 34, price_currency: 'EUR' });
+        expect(serialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ v: '34' })).toEqual({ v: '34' });
+
+        expect(deserialize<{ v: Embedded<Price> | string }>({ v_amount: 34 })).toEqual({ v: new Price(34) });
+        expect(deserialize<{ v: Embedded<Price> | string }>({ v_amount: 34, v_currency: '$' })).toEqual({ v: new Price(34, '$') });
+        expect(deserialize<{ v: Embedded<Price> | string }>({ v: '123' })).toEqual({ v: '123' });
+        expect(deserialize<{ v: Embedded<Price, { prefix: '' }> | string }>({ amount: 34 })).toEqual({ v: new Price(34) });
+        expect(deserialize<{ v: Embedded<Price, { prefix: '' }> | string }>({ v: '34' })).toEqual({ v: '34' });
+        expect(deserialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ price_amount: 34 })).toEqual({ v: new Price(34) });
+        expect(deserialize<{ v: Embedded<Price, { prefix: 'price_' }> | string }>({ v: '34' })).toEqual({ v: '34' });
+    });
+
+    test('class inheritance' + sfx, () => {
+        abstract class Person {
+            id: number & PrimaryKey & AutoIncrement = 0;
+            firstName?: string;
+            lastName?: string;
+            abstract type: string;
+        }
+
+        class Employee extends Person {
+            email?: string;
+            type: 'employee' = 'employee';
+        }
+
+        class Freelancer extends Person {
+            @t budget: number = 10_000;
+            type: 'freelancer' = 'freelancer';
+        }
+
+        const employee = ReflectionClass.from(Employee);
+        expect(employee.getProperty('firstName').getKind()).toBe(ReflectionKind.string);
+        const scopeSerializer = getSerializeFunction(employee.type, testSerializer.serializeRegistry);
+
+        expect(scopeSerializer({ type: 'employee', firstName: 'Peter', email: 'test@example.com' })).toEqual({ type: 'employee', firstName: 'Peter', email: 'test@example.com' });
+    });
+
+    test('class with union literal' + sfx, () => {
+        class ConnectionOptions {
+            readConcernLevel: 'local' | 'majority' | 'linearizable' | 'available' = 'majority';
+        }
+
+        expect(cast<ConnectionOptions>({ readConcernLevel: 'majority' })).toEqual({ readConcernLevel: 'majority' });
+        expect(cast<ConnectionOptions>({ readConcernLevel: 'linearizable' })).toEqual({ readConcernLevel: 'linearizable' });
+        expect(cast<ConnectionOptions>({ readConcernLevel: 'unknown' })).toEqual({ readConcernLevel: 'majority' });
+    });
+
+    test('named tuple in error message' + sfx, () => {
+        expect(cast<[age: number]>([23])).toEqual([23]);
+        expect(() => cast<{ v: [age: number] }>({ v: ['123abc'] })).toThrow('v.age(type): Cannot convert 123abc to number');
+    });
+
+    test('intersected mapped type key' + sfx, () => {
+        type SORT_ORDER = 'asc' | 'desc' | any;
+        type Sort<T, ORDER extends SORT_ORDER = SORT_ORDER> = { [P in keyof T & string]?: ORDER };
+
+        interface A {
+            username: string;
+            id: number;
+        }
+
+        type sortA = Sort<A>;
+
+        expect(cast<sortA>({ username: 'asc' })).toEqual({ username: 'asc' });
+        expect(cast<sortA>({ id: 'desc', username: 'asc' })).toEqual({ id: 'desc', username: 'asc' });
+
+        type sortAny = Sort<any>;
+        expect(cast<sortAny>({ username: 'asc' })).toEqual({ username: 'asc' });
+        expect(cast<sortAny>({ id: 'desc', username: 'asc' })).toEqual({ id: 'desc', username: 'asc' });
+    });
+
+    test('wild property names' + sfx, () => {
+        interface A {
+            ['asd-344']: string;
+            ['#$%^^x']: number;
+        }
+
+        expect(deserialize<A>({ 'asd-344': 'abc', '#$%^^x': 3 })).toEqual({ 'asd-344': 'abc', '#$%^^x': 3 });
+    });
+
+    test('embedded with lots of properties' + sfx, () => {
+        interface LotsOfIt {
+            a?: string;
+            lot?: string;
+            of?: string;
+            additional?: string;
+            properties?: string;
+        }
+
+        class A {
+            constructor(public options: Embedded<LotsOfIt, { prefix: '' }> = {}) {
+            }
+        }
+
+        const back1 = deserialize<A>({ a: 'abc', lot: 'string' });
+        expect(back1.options).toEqual({ a: 'abc', lot: 'string' });
+
+        class A2 {
+            public options: Embedded<LotsOfIt, { prefix: '' }> = {};
+        }
+
+        const back2 = deserialize<A2>({ a: 'abc', lot: 'string' });
+        expect(back2.options).toEqual({ a: 'abc', lot: 'string' });
+    });
+
+    test('embedded in super class' + sfx, () => {
+        class Thread {
+            public parentThreadId?: string;
+            public senderOrder?: number;
+
+            constructor(
+                public id: string & MapName<'~thread'>
+            ) {
+            }
+        }
+
+        class ComposedMessage {
+            thread?: Embedded<Thread, { prefix: '' }>;
+        }
+
+        class Message extends ComposedMessage {
+            public readonly type: string = Message.type;
+            public static readonly type = 'my-id';
+
+            public routingKeys?: string[];
+            public endpoint?: string;
+        }
+
+        const back1 = deserialize<Message>({ '~thread': 'foo' });
+        expect(back1).toEqual({ type: Message.type, thread: { id: 'foo' } });
+
+        const plain = serialize<Message>(back1);
+        expect(plain).toEqual({ type: Message.type, parentThreadId: null, senderOrder: null, '~thread': 'foo' });
+    });
+
+    test('disabled constructor' + sfx, () => {
+        let called = false;
+
+        @entity.disableConstructor()
+        class User {
+            id: number = 0;
+            title: string = 'id:' + this.id;
+
+            constructor(public type: string) {
+                called = true;
+            }
+        }
+
+        expect(ReflectionClass.from(User).disableConstructor).toBe(true);
+
+        const user = deserialize<User>({ type: 'nix' });
+        expect(called).toBe(false);
+        expect(user).toBeInstanceOf(User);
+        expect(user).toEqual({ id: 0, title: 'id:' + 0, type: 'nix' });
+    });
+
+    test('readonly constructor properties' + sfx, () => {
+        class Pilot {
+            constructor(readonly name: string, readonly age: number) {
+            }
+        }
+
+        expect(cast<Pilot>({ name: 'Peter', age: 32 })).toEqual({ name: 'Peter', age: 32 });
+        expect(cast<Pilot>({ name: 'Peter', age: '32' })).toEqual({ name: 'Peter', age: 32 });
+    });
+
+    test('naming strategy prefix' + sfx, () => {
+        class MyNamingStrategy extends NamingStrategy {
+            constructor() {
+                super('my');
+            }
+
+            override getPropertyName(type: TypeProperty | TypePropertySignature, forSerializer: string): string | undefined {
+                return '_' + super.getPropertyName(type, forSerializer);
+            }
+        }
+
+        interface Post {
+            id: number;
+            likesCount: number;
+        }
+
+        interface User {
+            readonly id: number;
+            readonly posts: readonly Post[];
+        }
+
+        {
+            const res = serialize<User>({ id: 2, posts: [{ id: 3, likesCount: 1 }, { id: 4, likesCount: 2 }] }, undefined, undefined, new MyNamingStrategy);
+            expect(res).toEqual({ _id: 2, _posts: [{ _id: 3, _likesCount: 1 }, { _id: 4, _likesCount: 2 }] });
+        }
+
+        {
+            const res = deserialize<User>({ _id: 2, _posts: [{ _id: 3, _likesCount: 1 }, { _id: 4, _likesCount: 2 }] }, undefined, undefined, new MyNamingStrategy);
+            expect(res).toEqual({ id: 2, posts: [{ id: 3, likesCount: 1 }, { id: 4, likesCount: 2 }] });
+        }
+    });
+
+    test('naming strategy camel case' + sfx, () => {
+        const camelCaseToSnakeCase = (str: string) =>
+            str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+
+        class CamelCaseToSnakeCaseNamingStrategy extends NamingStrategy {
+            constructor() {
+                super('snake-case-to-camel-case');
+            }
+
+            override getPropertyName(
+                type: TypeProperty | TypePropertySignature,
+                forSerializer: string
+            ): string | undefined {
+                const propertyName = super.getPropertyName(type, forSerializer);
+                return propertyName ? camelCaseToSnakeCase(propertyName) : undefined;
+            }
+        }
+
+        interface Post {
+            id: number;
+            likesCount: number;
+        }
+
+        interface User {
+            id: number;
+            posts: Post[];
+        }
+
+        {
+            const res = serialize<User>({ id: 2, posts: [{ id: 3, likesCount: 1 }, { id: 4, likesCount: 2 }] }, undefined, undefined, new CamelCaseToSnakeCaseNamingStrategy);
+            expect(res).toEqual({ id: 2, posts: [{ id: 3, likes_count: 1 }, { id: 4, likes_count: 2 }] });
+        }
+
+        {
+            const res = deserialize<User>({ id: 2, posts: [{ id: 3, likes_count: 1 }, { id: 4, likes_count: 2 }] }, undefined, undefined, new CamelCaseToSnakeCaseNamingStrategy);
+            expect(res).toEqual({ id: 2, posts: [{ id: 3, likesCount: 1 }, { id: 4, likesCount: 2 }] });
+        }
+    });
+
+    test('enum union' + sfx, () => {
+        enum StatEnginePowerUnit {
+            Hp = 'hp',
+        }
+
+        enum StatWeightUnit {
+            Lbs = 'lbs',
+            Kg = 'kg',
+        }
+
+        type StatMeasurementUnit = StatEnginePowerUnit | StatWeightUnit;
+        const type = typeOf<StatMeasurementUnit>();
+        assertType(type, ReflectionKind.union);
+        expect(type.types.length).toBe(2);
+
+        expect(deserialize<StatMeasurementUnit>(StatWeightUnit.Kg)).toBe(StatWeightUnit.Kg);
+        expect(deserialize<StatMeasurementUnit>(StatWeightUnit.Lbs)).toBe(StatWeightUnit.Lbs);
+        expect(deserialize<StatMeasurementUnit>(StatEnginePowerUnit.Hp)).toBe(StatEnginePowerUnit.Hp);
+    });
+
+    test('union literals in union' + sfx, () => {
+        type StatWeightUnit = 'lbs' | 'kg';
+        type StatEnginePowerUnit = 'hp';
+
+        type StatMeasurementUnit = StatEnginePowerUnit | StatWeightUnit;
+        const type = typeOf<StatMeasurementUnit>();
+        assertType(type, ReflectionKind.union);
+        expect(type.types.length).toBe(3);
+
+        expect(deserialize<StatMeasurementUnit>('kg')).toBe('kg');
+        expect(deserialize<StatMeasurementUnit>('lbs')).toBe('lbs');
+        expect(deserialize<StatMeasurementUnit>('hp')).toBe('hp');
+    });
+
+    test('union literals in union imported' + sfx, () => {
+        type StatMeasurementUnit = StatEnginePowerUnit | StatWeightUnit;
+        const type = typeOf<StatMeasurementUnit>();
+        assertType(type, ReflectionKind.union);
+        expect(type.types.length).toBe(3);
+
+        expect(deserialize<StatMeasurementUnit>('kg')).toBe('kg');
+        expect(deserialize<StatMeasurementUnit>('lbs')).toBe('lbs');
+        expect(deserialize<StatMeasurementUnit>('hp')).toBe('hp');
+    });
+
+    test('function rest parameters' + sfx, () => {
+        type t = (start: number, ...rest: string[]) => void;
+        const fn = typeOf<t>();
+        assertType(fn, ReflectionKind.function);
+        {
+            const type = typeOf<Parameters<never>>([fn]); //same as Parameters<t>
+            expect(deserialize([2, '33', 44], undefined, undefined, undefined, type)).toEqual([2, '33', '44']);
+        }
+        {
+            const type = parametersToTuple(fn.parameters);
+            expect(deserialize([2, '33', 44], undefined, undefined, undefined, type)).toEqual([2, '33', '44']);
+        }
+    });
+
+    test('discriminated union with string date in type guard' + sfx, () => {
+        expect(is<number | string>(12)).toBe(true);
+        expect(is<number | string>('abc')).toBe(true);
+        expect(is<number | string>(false)).toBe(false);
+        expect(is<number | (string | bigint)[]>([false])).toBe(false);
+
+        {
+            type ModelB = { kind: 'b', date: Date };
+            const b1 = cast<ModelB>({ kind: 'b', date: '2020-08-05T00:00:00.000Z' });
+            expect(b1).toEqual({ kind: 'b', date: new Date('2020-08-05T00:00:00.000Z') });
+        }
+
+        {
+            type ModelA = { id: number, title: string };
+            type ModelB = { id: number, date: Date };
+            type Union = ModelA | ModelB;
+
+            const b2 = cast<Union>({ id: 1, date: '2020-08-05T00:00:00.000Z' });
+            expect(b2).toEqual({ id: 1, date: new Date('2020-08-05T00:00:00.000Z') });
+        }
+
+        {
+            type ModelA = { kind: 'a', title: string };
+            type ModelB = { kind: 'b', date: Date };
+            type Union = ModelA | ModelB;
+
+            const b2 = cast<Union>({ kind: 'b', date: '2020-08-05T00:00:00.000Z' });
+            expect(b2).toEqual({ kind: 'b', date: new Date('2020-08-05T00:00:00.000Z') });
+        }
+
+        {
+            type ModelA = { kind: 'a', title: string };
+            type ModelB = { kind: 'b', date: number | Date };
+            type Union = ModelA | ModelB;
+            const b2 = cast<Union>({ kind: 'b', date: '2020-08-05T00:00:00.000Z' });
+            expect(b2).toEqual({ kind: 'b', date: new Date('2020-08-05T00:00:00.000Z') });
+        }
+    });
+
+    test('date format' + sfx, () => {
+        const date = cast<number | Date>('2020-07-02T12:00:00Z');
+        expect(date).toEqual(new Date('2020-07-02T12:00:00Z'));
+    });
+
+
+    test('patch' + sfx, () => {
+        class Address {
+            street!: string & MinLength<3>;
+            streetNo!: string;
+            additional: { [name: string]: string } = {};
+        }
+
+        class Order {
+            id!: number;
+            shippingAddress!: Address;
+        }
+
+        {
+            const data = patch<Order>({ id: 5, 'shippingAddress.street': 123 }, undefined, undefined, underscoreNamingStrategy);
+            expect(data).toEqual({ id: 5, 'shipping_address.street': '123' });
+        }
+
+        //no validation for the moment until object reference->primary key validation is implemented for the ORM
+        // {
+        //     expect(() => patch<Order>({ 'shippingAddress.street': 12 }, undefined, undefined, underscoreNamingStrategy)).toThrow('Min length is 3');
+        // }
+
+        {
+            //index signature are not touched by naming strategy
+            const data = patch<Order>({ id: 5, 'shippingAddress.additional.randomName': 12 }, undefined, undefined, underscoreNamingStrategy);
+            expect(data).toEqual({ id: 5, 'shipping_address.additional.randomName': '12' });
+        }
+    });
+
+    test('extend with custom type' + sfx, () => {
+        type StringifyTransport = { __meta?: never & ['stringifyTransport'] };
+
+        function isStringifyTransportType(type: Type): boolean {
+            return !!metaAnnotation.getForName(type, 'stringifyTransport');
+        }
+
+        testSerializer.serializeRegistry.addPostHook((type, state) => {
+            if (!isStringifyTransportType(type)) return;
+            state.addSetter(`JSON.stringify(${state.accessor})`);
+        });
+        testSerializer.deserializeRegistry.addPreHook((type, state) => {
+            if (!isStringifyTransportType(type)) return;
+            state.addSetter(`JSON.parse(${state.accessor})`);
+        });
+
+        class MyType {
+            test!: string;
+        }
+
+        class Entity {
+            obj: MyType & StringifyTransport = { test: 'abc' };
+        }
+
+        const e = new Entity();
+        const s = serialize<Entity>(e, undefined, testSerializer);
+        expect(s.obj).toBe('{"test":"abc"}');
+        const d = deserialize<Entity>(s, undefined, testSerializer);
+        expect(d.obj).toEqual({ test: 'abc' });
+    });
+
+    test('issue-415: serialize literal types in union' + sfx, () => {
+        enum MyEnum {
+            VALUE_0 = 0,
+            VALUE_180 = 180
+        }
+
+        class Data {
+            rotate: MyEnum.VALUE_180 | MyEnum.VALUE_0 = MyEnum.VALUE_0;
+        }
+
+        expect(deserialize<Data>({ rotate: 0 }, { loosely: true }).rotate).toBe(0);
+        expect(deserialize<Data>({ rotate: '0' }, { loosely: true }).rotate).toBe(0);
+        expect(deserialize<Data>({ rotate: 180 }, { loosely: true }).rotate).toBe(180);
+        expect(deserialize<Data>({ rotate: '180' }, { loosely: true }).rotate).toBe(180);
+        expect(deserialize<Data>({ rotate: 123456 }, { loosely: true }).rotate).toBe(0);
+    });
+}

--- a/packages/type/tests/typeguard.spec.ts
+++ b/packages/type/tests/typeguard.spec.ts
@@ -10,393 +10,400 @@
 import { expect, test } from '@jest/globals';
 import { float, float32, int8, integer, PrimaryKey, Reference } from '../src/reflection/type.js';
 import { is } from '../src/typeguard.js';
+import { serializer, quickSerializer, Serializer} from '../src/serializer.js';
 
-test('primitive string', () => {
-    expect(is<string>('a')).toEqual(true);
-    expect(is<string>(123)).toEqual(false);
-    expect(is<string>(true)).toEqual(false);
-    expect(is<string>({})).toEqual(false);
-});
+serializerSuit(serializer, 'serializer');
+serializerSuit(quickSerializer, 'Quick');
 
-test('primitive number', () => {
-    expect(is<number>('a')).toEqual(false);
-    expect(is<number>(123)).toEqual(true);
-    expect(is<number>(true)).toEqual(false);
-    expect(is<number>({})).toEqual(false);
-});
+function serializerSuit(testSerializer: Serializer, name: string) {
+    const sfx = ` ==> ${name}`;
+    test('primitive string' + sfx, () => {
+        expect(is<string>('a', testSerializer)).toEqual(true);
+        expect(is<string>(123, testSerializer)).toEqual(false);
+        expect(is<string>(true, testSerializer)).toEqual(false);
+        expect(is<string>({}, testSerializer)).toEqual(false);
+    });
 
-test('primitive number integer', () => {
-    expect(is<integer>('a')).toEqual(false);
-    expect(is<integer>(123)).toEqual(true);
-    expect(is<integer>(123.4)).toEqual(false);
-    expect(is<integer>(true)).toEqual(false);
-    expect(is<integer>({})).toEqual(false);
-});
+    test('primitive number' + sfx, () => {
+        expect(is<number>('a', testSerializer)).toEqual(false);
+        expect(is<number>(123, testSerializer)).toEqual(true);
+        expect(is<number>(true, testSerializer)).toEqual(false);
+        expect(is<number>({}, testSerializer)).toEqual(false);
+    });
 
-test('primitive number int8', () => {
-    expect(is<int8>('a')).toEqual(false);
-    expect(is<int8>(123)).toEqual(true);
-    expect(is<int8>(123.4)).toEqual(false);
-    expect(is<int8>(true)).toEqual(false);
-    expect(is<int8>({})).toEqual(false);
-    expect(is<int8>(127)).toEqual(true);
-    expect(is<int8>(128)).toEqual(false);
-    expect(is<int8>(-128)).toEqual(true);
-    expect(is<int8>(-129)).toEqual(false);
-    expect(is<int8>(129)).toEqual(false);
-});
+    test('primitive number integer' + sfx, () => {
+        expect(is<integer>('a', testSerializer)).toEqual(false);
+        expect(is<integer>(123, testSerializer)).toEqual(true);
+        expect(is<integer>(123.4, testSerializer)).toEqual(false);
+        expect(is<integer>(true, testSerializer)).toEqual(false);
+        expect(is<integer>({}, testSerializer)).toEqual(false);
+    });
 
-test('primitive number float', () => {
-    expect(is<float>('a')).toEqual(false);
-    expect(is<float>(123)).toEqual(true);
-    expect(is<float>(123.4)).toEqual(true);
-    expect(is<float>(true)).toEqual(false);
-    expect(is<float>({})).toEqual(false);
-});
+    test('primitive number int8' + sfx, () => {
+        expect(is<int8>('a', testSerializer)).toEqual(false);
+        expect(is<int8>(123, testSerializer)).toEqual(true);
+        expect(is<int8>(123.4, testSerializer)).toEqual(false);
+        expect(is<int8>(true, testSerializer)).toEqual(false);
+        expect(is<int8>({}, testSerializer)).toEqual(false);
+        expect(is<int8>(127, testSerializer)).toEqual(true);
+        expect(is<int8>(128, testSerializer)).toEqual(false);
+        expect(is<int8>(-128, testSerializer)).toEqual(true);
+        expect(is<int8>(-129, testSerializer)).toEqual(false);
+        expect(is<int8>(129, testSerializer)).toEqual(false);
+    });
 
-test('primitive number float32', () => {
-    expect(is<float32>('a')).toEqual(false);
-    expect(is<float32>(123)).toEqual(true);
-    expect(is<float32>(123.4)).toEqual(true);
-    expect(is<float32>(3.40282347e+38)).toEqual(true);
-    //JS precision issue:
-    expect(is<float32>(3.40282347e+38 + 100000000000000000000000)).toEqual(false);
-    expect(is<float32>(-3.40282347e+38)).toEqual(true);
-    expect(is<float32>(-3.40282347e+38 - 100000000000000000000000)).toEqual(false);
-    expect(is<float32>(true)).toEqual(false);
-    expect(is<float32>({})).toEqual(false);
-});
+    test('primitive number float' + sfx, () => {
+        expect(is<float>('a', testSerializer)).toEqual(false);
+        expect(is<float>(123, testSerializer)).toEqual(true);
+        expect(is<float>(123.4, testSerializer)).toEqual(true);
+        expect(is<float>(true, testSerializer)).toEqual(false);
+        expect(is<float>({}, testSerializer)).toEqual(false);
+    });
 
-test('enum', () => {
-    enum MyEnum {
-        a, b, c
-    }
+    test('primitive number float32' + sfx, () => {
+        expect(is<float32>('a', testSerializer)).toEqual(false);
+        expect(is<float32>(123, testSerializer)).toEqual(true);
+        expect(is<float32>(123.4, testSerializer)).toEqual(true);
+        expect(is<float32>(3.40282347e+38, testSerializer)).toEqual(true);
+        //JS precision issue:
+        expect(is<float32>(3.40282347e+38 + 100000000000000000000000, testSerializer)).toEqual(false);
+        expect(is<float32>(-3.40282347e+38, testSerializer)).toEqual(true);
+        expect(is<float32>(-3.40282347e+38 - 100000000000000000000000, testSerializer)).toEqual(false);
+        expect(is<float32>(true, testSerializer)).toEqual(false);
+        expect(is<float32>({}, testSerializer)).toEqual(false);
+    });
 
-    expect(is<MyEnum>(0)).toEqual(true);
-    expect(is<MyEnum>(1)).toEqual(true);
-    expect(is<MyEnum>(2)).toEqual(true);
-    expect(is<MyEnum>(3)).toEqual(false);
-    expect(is<MyEnum>(undefined)).toEqual(false);
-    expect(is<MyEnum>({})).toEqual(false);
-    expect(is<MyEnum>(true)).toEqual(false);
-});
+    test('enum' + sfx, () => {
+        enum MyEnum {
+            a, b, c
+        }
 
-test('enum const', () => {
-    const enum MyEnum {
-        a, b, c
-    }
+        expect(is<MyEnum>(0, testSerializer)).toEqual(true);
+        expect(is<MyEnum>(1, testSerializer)).toEqual(true);
+        expect(is<MyEnum>(2, testSerializer)).toEqual(true);
+        expect(is<MyEnum>(3, testSerializer)).toEqual(false);
+        expect(is<MyEnum>(undefined, testSerializer)).toEqual(false);
+        expect(is<MyEnum>({}, testSerializer)).toEqual(false);
+        expect(is<MyEnum>(true, testSerializer)).toEqual(false);
+    });
 
-    expect(is<MyEnum>(0)).toEqual(true);
-    expect(is<MyEnum>(1)).toEqual(true);
-    expect(is<MyEnum>(2)).toEqual(true);
-    expect(is<MyEnum>(3)).toEqual(false);
-    expect(is<MyEnum>(undefined)).toEqual(false);
-    expect(is<MyEnum>({})).toEqual(false);
-    expect(is<MyEnum>(true)).toEqual(false);
-});
+    test('enum const' + sfx, () => {
+        const enum MyEnum {
+            a, b, c
+        }
 
-test('enum string', () => {
-    enum MyEnum {
-        a = 'a', b = 'b', c = 'c'
-    }
+        expect(is<MyEnum>(0, testSerializer)).toEqual(true);
+        expect(is<MyEnum>(1, testSerializer)).toEqual(true);
+        expect(is<MyEnum>(2, testSerializer)).toEqual(true);
+        expect(is<MyEnum>(3, testSerializer)).toEqual(false);
+        expect(is<MyEnum>(undefined, testSerializer)).toEqual(false);
+        expect(is<MyEnum>({}, testSerializer)).toEqual(false);
+        expect(is<MyEnum>(true, testSerializer)).toEqual(false);
+    });
 
-    expect(is<MyEnum>('a')).toEqual(true);
-    expect(is<MyEnum>('b')).toEqual(true);
-    expect(is<MyEnum>('c')).toEqual(true);
-    expect(is<MyEnum>(0)).toEqual(false);
-    expect(is<MyEnum>(1)).toEqual(false);
-    expect(is<MyEnum>(2)).toEqual(false);
-    expect(is<MyEnum>(3)).toEqual(false);
-    expect(is<MyEnum>(undefined)).toEqual(false);
-    expect(is<MyEnum>({})).toEqual(false);
-    expect(is<MyEnum>(true)).toEqual(false);
-});
+    test('enum string' + sfx, () => {
+        enum MyEnum {
+            a = 'a', b = 'b', c = 'c'
+        }
 
-test('array string', () => {
-    expect(is<string[]>([])).toEqual(true);
-    expect(is<string[]>(['a'])).toEqual(true);
-    expect(is<string[]>(['a', 'b'])).toEqual(true);
-    expect(is<string[]>([1])).toEqual(false);
-    expect(is<string[]>([1, 2])).toEqual(false);
-    expect(is<string[]>(['a', 2])).toEqual(false);
-});
+        expect(is<MyEnum>('a', testSerializer)).toEqual(true);
+        expect(is<MyEnum>('b', testSerializer)).toEqual(true);
+        expect(is<MyEnum>('c', testSerializer)).toEqual(true);
+        expect(is<MyEnum>(0, testSerializer)).toEqual(false);
+        expect(is<MyEnum>(1, testSerializer)).toEqual(false);
+        expect(is<MyEnum>(2, testSerializer)).toEqual(false);
+        expect(is<MyEnum>(3, testSerializer)).toEqual(false);
+        expect(is<MyEnum>(undefined, testSerializer)).toEqual(false);
+        expect(is<MyEnum>({}, testSerializer)).toEqual(false);
+        expect(is<MyEnum>(true, testSerializer)).toEqual(false);
+    });
 
-test('tuple', () => {
-    expect(is<[string]>(['a'])).toEqual(true);
-    expect(is<[string]>([2])).toEqual(false);
-    expect(is<[string, string]>(['a', 'b'])).toEqual(true);
-    expect(is<[string, string]>(['a'])).toEqual(false);
-    expect(is<[string, number]>(['a', 3])).toEqual(true);
-    expect(is<[string, number]>(['a', undefined])).toEqual(false);
-    expect(is<[string, ...number[]]>(['a', 3])).toEqual(true);
-    expect(is<[string, ...number[]]>(['a', 3, 4])).toEqual(true);
-    expect(is<[string, ...number[]]>(['a', 3, 4, 5])).toEqual(true);
-    expect(is<[string, ...number[]]>([3, 3, 4, 5])).toEqual(false);
-});
+    test('array string' + sfx, () => {
+        expect(is<string[]>([], testSerializer)).toEqual(true);
+        expect(is<string[]>(['a'], testSerializer)).toEqual(true);
+        expect(is<string[]>(['a', 'b'], testSerializer)).toEqual(true);
+        expect(is<string[]>([1], testSerializer)).toEqual(false);
+        expect(is<string[]>([1, 2], testSerializer)).toEqual(false);
+        expect(is<string[]>(['a', 2], testSerializer)).toEqual(false);
+    });
 
-test('set', () => {
-    expect(is<Set<string>>(new Set(['a']))).toEqual(true);
-    expect(is<Set<string>>(new Set(['a', 'b']))).toEqual(true);
-    expect(is<Set<string>>(new Set(['a', 2]))).toEqual(false);
-    expect(is<Set<string>>(new Set([2, 3]))).toEqual(false);
-    expect(is<Set<string>>([2, 3])).toEqual(false);
-});
+    test('tuple' + sfx, () => {
+        expect(is<[string]>(['a'], testSerializer)).toEqual(true);
+        expect(is<[string]>([2], testSerializer)).toEqual(false);
+        expect(is<[string, string]>(['a', 'b'], testSerializer)).toEqual(true);
+        expect(is<[string, string]>(['a'], testSerializer)).toEqual(false);
+        expect(is<[string, number]>(['a', 3], testSerializer)).toEqual(true);
+        expect(is<[string, number]>(['a', undefined], testSerializer)).toEqual(false);
+        expect(is<[string, ...number[]]>(['a', 3], testSerializer)).toEqual(true);
+        expect(is<[string, ...number[]]>(['a', 3, 4], testSerializer)).toEqual(true);
+        expect(is<[string, ...number[]]>(['a', 3, 4, 5], testSerializer)).toEqual(true);
+        expect(is<[string, ...number[]]>([3, 3, 4, 5], testSerializer)).toEqual(false);
+    });
 
-test('map', () => {
-    expect(is<Map<string, number>>(new Map([['a', 1]]))).toEqual(true);
-    expect(is<Map<string, number>>(new Map([['a', 1], ['b', 2]]))).toEqual(true);
-    expect(is<Map<string, number>>(new Map<any, any>([['a', 1], ['b', 'b']]))).toEqual(false);
-    expect(is<Map<string, number>>(new Map<any, any>([[2, 1]]))).toEqual(false);
-});
+    test('set' + sfx, () => {
+        expect(is<Set<string>>(new Set(['a']), testSerializer)).toEqual(true);
+        expect(is<Set<string>>(new Set(['a', 'b']), testSerializer)).toEqual(true);
+        expect(is<Set<string>>(new Set(['a', 2]), testSerializer)).toEqual(false);
+        expect(is<Set<string>>(new Set([2, 3]), testSerializer)).toEqual(false);
+        expect(is<Set<string>>([2, 3], testSerializer)).toEqual(false);
+    });
 
-test('literal', () => {
-    expect(is<1>(1)).toEqual(true);
-    expect(is<1>(2)).toEqual(false);
-    expect(is<'abc'>('abc')).toEqual(true);
-    expect(is<'abc'>('ab')).toEqual(false);
-    expect(is<false>(false)).toEqual(true);
-    expect(is<false>(true)).toEqual(false);
-    expect(is<true>(true)).toEqual(true);
-    expect(is<true>(false)).toEqual(false);
-});
+    test('map' + sfx, () => {
+        expect(is<Map<string, number>>(new Map([['a', 1]]), testSerializer)).toEqual(true);
+        expect(is<Map<string, number>>(new Map([['a', 1], ['b', 2]]), testSerializer)).toEqual(true);
+        expect(is<Map<string, number>>(new Map<any, any>([['a', 1], ['b', 'b']]), testSerializer)).toEqual(false);
+        expect(is<Map<string, number>>(new Map<any, any>([[2, 1]]), testSerializer)).toEqual(false);
+    });
 
-test('any', () => {
-    expect(is<any>(['a'])).toEqual(true);
-    expect(is<any>([1])).toEqual(true);
-    expect(is<any>([true])).toEqual(true);
-    expect(is<any>([false])).toEqual(true);
-    expect(is<any>([undefined])).toEqual(true);
-    expect(is<any>([null])).toEqual(true);
-    expect(is<any>([{}])).toEqual(true);
-    expect(is<any>([])).toEqual(true);
+    test('literal' + sfx, () => {
+        expect(is<1>(1, testSerializer)).toEqual(true);
+        expect(is<1>(2, testSerializer)).toEqual(false);
+        expect(is<'abc'>('abc', testSerializer)).toEqual(true);
+        expect(is<'abc'>('ab', testSerializer)).toEqual(false);
+        expect(is<false>(false, testSerializer)).toEqual(true);
+        expect(is<false>(true, testSerializer)).toEqual(false);
+        expect(is<true>(true, testSerializer)).toEqual(true);
+        expect(is<true>(false, testSerializer)).toEqual(false);
+    });
 
-    expect(is<any>('a')).toEqual(true);
-    expect(is<any>(1)).toEqual(true);
-    expect(is<any>(true)).toEqual(true);
-    expect(is<any>(false)).toEqual(true);
-    expect(is<any>(undefined)).toEqual(true);
-    expect(is<any>(null)).toEqual(true);
-    expect(is<any>({})).toEqual(true);
-    expect(is<any>([])).toEqual(true);
-});
+    test('any' + sfx, () => {
+        expect(is<any>(['a'], testSerializer)).toEqual(true);
+        expect(is<any>([1], testSerializer)).toEqual(true);
+        expect(is<any>([true], testSerializer)).toEqual(true);
+        expect(is<any>([false], testSerializer)).toEqual(true);
+        expect(is<any>([undefined], testSerializer)).toEqual(true);
+        expect(is<any>([null], testSerializer)).toEqual(true);
+        expect(is<any>([{}], testSerializer)).toEqual(true);
+        expect(is<any>([], testSerializer)).toEqual(true);
 
-test('array any', () => {
-    expect(is<any[]>(['a'])).toEqual(true);
-    expect(is<any[]>([1])).toEqual(true);
-    expect(is<any[]>([true])).toEqual(true);
-    expect(is<any[]>([false])).toEqual(true);
-    expect(is<any[]>([undefined])).toEqual(true);
-    expect(is<any[]>([null])).toEqual(true);
-    expect(is<any[]>([{}])).toEqual(true);
-    expect(is<any[]>([])).toEqual(true);
-    expect(is<Array<any>>([])).toEqual(true);
-    expect(is<Array<any>>(['a'])).toEqual(true);
+        expect(is<any>('a', testSerializer)).toEqual(true);
+        expect(is<any>(1, testSerializer)).toEqual(true);
+        expect(is<any>(true, testSerializer)).toEqual(true);
+        expect(is<any>(false, testSerializer)).toEqual(true);
+        expect(is<any>(undefined, testSerializer)).toEqual(true);
+        expect(is<any>(null, testSerializer)).toEqual(true);
+        expect(is<any>({}, testSerializer)).toEqual(true);
+        expect(is<any>([], testSerializer)).toEqual(true);
+    });
 
-    expect(is<any[]>(null)).toEqual(false);
-    expect(is<any[]>(undefined)).toEqual(false);
-    expect(is<any[]>(1)).toEqual(false);
-    expect(is<any[]>(true)).toEqual(false);
-    expect(is<any[]>({})).toEqual(false);
+    test('array any' + sfx, () => {
+        expect(is<any[]>(['a'], testSerializer)).toEqual(true);
+        expect(is<any[]>([1], testSerializer)).toEqual(true);
+        expect(is<any[]>([true], testSerializer)).toEqual(true);
+        expect(is<any[]>([false], testSerializer)).toEqual(true);
+        expect(is<any[]>([undefined], testSerializer)).toEqual(true);
+        expect(is<any[]>([null], testSerializer)).toEqual(true);
+        expect(is<any[]>([{}], testSerializer)).toEqual(true);
+        expect(is<any[]>([], testSerializer)).toEqual(true);
+        expect(is<Array<any>>([], testSerializer)).toEqual(true);
+        expect(is<Array<any>>(['a'], testSerializer)).toEqual(true);
 
-    expect(is<any[]>({length:1})).toEqual(false);
-    expect(is<any[]>({length:0})).toEqual(false);
-    expect(is<any[]>({length:null})).toEqual(false);
-    expect(is<any[]>({length:undefined})).toEqual(false);
-});
+        expect(is<any[]>(null, testSerializer)).toEqual(false);
+        expect(is<any[]>(undefined, testSerializer)).toEqual(false);
+        expect(is<any[]>(1, testSerializer)).toEqual(false);
+        expect(is<any[]>(true, testSerializer)).toEqual(false);
+        expect(is<any[]>({}, testSerializer)).toEqual(false);
 
-test('union', () => {
-    expect(is<string | number>(1)).toEqual(true);
-    expect(is<string | number>('abc')).toEqual(true);
-    expect(is<string | number>(false)).toEqual(false);
-});
+        expect(is<any[]>({length:1}, testSerializer)).toEqual(false);
+        expect(is<any[]>({length:0}, testSerializer)).toEqual(false);
+        expect(is<any[]>({length:null}, testSerializer)).toEqual(false);
+        expect(is<any[]>({length:undefined}, testSerializer)).toEqual(false);
+    });
 
-test('deep union', () => {
-    expect(is<string | (number | bigint)[]>(1)).toEqual(false);
-    expect(is<string | (number | bigint)[]>('1')).toEqual(true);
-    expect(is<string | (number | bigint)[]>([1])).toEqual(true);
-    expect(is<string | (number | bigint)[]>([1n])).toEqual(true);
-    expect(is<string | (number | bigint)[]>(['1'])).toEqual(false);
-});
+    test('union' + sfx, () => {
+        expect(is<string | number>(1, testSerializer)).toEqual(true);
+        expect(is<string | number>('abc', testSerializer)).toEqual(true);
+        expect(is<string | number>(false, testSerializer)).toEqual(false);
+    });
 
-test('object literal', () => {
-    expect(is<{ a: string }>({ a: 'abc' })).toEqual(true);
-    expect(is<{ a: string }>({ a: 123 })).toEqual(false);
-    expect(is<{ a: string }>({})).toEqual(false);
-    expect(is<{ a?: string }>({})).toEqual(true);
-    expect(is<{ a?: string }>({ a: 'abc' })).toEqual(true);
-    expect(is<{ a?: string }>({ a: 123 })).toEqual(false);
-    expect(is<{ a: string, b: number }>({ a: 'a', b: 12 })).toEqual(true);
-    expect(is<{ a: string, b: number }>({ a: 'a', b: 'asd' })).toEqual(false);
-});
+    test('deep union' + sfx, () => {
+        expect(is<string | (number | bigint)[]>(1, testSerializer)).toEqual(false);
+        expect(is<string | (number | bigint)[]>('1', testSerializer)).toEqual(true);
+        expect(is<string | (number | bigint)[]>([1], testSerializer)).toEqual(true);
+        expect(is<string | (number | bigint)[]>([1n], testSerializer)).toEqual(true);
+        expect(is<string | (number | bigint)[]>(['1'], testSerializer)).toEqual(false);
+    });
 
-test('class', () => {
-    class A {
-        a!: string;
-    }
+    test('object literal' + sfx, () => {
+        expect(is<{ a: string }>({ a: 'abc' }, testSerializer)).toEqual(true);
+        expect(is<{ a: string }>({ a: 123 }, testSerializer)).toEqual(false);
+        expect(is<{ a: string }>({}, testSerializer)).toEqual(false);
+        expect(is<{ a?: string }>({}, testSerializer)).toEqual(true);
+        expect(is<{ a?: string }>({ a: 'abc' }, testSerializer)).toEqual(true);
+        expect(is<{ a?: string }>({ a: 123 }, testSerializer)).toEqual(false);
+        expect(is<{ a: string, b: number }>({ a: 'a', b: 12 }, testSerializer)).toEqual(true);
+        expect(is<{ a: string, b: number }>({ a: 'a', b: 'asd' }, testSerializer)).toEqual(false);
+    });
 
-    class A2 {
-        a?: string;
-    }
+    test('class' + sfx, () => {
+        class A {
+            a!: string;
+        }
 
-    class A3 {
-        a!: string;
-        b!: number;
-    }
+        class A2 {
+            a?: string;
+        }
 
-    expect(is<A>({ a: 'abc' })).toEqual(true);
-    expect(is<A>({ a: 123 })).toEqual(false);
-    expect(is<A>({})).toEqual(false);
-    expect(is<A2>({})).toEqual(true);
-    expect(is<A2>({ a: 'abc' })).toEqual(true);
-    expect(is<A2>({ a: 123 })).toEqual(false);
-    expect(is<A3>({ a: 'a', b: 12 })).toEqual(true);
-    expect(is<A3>({ a: 'a', b: 'asd' })).toEqual(false);
-});
+        class A3 {
+            a!: string;
+            b!: number;
+        }
 
-test('index signature', () => {
-    expect(is<{ [name: string]: string }>({})).toEqual(true);
-    expect(is<{ [name: string]: string }>({ a: 'abc' })).toEqual(true);
-    expect(is<{ [name: string]: string }>({ a: 123 })).toEqual(false);
+        expect(is<A>({ a: 'abc' }, testSerializer)).toEqual(true);
+        expect(is<A>({ a: 123 }, testSerializer)).toEqual(false);
+        expect(is<A>({}, testSerializer)).toEqual(false);
+        expect(is<A2>({}, testSerializer)).toEqual(true);
+        expect(is<A2>({ a: 'abc' }, testSerializer)).toEqual(true);
+        expect(is<A2>({ a: 123 }, testSerializer)).toEqual(false);
+        expect(is<A3>({ a: 'a', b: 12 }, testSerializer)).toEqual(true);
+        expect(is<A3>({ a: 'a', b: 'asd' }, testSerializer)).toEqual(false);
+    });
 
-    expect(is<{ [name: number]: string }>({ 1: 'abc' })).toEqual(true);
-    expect(is<{ [name: number]: string }>({ 1: 123 })).toEqual(false);
-    expect(is<{ [name: number]: string }>({ a: 'abc' })).toEqual(false);
-});
+    test('index signature' + sfx, () => {
+        expect(is<{ [name: string]: string }>({}, testSerializer)).toEqual(true);
+        expect(is<{ [name: string]: string }>({ a: 'abc' }, testSerializer)).toEqual(true);
+        expect(is<{ [name: string]: string }>({ a: 123 }, testSerializer)).toEqual(false);
 
-test('object literal methods', () => {
-    expect(is<{ m: () => void }>({ m: (): void => undefined })).toEqual(true);
-    expect(is<{ m: () => void }>({ m: false })).toEqual(false);
-    expect(is<{ m: (name: string) => void }>({ m: () => undefined })).toEqual(true); //`() => undefined` has no types, so no __type emitted. Means return=any
-    expect(is<{ m: (name: string) => void }>({ m: (name: string): void => undefined })).toEqual(true);
-    expect(is<{ m: (name: string) => string }>({ m: (name: string): string => 'asd' })).toEqual(true);
-    expect(is<{ m: (name: string) => string }>({ m: (name: string) => 'asd' })).toEqual(true);
-    expect(is<{ m: (name: string) => string }>({ m: (name: number): string => 'asd' })).toEqual(false);
-    expect(is<{ m: (name: string) => string }>({ m: (name: string): number => 2 })).toEqual(false);
-    expect(is<{ m: (name: string) => any }>({ m: (name: string): number => 2 })).toEqual(true);
-    expect(is<{ m: (name: any) => number }>({ m: (name: string): number => 2 })).toEqual(true);
-});
+        expect(is<{ [name: number]: string }>({ 1: 'abc' }, testSerializer)).toEqual(true);
+        expect(is<{ [name: number]: string }>({ 1: 123 }, testSerializer)).toEqual(false);
+        expect(is<{ [name: number]: string }>({ a: 'abc' }, testSerializer)).toEqual(false);
+    });
 
-test('multiple index signature', () => {
-    expect(is<{ [name: string]: string | number, [name: number]: string }>({})).toEqual(true);
-    expect(is<{ [name: string]: string | number, [name: number]: number }>({ a: 'abc' })).toEqual(true);
-    expect(is<{ [name: string]: string | number, [name: number]: number }>({ a: 123 })).toEqual(true);
-    expect(is<{ [name: string]: string | number, [name: number]: number }>({ 1: 123 })).toEqual(true);
-    expect(is<{ [name: string]: string | number, [name: number]: number }>({ 1: 'abc' })).toEqual(false);
-});
+    test('object literal methods' + sfx, () => {
+        expect(is<{ m: () => void }>({ m: (): void => undefined }, testSerializer)).toEqual(true);
+        expect(is<{ m: () => void }>({ m: false }, testSerializer)).toEqual(false);
+        expect(is<{ m: (name: string) => void }>({ m: () => undefined }, testSerializer)).toEqual(true); //`() => undefined` has no types, so no __type emitted. Means return=any
+        expect(is<{ m: (name: string) => void }>({ m: (name: string): void => undefined }, testSerializer)).toEqual(true);
+        expect(is<{ m: (name: string) => string }>({ m: (name: string): string => 'asd' }, testSerializer)).toEqual(true);
+        expect(is<{ m: (name: string) => string }>({ m: (name: string) => 'asd' }, testSerializer)).toEqual(true);
+        expect(is<{ m: (name: string) => string }>({ m: (name: number): string => 'asd' }, testSerializer)).toEqual(false);
+        expect(is<{ m: (name: string) => string }>({ m: (name: string): number => 2 }, testSerializer)).toEqual(false);
+        expect(is<{ m: (name: string) => any }>({ m: (name: string): number => 2 }, testSerializer)).toEqual(true);
+        expect(is<{ m: (name: any) => number }>({ m: (name: string): number => 2 }, testSerializer)).toEqual(true);
+    });
 
-test('brands', () => {
-    expect(is<number & PrimaryKey>(2)).toEqual(true);
-    expect(is<number & PrimaryKey>('2')).toEqual(false);
-});
+    test('multiple index signature' + sfx, () => {
+        expect(is<{ [name: string]: string | number, [name: number]: string }>({}, testSerializer)).toEqual(true);
+        expect(is<{ [name: string]: string | number, [name: number]: number }>({ a: 'abc' }, testSerializer)).toEqual(true);
+        expect(is<{ [name: string]: string | number, [name: number]: number }>({ a: 123 }, testSerializer)).toEqual(true);
+        expect(is<{ [name: string]: string | number, [name: number]: number }>({ 1: 123 }, testSerializer)).toEqual(true);
+        expect(is<{ [name: string]: string | number, [name: number]: number }>({ 1: 'abc' }, testSerializer)).toEqual(false);
+    });
 
-test('generic interface', () => {
-    interface List<T> {
-        items: T[];
-    }
+    test('brands' + sfx, () => {
+        expect(is<number & PrimaryKey>(2, testSerializer)).toEqual(true);
+        expect(is<number & PrimaryKey>('2', testSerializer)).toEqual(false);
+    });
 
-    expect(is<List<number>>({ items: [1] })).toEqual(true);
-    expect(is<List<string>>({ items: [1] })).toEqual(false);
-    expect(is<List<string>>({ items: null })).toEqual(false);
-    expect(is<List<string>>({ items: ['abc'] })).toEqual(true);
-});
+    test('generic interface' + sfx, () => {
+        interface List<T> {
+            items: T[];
+        }
 
-test('generic alias', () => {
-    type List<T> = T[];
+        expect(is<List<number>>({ items: [1] }, testSerializer)).toEqual(true);
+        expect(is<List<string>>({ items: [1] }, testSerializer)).toEqual(false);
+        expect(is<List<string>>({ items: null }, testSerializer)).toEqual(false);
+        expect(is<List<string>>({ items: ['abc'] }, testSerializer)).toEqual(true);
+    });
 
-    expect(is<List<number>>([1])).toEqual(true);
-    expect(is<List<string>>([1])).toEqual(false);
-    expect(is<List<string>>(null)).toEqual(false);
-    expect(is<List<string>>(['abc'])).toEqual(true);
-});
+    test('generic alias' + sfx, () => {
+        type List<T> = T[];
 
-test('index signature ', () => {
-    interface BagOfNumbers {
-        [name: string]: number;
-    }
+        expect(is<List<number>>([1], testSerializer)).toEqual(true);
+        expect(is<List<string>>([1], testSerializer)).toEqual(false);
+        expect(is<List<string>>(null, testSerializer)).toEqual(false);
+        expect(is<List<string>>(['abc'], testSerializer)).toEqual(true);
+    });
 
-    interface BagOfStrings {
-        [name: string]: string;
-    }
+    test('index signature ' + sfx, () => {
+        interface BagOfNumbers {
+            [name: string]: number;
+        }
 
-    expect(is<BagOfNumbers>({ a: 1 })).toEqual(true);
-    expect(is<BagOfNumbers>({ a: 1, b: 2 })).toEqual(true);
-    expect(is<BagOfNumbers>({ a: 'b' })).toEqual(false);
-    expect(is<BagOfNumbers>({ a: 'b', b: 'c' })).toEqual(false);
+        interface BagOfStrings {
+            [name: string]: string;
+        }
 
-    expect(is<BagOfStrings>({ a: 1 })).toEqual(false);
-    expect(is<BagOfStrings>({ a: 1, b: 2 })).toEqual(false);
-    expect(is<BagOfStrings>({ a: 'b' })).toEqual(true);
-    expect(is<BagOfStrings>({ a: 'b', b: 'c' })).toEqual(true);
-});
+        expect(is<BagOfNumbers>({ a: 1 }, testSerializer)).toEqual(true);
+        expect(is<BagOfNumbers>({ a: 1, b: 2 }, testSerializer)).toEqual(true);
+        expect(is<BagOfNumbers>({ a: 'b' }, testSerializer)).toEqual(false);
+        expect(is<BagOfNumbers>({ a: 'b', b: 'c' }, testSerializer)).toEqual(false);
 
-test('reference', () => {
-    class Image {
-        id: number = 0;
-    }
+        expect(is<BagOfStrings>({ a: 1 }, testSerializer)).toEqual(false);
+        expect(is<BagOfStrings>({ a: 1, b: 2 }, testSerializer)).toEqual(false);
+        expect(is<BagOfStrings>({ a: 'b' }, testSerializer)).toEqual(true);
+        expect(is<BagOfStrings>({ a: 'b', b: 'c' }, testSerializer)).toEqual(true);
+    });
 
-    class User {
-        image?: Image & Reference;
-    }
+    test('reference' + sfx, () => {
+        class Image {
+            id: number = 0;
+        }
 
-    expect(is<Image>({})).toEqual(false);
-    expect(is<Image>({ id: 0 })).toEqual(true);
+        class User {
+            image?: Image & Reference;
+        }
 
-    expect(is<User>({})).toEqual(true);
-    expect(is<User>({ image: undefined })).toEqual(true);
-    expect(is<User>({ image: { id: 1 } })).toEqual(true);
-    expect(is<User>({ image: { id: false } })).toEqual(false);
-    expect(is<User>({ image: false })).toEqual(false);
-    expect(is<User>({ image: null })).toEqual(false);
-    expect(is<User>({ image: {} })).toEqual(false);
-});
+        expect(is<Image>({}, testSerializer)).toEqual(false);
+        expect(is<Image>({ id: 0 }, testSerializer)).toEqual(true);
 
-test('template literal', () => {
-    expect(is<`abc`>('abc')).toBe(true);
-    expect(is<`abc`>('abce')).toBe(false);
+        expect(is<User>({}, testSerializer)).toEqual(true);
+        expect(is<User>({ image: undefined }, testSerializer)).toEqual(true);
+        expect(is<User>({ image: { id: 1 } }, testSerializer)).toEqual(true);
+        expect(is<User>({ image: { id: false } }, testSerializer)).toEqual(false);
+        expect(is<User>({ image: false }, testSerializer)).toEqual(false);
+        expect(is<User>({ image: null }, testSerializer)).toEqual(false);
+        expect(is<User>({ image: {} }, testSerializer)).toEqual(false);
+    });
 
-    expect(is<`ab${string}`>('abc')).toBe(true);
-    expect(is<`ab${string}`>('ab3')).toBe(true);
+    test('template literal' + sfx, () => {
+        expect(is<`abc`>('abc')).toBe(true);
+        expect(is<`abc`>('abce')).toBe(false);
 
-    type a = 'ab3' extends `ab${string}` ? true : false;
-    type a2 = 'ab' extends `ab${string}` ? true : false;
-    type a3 = 'a' extends `ab${string}` ? true : false;
+        expect(is<`ab${string}`>('abc')).toBe(true);
+        expect(is<`ab${string}`>('ab3')).toBe(true);
 
-    expect(is<`ab${string}`>('ab3')).toBe(true);
-    expect(is<`ab${string}`>('ab')).toBe(true);
-    expect(is<`ab${string}`>('a')).toBe(false);
+        type a = 'ab3' extends `ab${string}` ? true : false;
+        type a2 = 'ab' extends `ab${string}` ? true : false;
+        type a3 = 'a' extends `ab${string}` ? true : false;
 
-    type b = 'ab3' extends `ab${number}` ? true : false;
-    type b2 = 'ab' extends `ab${number}` ? true : false;
-    type b3 = 'a' extends `ab${number}` ? true : false;
-    type b4 = 'abc' extends `ab${number}` ? true : false;
+        expect(is<`ab${string}`>('ab3')).toBe(true);
+        expect(is<`ab${string}`>('ab')).toBe(true);
+        expect(is<`ab${string}`>('a')).toBe(false);
 
-    expect(is<`ab${number}`>('ab3')).toBe(true);
-    expect(is<`ab${number}`>('ab')).toBe(false);
-    expect(is<`ab${number}`>('a')).toBe(false);
-    expect(is<`ab${number}`>('abc')).toBe(false);
-});
+        type b = 'ab3' extends `ab${number}` ? true : false;
+        type b2 = 'ab' extends `ab${number}` ? true : false;
+        type b3 = 'a' extends `ab${number}` ? true : false;
+        type b4 = 'abc' extends `ab${number}` ? true : false;
 
-test('union template literal', () => {
-    expect(is<`abc${number}` | number>('abc2')).toBe(true);
-    expect(is<`abc${number}` | number>(23)).toBe(true);
-    expect(is<`abc${number}` | number>('abcd')).toBe(false);
-    expect(is<`abc${number}` | number>('abc')).toBe(false);
-});
+        expect(is<`ab${number}`>('ab3')).toBe(true);
+        expect(is<`ab${number}`>('ab')).toBe(false);
+        expect(is<`ab${number}`>('a')).toBe(false);
+        expect(is<`ab${number}`>('abc')).toBe(false);
+    });
 
-test('class with literal and default', () => {
-    class ConnectionOptions {
-        readConcernLevel: 'local' = 'local';
-    }
+    test('union template literal' + sfx, () => {
+        expect(is<`abc${number}` | number>('abc2')).toBe(true);
+        expect(is<`abc${number}` | number>(23)).toBe(true);
+        expect(is<`abc${number}` | number>('abcd')).toBe(false);
+        expect(is<`abc${number}` | number>('abc')).toBe(false);
+    });
 
-    expect(is<ConnectionOptions>({readConcernLevel: 'local'})).toBe(true);
-    expect(is<ConnectionOptions>({readConcernLevel: 'local2'})).toBe(false);
-});
+    test('class with literal and default' + sfx, () => {
+        class ConnectionOptions {
+            readConcernLevel: 'local' = 'local';
+        }
 
-test('union literal', () => {
-    class ConnectionOptions {
-        readConcernLevel: 'local' | 'majority' | 'linearizable' | 'available' = 'majority';
-    }
+        expect(is<ConnectionOptions>({readConcernLevel: 'local'})).toBe(true);
+        expect(is<ConnectionOptions>({readConcernLevel: 'local2'})).toBe(false);
+    });
 
-    expect(is<ConnectionOptions>({readConcernLevel: 'majority'})).toBe(true);
-    expect(is<ConnectionOptions>({readConcernLevel: 'majority2'})).toBe(false);
-});
+    test('union literal' + sfx, () => {
+        class ConnectionOptions {
+            readConcernLevel: 'local' | 'majority' | 'linearizable' | 'available' = 'majority';
+        }
+
+        expect(is<ConnectionOptions>({readConcernLevel: 'majority'})).toBe(true);
+        expect(is<ConnectionOptions>({readConcernLevel: 'majority2'})).toBe(false);
+    });
+}

--- a/packages/type/tests/typeguard.spec.ts
+++ b/packages/type/tests/typeguard.spec.ts
@@ -10,24 +10,24 @@
 import { expect, test, describe } from '@jest/globals';
 import { float, float32, int8, integer, PrimaryKey, Reference } from '../src/reflection/type.js';
 import { is } from '../src/typeguard.js';
-import { serializer, quickSerializer} from '../src/serializer.js';
+import { serializer, quickSerializer } from '../src/serializer.js';
 
-describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']])('typeguard suit', (testSerializer, name) => {
-    test(`primitive string ${name}`, () => {
+describe.each([serializer, quickSerializer])('', (testSerializer, name) => {
+    test('primitive string', () => {
         expect(is<string>('a', testSerializer)).toEqual(true);
         expect(is<string>(123, testSerializer)).toEqual(false);
         expect(is<string>(true, testSerializer)).toEqual(false);
         expect(is<string>({}, testSerializer)).toEqual(false);
     });
 
-    test(`primitive number ${name}`, () => {
+    test('primitive number', () => {
         expect(is<number>('a', testSerializer)).toEqual(false);
         expect(is<number>(123, testSerializer)).toEqual(true);
         expect(is<number>(true, testSerializer)).toEqual(false);
         expect(is<number>({}, testSerializer)).toEqual(false);
     });
 
-    test(`primitive number integer ${name}`, () => {
+    test('primitive number integer', () => {
         expect(is<integer>('a', testSerializer)).toEqual(false);
         expect(is<integer>(123, testSerializer)).toEqual(true);
         expect(is<integer>(123.4, testSerializer)).toEqual(false);
@@ -35,7 +35,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<integer>({}, testSerializer)).toEqual(false);
     });
 
-    test(`primitive number int8 ${name}`, () => {
+    test('primitive number int8', () => {
         expect(is<int8>('a', testSerializer)).toEqual(false);
         expect(is<int8>(123, testSerializer)).toEqual(true);
         expect(is<int8>(123.4, testSerializer)).toEqual(false);
@@ -48,7 +48,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<int8>(129, testSerializer)).toEqual(false);
     });
 
-    test(`primitive number float ${name}`, () => {
+    test('primitive number float', () => {
         expect(is<float>('a', testSerializer)).toEqual(false);
         expect(is<float>(123, testSerializer)).toEqual(true);
         expect(is<float>(123.4, testSerializer)).toEqual(true);
@@ -56,7 +56,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<float>({}, testSerializer)).toEqual(false);
     });
 
-    test(`primitive number float32 ${name}`, () => {
+    test('primitive number float32', () => {
         expect(is<float32>('a', testSerializer)).toEqual(false);
         expect(is<float32>(123, testSerializer)).toEqual(true);
         expect(is<float32>(123.4, testSerializer)).toEqual(true);
@@ -69,7 +69,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<float32>({}, testSerializer)).toEqual(false);
     });
 
-    test(`enum ${name}`, () => {
+    test('enum', () => {
         enum MyEnum {
             a, b, c
         }
@@ -83,7 +83,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<MyEnum>(true, testSerializer)).toEqual(false);
     });
 
-    test(`enum const ${name}`, () => {
+    test('enum const', () => {
         const enum MyEnum {
             a, b, c
         }
@@ -97,7 +97,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<MyEnum>(true, testSerializer)).toEqual(false);
     });
 
-    test(`enum string ${name}`, () => {
+    test('enum string', () => {
         enum MyEnum {
             a = 'a', b = 'b', c = 'c'
         }
@@ -114,7 +114,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<MyEnum>(true, testSerializer)).toEqual(false);
     });
 
-    test(`array string ${name}`, () => {
+    test('array string', () => {
         expect(is<string[]>([], testSerializer)).toEqual(true);
         expect(is<string[]>(['a'], testSerializer)).toEqual(true);
         expect(is<string[]>(['a', 'b'], testSerializer)).toEqual(true);
@@ -123,7 +123,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<string[]>(['a', 2], testSerializer)).toEqual(false);
     });
 
-    test(`tuple ${name}`, () => {
+    test('tuple', () => {
         expect(is<[string]>(['a'], testSerializer)).toEqual(true);
         expect(is<[string]>([2], testSerializer)).toEqual(false);
         expect(is<[string, string]>(['a', 'b'], testSerializer)).toEqual(true);
@@ -136,7 +136,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<[string, ...number[]]>([3, 3, 4, 5], testSerializer)).toEqual(false);
     });
 
-    test(`set ${name}`, () => {
+    test('set', () => {
         expect(is<Set<string>>(new Set(['a']), testSerializer)).toEqual(true);
         expect(is<Set<string>>(new Set(['a', 'b']), testSerializer)).toEqual(true);
         expect(is<Set<string>>(new Set(['a', 2]), testSerializer)).toEqual(false);
@@ -144,14 +144,14 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<Set<string>>([2, 3], testSerializer)).toEqual(false);
     });
 
-    test(`map ${name}`, () => {
+    test('map', () => {
         expect(is<Map<string, number>>(new Map([['a', 1]]), testSerializer)).toEqual(true);
         expect(is<Map<string, number>>(new Map([['a', 1], ['b', 2]]), testSerializer)).toEqual(true);
         expect(is<Map<string, number>>(new Map<any, any>([['a', 1], ['b', 'b']]), testSerializer)).toEqual(false);
         expect(is<Map<string, number>>(new Map<any, any>([[2, 1]]), testSerializer)).toEqual(false);
     });
 
-    test(`literal ${name}`, () => {
+    test('literal', () => {
         expect(is<1>(1, testSerializer)).toEqual(true);
         expect(is<1>(2, testSerializer)).toEqual(false);
         expect(is<'abc'>('abc', testSerializer)).toEqual(true);
@@ -162,7 +162,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<true>(false, testSerializer)).toEqual(false);
     });
 
-    test(`any ${name}`, () => {
+    test('any', () => {
         expect(is<any>(['a'], testSerializer)).toEqual(true);
         expect(is<any>([1], testSerializer)).toEqual(true);
         expect(is<any>([true], testSerializer)).toEqual(true);
@@ -182,7 +182,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<any>([], testSerializer)).toEqual(true);
     });
 
-    test(`array any ${name}`, () => {
+    test('array any', () => {
         expect(is<any[]>(['a'], testSerializer)).toEqual(true);
         expect(is<any[]>([1], testSerializer)).toEqual(true);
         expect(is<any[]>([true], testSerializer)).toEqual(true);
@@ -200,19 +200,19 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<any[]>(true, testSerializer)).toEqual(false);
         expect(is<any[]>({}, testSerializer)).toEqual(false);
 
-        expect(is<any[]>({length:1}, testSerializer)).toEqual(false);
-        expect(is<any[]>({length:0}, testSerializer)).toEqual(false);
-        expect(is<any[]>({length:null}, testSerializer)).toEqual(false);
-        expect(is<any[]>({length:undefined}, testSerializer)).toEqual(false);
+        expect(is<any[]>({ length: 1 }, testSerializer)).toEqual(false);
+        expect(is<any[]>({ length: 0 }, testSerializer)).toEqual(false);
+        expect(is<any[]>({ length: null }, testSerializer)).toEqual(false);
+        expect(is<any[]>({ length: undefined }, testSerializer)).toEqual(false);
     });
 
-    test(`union ${name}`, () => {
+    test('union', () => {
         expect(is<string | number>(1, testSerializer)).toEqual(true);
         expect(is<string | number>('abc', testSerializer)).toEqual(true);
         expect(is<string | number>(false, testSerializer)).toEqual(false);
     });
 
-    test(`deep union ${name}`, () => {
+    test('deep union', () => {
         expect(is<string | (number | bigint)[]>(1, testSerializer)).toEqual(false);
         expect(is<string | (number | bigint)[]>('1', testSerializer)).toEqual(true);
         expect(is<string | (number | bigint)[]>([1], testSerializer)).toEqual(true);
@@ -220,7 +220,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<string | (number | bigint)[]>(['1'], testSerializer)).toEqual(false);
     });
 
-    test(`object literal ${name}`, () => {
+    test('object literal', () => {
         expect(is<{ a: string }>({ a: 'abc' }, testSerializer)).toEqual(true);
         expect(is<{ a: string }>({ a: 123 }, testSerializer)).toEqual(false);
         expect(is<{ a: string }>({}, testSerializer)).toEqual(false);
@@ -231,7 +231,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<{ a: string, b: number }>({ a: 'a', b: 'asd' }, testSerializer)).toEqual(false);
     });
 
-    test(`class ${name}`, () => {
+    test('class', () => {
         class A {
             a!: string;
         }
@@ -255,7 +255,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<A3>({ a: 'a', b: 'asd' }, testSerializer)).toEqual(false);
     });
 
-    test(`index signature ${name}`, () => {
+    test('index signature', () => {
         expect(is<{ [name: string]: string }>({}, testSerializer)).toEqual(true);
         expect(is<{ [name: string]: string }>({ a: 'abc' }, testSerializer)).toEqual(true);
         expect(is<{ [name: string]: string }>({ a: 123 }, testSerializer)).toEqual(false);
@@ -265,7 +265,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<{ [name: number]: string }>({ a: 'abc' }, testSerializer)).toEqual(false);
     });
 
-    test(`object literal methods ${name}`, () => {
+    test('object literal methods', () => {
         expect(is<{ m: () => void }>({ m: (): void => undefined }, testSerializer)).toEqual(true);
         expect(is<{ m: () => void }>({ m: false }, testSerializer)).toEqual(false);
         expect(is<{ m: (name: string) => void }>({ m: () => undefined }, testSerializer)).toEqual(true); //`() => undefined` has no types, so no __type emitted. Means return=any
@@ -278,7 +278,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<{ m: (name: any) => number }>({ m: (name: string): number => 2 }, testSerializer)).toEqual(true);
     });
 
-    test(`multiple index signature ${name}`, () => {
+    test('multiple index signature', () => {
         expect(is<{ [name: string]: string | number, [name: number]: string }>({}, testSerializer)).toEqual(true);
         expect(is<{ [name: string]: string | number, [name: number]: number }>({ a: 'abc' }, testSerializer)).toEqual(true);
         expect(is<{ [name: string]: string | number, [name: number]: number }>({ a: 123 }, testSerializer)).toEqual(true);
@@ -286,12 +286,12 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<{ [name: string]: string | number, [name: number]: number }>({ 1: 'abc' }, testSerializer)).toEqual(false);
     });
 
-    test(`brands ${name}`, () => {
+    test('brands', () => {
         expect(is<number & PrimaryKey>(2, testSerializer)).toEqual(true);
         expect(is<number & PrimaryKey>('2', testSerializer)).toEqual(false);
     });
 
-    test(`generic interface ${name}`, () => {
+    test('generic interface', () => {
         interface List<T> {
             items: T[];
         }
@@ -302,7 +302,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<List<string>>({ items: ['abc'] }, testSerializer)).toEqual(true);
     });
 
-    test(`generic alias ${name}`, () => {
+    test('generic alias', () => {
         type List<T> = T[];
 
         expect(is<List<number>>([1], testSerializer)).toEqual(true);
@@ -311,7 +311,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<List<string>>(['abc'], testSerializer)).toEqual(true);
     });
 
-    test(`index signature  ${name}`, () => {
+    test('index signature ', () => {
         interface BagOfNumbers {
             [name: string]: number;
         }
@@ -331,7 +331,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<BagOfStrings>({ a: 'b', b: 'c' }, testSerializer)).toEqual(true);
     });
 
-    test(`reference ${name}`, () => {
+    test('reference', () => {
         class Image {
             id: number = 0;
         }
@@ -352,7 +352,7 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<User>({ image: {} }, testSerializer)).toEqual(false);
     });
 
-    test(`template literal ${name}`, () => {
+    test('template literal', () => {
         expect(is<`abc`>('abc')).toBe(true);
         expect(is<`abc`>('abce')).toBe(false);
 
@@ -378,28 +378,28 @@ describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']]
         expect(is<`ab${number}`>('abc')).toBe(false);
     });
 
-    test(`union template literal ${name}`, () => {
+    test('union template literal', () => {
         expect(is<`abc${number}` | number>('abc2')).toBe(true);
         expect(is<`abc${number}` | number>(23)).toBe(true);
         expect(is<`abc${number}` | number>('abcd')).toBe(false);
         expect(is<`abc${number}` | number>('abc')).toBe(false);
     });
 
-    test(`class with literal and default ${name}`, () => {
+    test('class with literal and default', () => {
         class ConnectionOptions {
             readConcernLevel: 'local' = 'local';
         }
 
-        expect(is<ConnectionOptions>({readConcernLevel: 'local'})).toBe(true);
-        expect(is<ConnectionOptions>({readConcernLevel: 'local2'})).toBe(false);
+        expect(is<ConnectionOptions>({ readConcernLevel: 'local' })).toBe(true);
+        expect(is<ConnectionOptions>({ readConcernLevel: 'local2' })).toBe(false);
     });
 
-    test(`union literal ${name}`, () => {
+    test('union literal', () => {
         class ConnectionOptions {
             readConcernLevel: 'local' | 'majority' | 'linearizable' | 'available' = 'majority';
         }
 
-        expect(is<ConnectionOptions>({readConcernLevel: 'majority'})).toBe(true);
-        expect(is<ConnectionOptions>({readConcernLevel: 'majority2'})).toBe(false);
+        expect(is<ConnectionOptions>({ readConcernLevel: 'majority' })).toBe(true);
+        expect(is<ConnectionOptions>({ readConcernLevel: 'majority2' })).toBe(false);
     });
 });

--- a/packages/type/tests/typeguard.spec.ts
+++ b/packages/type/tests/typeguard.spec.ts
@@ -7,31 +7,27 @@
  *
  * You should have received a copy of the MIT License along with this program.
  */
-import { expect, test } from '@jest/globals';
+import { expect, test, describe } from '@jest/globals';
 import { float, float32, int8, integer, PrimaryKey, Reference } from '../src/reflection/type.js';
 import { is } from '../src/typeguard.js';
-import { serializer, quickSerializer, Serializer} from '../src/serializer.js';
+import { serializer, quickSerializer} from '../src/serializer.js';
 
-serializerSuit(serializer, 'serializer');
-serializerSuit(quickSerializer, 'Quick');
-
-function serializerSuit(testSerializer: Serializer, name: string) {
-    const sfx = ` ==> ${name}`;
-    test('primitive string' + sfx, () => {
+describe.each([[serializer, 'serializer'], [quickSerializer, 'quickSerializer']])('typeguard suit', (testSerializer, name) => {
+    test(`primitive string ${name}`, () => {
         expect(is<string>('a', testSerializer)).toEqual(true);
         expect(is<string>(123, testSerializer)).toEqual(false);
         expect(is<string>(true, testSerializer)).toEqual(false);
         expect(is<string>({}, testSerializer)).toEqual(false);
     });
 
-    test('primitive number' + sfx, () => {
+    test(`primitive number ${name}`, () => {
         expect(is<number>('a', testSerializer)).toEqual(false);
         expect(is<number>(123, testSerializer)).toEqual(true);
         expect(is<number>(true, testSerializer)).toEqual(false);
         expect(is<number>({}, testSerializer)).toEqual(false);
     });
 
-    test('primitive number integer' + sfx, () => {
+    test(`primitive number integer ${name}`, () => {
         expect(is<integer>('a', testSerializer)).toEqual(false);
         expect(is<integer>(123, testSerializer)).toEqual(true);
         expect(is<integer>(123.4, testSerializer)).toEqual(false);
@@ -39,7 +35,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<integer>({}, testSerializer)).toEqual(false);
     });
 
-    test('primitive number int8' + sfx, () => {
+    test(`primitive number int8 ${name}`, () => {
         expect(is<int8>('a', testSerializer)).toEqual(false);
         expect(is<int8>(123, testSerializer)).toEqual(true);
         expect(is<int8>(123.4, testSerializer)).toEqual(false);
@@ -52,7 +48,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<int8>(129, testSerializer)).toEqual(false);
     });
 
-    test('primitive number float' + sfx, () => {
+    test(`primitive number float ${name}`, () => {
         expect(is<float>('a', testSerializer)).toEqual(false);
         expect(is<float>(123, testSerializer)).toEqual(true);
         expect(is<float>(123.4, testSerializer)).toEqual(true);
@@ -60,7 +56,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<float>({}, testSerializer)).toEqual(false);
     });
 
-    test('primitive number float32' + sfx, () => {
+    test(`primitive number float32 ${name}`, () => {
         expect(is<float32>('a', testSerializer)).toEqual(false);
         expect(is<float32>(123, testSerializer)).toEqual(true);
         expect(is<float32>(123.4, testSerializer)).toEqual(true);
@@ -73,7 +69,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<float32>({}, testSerializer)).toEqual(false);
     });
 
-    test('enum' + sfx, () => {
+    test(`enum ${name}`, () => {
         enum MyEnum {
             a, b, c
         }
@@ -87,7 +83,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<MyEnum>(true, testSerializer)).toEqual(false);
     });
 
-    test('enum const' + sfx, () => {
+    test(`enum const ${name}`, () => {
         const enum MyEnum {
             a, b, c
         }
@@ -101,7 +97,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<MyEnum>(true, testSerializer)).toEqual(false);
     });
 
-    test('enum string' + sfx, () => {
+    test(`enum string ${name}`, () => {
         enum MyEnum {
             a = 'a', b = 'b', c = 'c'
         }
@@ -118,7 +114,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<MyEnum>(true, testSerializer)).toEqual(false);
     });
 
-    test('array string' + sfx, () => {
+    test(`array string ${name}`, () => {
         expect(is<string[]>([], testSerializer)).toEqual(true);
         expect(is<string[]>(['a'], testSerializer)).toEqual(true);
         expect(is<string[]>(['a', 'b'], testSerializer)).toEqual(true);
@@ -127,7 +123,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<string[]>(['a', 2], testSerializer)).toEqual(false);
     });
 
-    test('tuple' + sfx, () => {
+    test(`tuple ${name}`, () => {
         expect(is<[string]>(['a'], testSerializer)).toEqual(true);
         expect(is<[string]>([2], testSerializer)).toEqual(false);
         expect(is<[string, string]>(['a', 'b'], testSerializer)).toEqual(true);
@@ -140,7 +136,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<[string, ...number[]]>([3, 3, 4, 5], testSerializer)).toEqual(false);
     });
 
-    test('set' + sfx, () => {
+    test(`set ${name}`, () => {
         expect(is<Set<string>>(new Set(['a']), testSerializer)).toEqual(true);
         expect(is<Set<string>>(new Set(['a', 'b']), testSerializer)).toEqual(true);
         expect(is<Set<string>>(new Set(['a', 2]), testSerializer)).toEqual(false);
@@ -148,14 +144,14 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<Set<string>>([2, 3], testSerializer)).toEqual(false);
     });
 
-    test('map' + sfx, () => {
+    test(`map ${name}`, () => {
         expect(is<Map<string, number>>(new Map([['a', 1]]), testSerializer)).toEqual(true);
         expect(is<Map<string, number>>(new Map([['a', 1], ['b', 2]]), testSerializer)).toEqual(true);
         expect(is<Map<string, number>>(new Map<any, any>([['a', 1], ['b', 'b']]), testSerializer)).toEqual(false);
         expect(is<Map<string, number>>(new Map<any, any>([[2, 1]]), testSerializer)).toEqual(false);
     });
 
-    test('literal' + sfx, () => {
+    test(`literal ${name}`, () => {
         expect(is<1>(1, testSerializer)).toEqual(true);
         expect(is<1>(2, testSerializer)).toEqual(false);
         expect(is<'abc'>('abc', testSerializer)).toEqual(true);
@@ -166,7 +162,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<true>(false, testSerializer)).toEqual(false);
     });
 
-    test('any' + sfx, () => {
+    test(`any ${name}`, () => {
         expect(is<any>(['a'], testSerializer)).toEqual(true);
         expect(is<any>([1], testSerializer)).toEqual(true);
         expect(is<any>([true], testSerializer)).toEqual(true);
@@ -186,7 +182,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<any>([], testSerializer)).toEqual(true);
     });
 
-    test('array any' + sfx, () => {
+    test(`array any ${name}`, () => {
         expect(is<any[]>(['a'], testSerializer)).toEqual(true);
         expect(is<any[]>([1], testSerializer)).toEqual(true);
         expect(is<any[]>([true], testSerializer)).toEqual(true);
@@ -210,13 +206,13 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<any[]>({length:undefined}, testSerializer)).toEqual(false);
     });
 
-    test('union' + sfx, () => {
+    test(`union ${name}`, () => {
         expect(is<string | number>(1, testSerializer)).toEqual(true);
         expect(is<string | number>('abc', testSerializer)).toEqual(true);
         expect(is<string | number>(false, testSerializer)).toEqual(false);
     });
 
-    test('deep union' + sfx, () => {
+    test(`deep union ${name}`, () => {
         expect(is<string | (number | bigint)[]>(1, testSerializer)).toEqual(false);
         expect(is<string | (number | bigint)[]>('1', testSerializer)).toEqual(true);
         expect(is<string | (number | bigint)[]>([1], testSerializer)).toEqual(true);
@@ -224,7 +220,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<string | (number | bigint)[]>(['1'], testSerializer)).toEqual(false);
     });
 
-    test('object literal' + sfx, () => {
+    test(`object literal ${name}`, () => {
         expect(is<{ a: string }>({ a: 'abc' }, testSerializer)).toEqual(true);
         expect(is<{ a: string }>({ a: 123 }, testSerializer)).toEqual(false);
         expect(is<{ a: string }>({}, testSerializer)).toEqual(false);
@@ -235,7 +231,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<{ a: string, b: number }>({ a: 'a', b: 'asd' }, testSerializer)).toEqual(false);
     });
 
-    test('class' + sfx, () => {
+    test(`class ${name}`, () => {
         class A {
             a!: string;
         }
@@ -259,7 +255,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<A3>({ a: 'a', b: 'asd' }, testSerializer)).toEqual(false);
     });
 
-    test('index signature' + sfx, () => {
+    test(`index signature ${name}`, () => {
         expect(is<{ [name: string]: string }>({}, testSerializer)).toEqual(true);
         expect(is<{ [name: string]: string }>({ a: 'abc' }, testSerializer)).toEqual(true);
         expect(is<{ [name: string]: string }>({ a: 123 }, testSerializer)).toEqual(false);
@@ -269,7 +265,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<{ [name: number]: string }>({ a: 'abc' }, testSerializer)).toEqual(false);
     });
 
-    test('object literal methods' + sfx, () => {
+    test(`object literal methods ${name}`, () => {
         expect(is<{ m: () => void }>({ m: (): void => undefined }, testSerializer)).toEqual(true);
         expect(is<{ m: () => void }>({ m: false }, testSerializer)).toEqual(false);
         expect(is<{ m: (name: string) => void }>({ m: () => undefined }, testSerializer)).toEqual(true); //`() => undefined` has no types, so no __type emitted. Means return=any
@@ -282,7 +278,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<{ m: (name: any) => number }>({ m: (name: string): number => 2 }, testSerializer)).toEqual(true);
     });
 
-    test('multiple index signature' + sfx, () => {
+    test(`multiple index signature ${name}`, () => {
         expect(is<{ [name: string]: string | number, [name: number]: string }>({}, testSerializer)).toEqual(true);
         expect(is<{ [name: string]: string | number, [name: number]: number }>({ a: 'abc' }, testSerializer)).toEqual(true);
         expect(is<{ [name: string]: string | number, [name: number]: number }>({ a: 123 }, testSerializer)).toEqual(true);
@@ -290,12 +286,12 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<{ [name: string]: string | number, [name: number]: number }>({ 1: 'abc' }, testSerializer)).toEqual(false);
     });
 
-    test('brands' + sfx, () => {
+    test(`brands ${name}`, () => {
         expect(is<number & PrimaryKey>(2, testSerializer)).toEqual(true);
         expect(is<number & PrimaryKey>('2', testSerializer)).toEqual(false);
     });
 
-    test('generic interface' + sfx, () => {
+    test(`generic interface ${name}`, () => {
         interface List<T> {
             items: T[];
         }
@@ -306,7 +302,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<List<string>>({ items: ['abc'] }, testSerializer)).toEqual(true);
     });
 
-    test('generic alias' + sfx, () => {
+    test(`generic alias ${name}`, () => {
         type List<T> = T[];
 
         expect(is<List<number>>([1], testSerializer)).toEqual(true);
@@ -315,7 +311,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<List<string>>(['abc'], testSerializer)).toEqual(true);
     });
 
-    test('index signature ' + sfx, () => {
+    test(`index signature  ${name}`, () => {
         interface BagOfNumbers {
             [name: string]: number;
         }
@@ -335,7 +331,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<BagOfStrings>({ a: 'b', b: 'c' }, testSerializer)).toEqual(true);
     });
 
-    test('reference' + sfx, () => {
+    test(`reference ${name}`, () => {
         class Image {
             id: number = 0;
         }
@@ -356,7 +352,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<User>({ image: {} }, testSerializer)).toEqual(false);
     });
 
-    test('template literal' + sfx, () => {
+    test(`template literal ${name}`, () => {
         expect(is<`abc`>('abc')).toBe(true);
         expect(is<`abc`>('abce')).toBe(false);
 
@@ -382,14 +378,14 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<`ab${number}`>('abc')).toBe(false);
     });
 
-    test('union template literal' + sfx, () => {
+    test(`union template literal ${name}`, () => {
         expect(is<`abc${number}` | number>('abc2')).toBe(true);
         expect(is<`abc${number}` | number>(23)).toBe(true);
         expect(is<`abc${number}` | number>('abcd')).toBe(false);
         expect(is<`abc${number}` | number>('abc')).toBe(false);
     });
 
-    test('class with literal and default' + sfx, () => {
+    test(`class with literal and default ${name}`, () => {
         class ConnectionOptions {
             readConcernLevel: 'local' = 'local';
         }
@@ -398,7 +394,7 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<ConnectionOptions>({readConcernLevel: 'local2'})).toBe(false);
     });
 
-    test('union literal' + sfx, () => {
+    test(`union literal ${name}`, () => {
         class ConnectionOptions {
             readConcernLevel: 'local' | 'majority' | 'linearizable' | 'available' = 'majority';
         }
@@ -406,4 +402,4 @@ function serializerSuit(testSerializer: Serializer, name: string) {
         expect(is<ConnectionOptions>({readConcernLevel: 'majority'})).toBe(true);
         expect(is<ConnectionOptions>({readConcernLevel: 'majority2'})).toBe(false);
     });
-}
+});


### PR DESCRIPTION
### Summary of changes

* Add options to configure the  JIT compiler.
* 2 small optimisations to emitted code (won't make any noticeable difference, mostly emitted code is more concise) [here](https://github.com/deepkit/deepkit-framework/pull/546/files#diff-1e814ff384e15a44bcdb3386a47acd35c1e641cc6695c132447f9bc509137434R876-R901) & [here](https://github.com/deepkit/deepkit-framework/pull/546/files#diff-1e814ff384e15a44bcdb3386a47acd35c1e641cc6695c132447f9bc509137434R1071-R1075) (these ones affect existing  serializer also)

After a bit of investigation about how to possibly improve the validation and serialization performance, there were a couple of improvements that could be easy enough to tackle:

* **No emitting errors:** only return success or fail (this removes all error related code from the generated JIT functions)
* **No onpopulate properties:**  this are handier when we know the data and can consider it safe (i.e: orm operations) but not so much when the data is unsafe (i.e: user input), there is an extra check for unpopulated properties for every single property, so removing those from the function also improve performance.
* **No groups:** controls wether or not the code related to groups functionality is emitted

The PR might look big but is actually not that big and kind of simple. I just went for the low hanging fruit. 

### How to use

Data:
```ts
interface ToBeChecked {
  number: number;
  negNumber: number;
  maxNumber: number;
  string: string;
  longString: string;
  boolean: boolean;
  deeplyNested: {
    foo: string;
    num: number;
    bool: boolean;
  };
}
```

IE: Normal Serializer
```ts
import { castFunction, getValidatorFunction } from '@deepkit/type';

const isToBeChecked = getValidatorFunction<ToBeChecked>();
const safeToBeChecked = castFunction<ToBeChecked>();

export function assertLoose(input: unknown): boolean {
  if (!isToBeChecked(input) as boolean) throw new Error('wrong type.');
  return true;
}

export function parseSafe(input: unknown): ToBeChecked {
  return safeToBeChecked(input);
}
```

IE: Quick Serializer (no Emit errors , no unpopulated check, no groups)    
**NOTE THESE FUNCTIONS DO NOT EMIT ERROR INFORMATION WHEN VALIDATING**
```ts
import {
  castFunction,
  getValidatorFunction,
  quickSerializer,
} from '@deepkit/type';

const isToBeChecked = getValidatorFunction<ToBeChecked>(quickSerializer);
const safeToBeChecked = castFunction<ToBeChecked>(quickSerializer);

export function assertLoose(input: unknown): boolean {
  if (!isToBeChecked(input) as boolean) throw new Error('wrong type.');
  return true;
}

export function parseSafe(input: unknown): ToBeChecked {
  return safeToBeChecked(input);
}
```

### Benchmark results 

to test the benchmarks download this [branch](https://github.com/M-jerez/typescript-runtime-type-benchmarks/tree/test-quick-deepkit-options) install modules and simLink @deepkit/types into it, then run the benhcmarks.

<img width="1149" alt="benhcmark-after-pr-changes" src="https://github.com/deepkit/deepkit-framework/assets/2648215/63e11d6c-a031-4619-a857-337a6c85864c">

Would say  the Improvement when serializing is not really significant but it is when validating!

### Benchmark results from master branch

<img width="1096" alt="before-pr-changes" src="https://github.com/deepkit/deepkit-framework/assets/2648215/9f6385d9-ea65-4fd5-9483-db1250b8b4bb">


### COMPARISON of generated JIT code

REGULAR JIT VALIDATION FUNCTION
```js
// Validation function generated using the regular serializer
function self(data, state, _path) {
  "use strict";

  var result;
  if (_path === undefined) _path = "";

  state = state ? state : {};

  result = true;
  if (data && "object" === typeof data) {
    if (data["number"] !== unpopulatedSymbol) {
      let check_0 = "number" === typeof data["number"];
      if (!check_0)
        if (state.errors)
          state.errors.push(
            new ValidationErrorItem(
              _path + "." + "number",
              "type",
              "Not a number",
              data["number"]
            )
          );
      if (!check_0) result = false;
    }
    if (data["negNumber"] !== unpopulatedSymbol) {
      let check_1 = "number" === typeof data["negNumber"];
      if (!check_1)
        if (state.errors)
          state.errors.push(
            new ValidationErrorItem(
              _path + "." + "negNumber",
              "type",
              "Not a number",
              data["negNumber"]
            )
          );
      if (!check_1) result = false;
    }
    if (data["maxNumber"] !== unpopulatedSymbol) {
      let check_2 = "number" === typeof data["maxNumber"];
      if (!check_2)
        if (state.errors)
          state.errors.push(
            new ValidationErrorItem(
              _path + "." + "maxNumber",
              "type",
              "Not a number",
              data["maxNumber"]
            )
          );
      if (!check_2) result = false;
    }
    if (data["string"] !== unpopulatedSymbol) {
      let check_3 = "string" === typeof data["string"];
      if (!check_3)
        if (state.errors)
          state.errors.push(
            new ValidationErrorItem(
              _path + "." + "string",
              "type",
              "Not a string",
              data["string"]
            )
          );
      if (!check_3) result = false;
    }
    if (data["longString"] !== unpopulatedSymbol) {
      let check_4 = "string" === typeof data["longString"];
      if (!check_4)
        if (state.errors)
          state.errors.push(
            new ValidationErrorItem(
              _path + "." + "longString",
              "type",
              "Not a string",
              data["longString"]
            )
          );
      if (!check_4) result = false;
    }
    if (data["boolean"] !== unpopulatedSymbol) {
      let check_5 = "boolean" === typeof data["boolean"];
      if (!check_5)
        if (state.errors)
          state.errors.push(
            new ValidationErrorItem(
              _path + "." + "boolean",
              "type",
              "Not a boolean",
              data["boolean"]
            )
          );
      if (!check_5) result = false;
    }
    if (data["deeplyNested"] !== unpopulatedSymbol) {
      let check_6 = false; //call jit for check_6 via propertyName
      check_6 = jit_1.fn(
        data["deeplyNested"],
        state,
        _path + "." + "deeplyNested"
      );
      if (!check_6) result = false;
    }
  } else {
    if (true)
      if (state.errors)
        state.errors.push(
          new ValidationErrorItem(_path, "type", "Not an object", data)
        );
    result = false;
  }

  return result;
}
```

QUICK VALIDATION FUNCTION
```js
// Validation function generated using the quick serializer
function self(data, state, _path) {
  "use strict";

  var result;
  if (_path === undefined) _path = "";

  state = state ? state : {};

  result = true;
  if (data && "object" === typeof data) {
    let check_0 = "number" === typeof data["number"];
    if (!check_0) result = false;

    let check_1 = "number" === typeof data["negNumber"];
    if (!check_1) result = false;

    let check_2 = "number" === typeof data["maxNumber"];
    if (!check_2) result = false;

    let check_3 = "string" === typeof data["string"];
    if (!check_3) result = false;

    let check_4 = "string" === typeof data["longString"];
    if (!check_4) result = false;

    let check_5 = "boolean" === typeof data["boolean"];
    if (!check_5) result = false;

    let check_6 = false; //call jit for check_6 via propertyName
    check_6 = jit_1.fn(
      data["deeplyNested"],
      state,
      _path + "." + "deeplyNested"
    );
    if (!check_6) result = false;
  } else {
    if (true) {
      /* noop */
    }
    result = false;
  }

  return result;
}
```

Any comments please let me know! 👍 

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
