### PR TITLE
fix(type): require tld for email addresses

### DIFF
--- a/packages/type/src/validator.ts
+++ b/packages/type/src/validator.ts
@@ -45,7 +45,7 @@ export type AfterDate<T extends number> = ValidatorMeta<'afterDate', [T]>;
 export type BeforeNow = ValidatorMeta<'beforeNow'>;
 export type AfterNow = ValidatorMeta<'afterNow'>;
 
-export const EMAIL_REGEX = /^\S+@\S+$/;
+export const EMAIL_REGEX = /^\S+@\S+\.\S+$/;
 export type Email = string & Pattern<typeof EMAIL_REGEX>;
 
 /**

--- a/packages/type/tests/validation.spec.ts
+++ b/packages/type/tests/validation.spec.ts
@@ -22,9 +22,10 @@ test('email', () => {
     expect(is<string & Email>('@')).toBe(false);
 
     expect(validate<Email>('peter@example.com')).toEqual([]);
-    expect(validate<Email>('nope')).toEqual([{ path: '', code: 'pattern', message: `Pattern ^\\S+@\\S+$ does not match`, value: 'nope' }]);
-    expect(validate<Email>('nope@')).toEqual([{ path: '', code: 'pattern', message: `Pattern ^\\S+@\\S+$ does not match`, value: 'nope@' }]);
-    expect(validate<Email>('@')).toEqual([{ path: '', code: 'pattern', message: `Pattern ^\\S+@\\S+$ does not match`, value: '@' }]);
+    expect(validate<Email>('nope')).toEqual([{ path: '', code: 'pattern', message: `Pattern ^\\S+@\\S+\\.\\S+$ does not match`, value: 'nope' }]);
+    expect(validate<Email>('nope@')).toEqual([{ path: '', code: 'pattern', message: `Pattern ^\\S+@\\S+\\.\\S+$ does not match`, value: 'nope@' }]);
+    expect(validate<Email>('nope@gmail')).toEqual([{ path: '', code: 'pattern', message: `Pattern ^\\S+@\\S+\\.\\S+$ does not match`, value: 'nope@gmail' }]);
+    expect(validate<Email>('@')).toEqual([{ path: '', code: 'pattern', message: `Pattern ^\\S+@\\S+\\.\\S+$ does not match`, value: '@' }]);
 });
 
 test('minLength', () => {
@@ -147,7 +148,8 @@ test('class', () => {
     expect(is<User>({ id: 0, logins: 0, username: 'Peter' })).toBe(true);
     expect(is<User>({ id: -1, logins: 0, username: 'Peter' })).toBe(false);
     expect(is<User>({ id: 0, logins: 0, username: 'AB' })).toBe(false);
-    expect(is<User>({ id: 0, logins: 0, username: 'Peter', email: 'abc@abc' })).toBe(true);
+    expect(is<User>({ id: 0, logins: 0, username: 'Peter', email: 'abc@abc.com' })).toBe(true);
+    expect(is<User>({ id: 0, logins: 0, username: 'Peter', email: 'abc@abc' })).toBe(false);
     expect(is<User>({ id: 0, logins: 0, username: 'Peter', email: 'abc' })).toBe(false);
 });
 


### PR DESCRIPTION
### Summary of changes

I had some users enter `someuser@gmail` as their email.  The validator accepted it, but then Stripe threw when trying to create their customer profile since `gmail` isn't a valid FQDN.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
