### PR TITLE
fix(type-compiler): Node InferType did not pass test 'isEntityName'.

### DIFF
--- a/packages/type-compiler/src/compiler.ts
+++ b/packages/type-compiler/src/compiler.ts
@@ -2382,7 +2382,7 @@ export class ReflectionTransformer implements CustomTransformer {
                     const searchArgument = (node: Node): Node => {
                         node = visitEachChild(node, searchArgument, this.context);
 
-                        if (isIdentifier(node) && node.escapedText === argumentName) {
+                        if (isTypeReferenceNode(node) && isIdentifier(node.typeName) && node.typeName.escapedText === argumentName) {
                             //transform to infer T
                             found = true;
                             node = this.f.createInferTypeNode(declaration);


### PR DESCRIPTION
### Summary of changes
https://github.com/microsoft/TypeScript/issues/56480#issuecomment-2004965554

Fixes https://github.com/deepkit/deepkit-framework/issues/509


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
