### PR TITLE
fix(sql): dates should be nullable without casting as JSON

### DIFF
--- a/packages/mysql/src/mysql-platform.ts
+++ b/packages/mysql/src/mysql-platform.ts
@@ -10,17 +10,7 @@
 
 import { Pool } from 'mariadb';
 import { mySqlSerializer } from './mysql-serializer.js';
-import {
-    isDateType,
-    isReferenceType,
-    isUUIDType,
-    ReflectionClass,
-    ReflectionKind,
-    ReflectionProperty,
-    Serializer,
-    Type,
-    TypeNumberBrand,
-} from '@deepkit/type';
+import { isReferenceType, isUUIDType, ReflectionClass, ReflectionKind, ReflectionProperty, Serializer, Type, TypeNumberBrand } from '@deepkit/type';
 import {
     Column,
     DefaultPlatform,
@@ -30,6 +20,7 @@ import {
     PreparedAdapter,
     typeResolvesToBigInt,
     typeResolvesToBoolean,
+    typeResolvesToDate,
     typeResolvesToInteger,
     typeResolvesToNumber,
     typeResolvesToString,
@@ -78,7 +69,7 @@ export class MySQLPlatform extends DefaultPlatform {
         this.addType(type => type.kind === ReflectionKind.number && type.brand === TypeNumberBrand.float64, 'double');
         this.addType(type => type.kind === ReflectionKind.number && type.brand === TypeNumberBrand.float, 'double');
 
-        this.addType(isDateType, 'datetime');
+        this.addType(typeResolvesToDate, 'datetime');
         this.addType(isUUIDType, 'binary', 16);
 
         this.addBinaryType('longblob');

--- a/packages/mysql/tests/mysql.spec.ts
+++ b/packages/mysql/tests/mysql.spec.ts
@@ -324,21 +324,23 @@ test('unique constraint 1', async () => {
     }
 });
 
-test('string/null unions should not render as JSON', async () => {
+test('non-object null unions should not render as JSON', async () => {
     @entity.name('model6')
     class Model {
         id: number & PrimaryKey & AutoIncrement = 0;
 
-        constructor(public name: string, public nickName: string | null = null) {}
+        constructor(public name: string, public nickName: string | null = null, public birthdate: Date | null = null) {}
     }
 
     const database = await databaseFactory([Model]);
     await database.persist(new Model('Peter'));
     await database.persist(new Model('Christopher', 'Chris'));
+    await database.persist(new Model('Thomas', 'Tom', new Date('1960-02-10T00:00:00Z')));
 
     const result = await database.query(Model).orderBy('id', 'asc').find();
     expect(result).toMatchObject([
         {name: 'Peter', nickName: null},
-        {name: 'Christopher', nickName: 'Chris'}
+        {name: 'Christopher', nickName: 'Chris'},
+        {name: 'Thomas', nickName: 'Tom', birthdate: new Date('1960-02-10T00:00:00Z')},
     ]);
 });

--- a/packages/sql/src/platform/default-platform.ts
+++ b/packages/sql/src/platform/default-platform.ts
@@ -24,17 +24,7 @@ import { sqlSerializer } from '../serializer/sql-serializer.js';
 import { parseType, SchemaParser } from '../reverse/schema-parser.js';
 import { SQLFilterBuilder } from '../sql-filter-builder.js';
 import { Sql } from '../sql-builder.js';
-import {
-    binaryTypes,
-    databaseAnnotation,
-    isCustomTypeClass,
-    isIntegerType,
-    ReflectionClass,
-    ReflectionKind,
-    ReflectionProperty,
-    Serializer,
-    Type,
-} from '@deepkit/type';
+import { binaryTypes, databaseAnnotation, isCustomTypeClass, isDateType, isIntegerType, ReflectionClass, ReflectionKind, ReflectionProperty, Serializer, Type } from '@deepkit/type';
 import { DatabaseEntityRegistry, MigrateOptions } from '@deepkit/orm';
 import { splitDotPath } from '../sql-adapter.js';
 import { PreparedAdapter } from '../prepare.js';
@@ -96,6 +86,11 @@ export function typeResolvesToBoolean(type: Type): boolean {
     if (type.kind === ReflectionKind.union) return type.types.filter(isNonUndefined).every(typeResolvesToBoolean);
     if (type.kind === ReflectionKind.enum) return typeResolvesToBoolean(type.indexType);
     return false;
+}
+
+export function typeResolvesToDate(type: Type): boolean {
+    if (type.kind === ReflectionKind.union) return type.types.filter(isNonUndefined).every(isDateType);
+    return isDateType(type);
 }
 
 export function noopSqlTypeCaster(placeholder: string): string {


### PR DESCRIPTION
### Summary of changes

Same as #552, but for dates. Can't use `Date | null` on SQL entities right now without Deepkit trying to cast them as JSON into the database.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
