### PR TITLE
fix(sql): strings should be nullable without casting as JSON

### DIFF
--- a/packages/mysql/tests/mysql.spec.ts
+++ b/packages/mysql/tests/mysql.spec.ts
@@ -323,3 +323,22 @@ test('unique constraint 1', async () => {
         await expect(p).rejects.toBeInstanceOf(UniqueConstraintFailure);
     }
 });
+
+test('string/null unions should not render as JSON', async () => {
+    @entity.name('model6')
+    class Model {
+        id: number & PrimaryKey & AutoIncrement = 0;
+
+        constructor(public name: string, public nickName: string | null = null) {}
+    }
+
+    const database = await databaseFactory([Model]);
+    await database.persist(new Model('Peter'));
+    await database.persist(new Model('Christopher', 'Chris'));
+
+    const result = await database.query(Model).orderBy('id', 'asc').find();
+    expect(result).toMatchObject([
+        {name: 'Peter', nickName: null},
+        {name: 'Christopher', nickName: 'Chris'}
+    ]);
+});

--- a/packages/sql/src/platform/default-platform.ts
+++ b/packages/sql/src/platform/default-platform.ts
@@ -31,7 +31,7 @@ export function isNonUndefined(type: Type): boolean {
 export function typeResolvesToString(type: Type): boolean {
     if (type.kind === ReflectionKind.string) return true;
     if (type.kind === ReflectionKind.literal && 'string' === typeof type.literal) return true;
-    if (type.kind === ReflectionKind.union) return type.types.every(v => typeResolvesToString(v));
+    if (type.kind === ReflectionKind.union) return type.types.filter(isNonUndefined).every(v => typeResolvesToString(v));
     if (type.kind === ReflectionKind.enum) return typeResolvesToString(type.indexType);
     return false;
 }


### PR DESCRIPTION
### Summary of changes
The other typeResolvesToX functions filter out undefined/null before determining if the type correctly resolves, but string does not.  As a result, `string | null` types on database entities are being coerced to JSON.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
