### PR TITLE
fix(http): support for JSON array payloads

### DIFF
--- a/packages/http/src/request-parser.ts
+++ b/packages/http/src/request-parser.ts
@@ -39,7 +39,14 @@ function parseBody(
             if (err) {
                 reject(err);
             } else {
-                for (const [name, file] of Object.entries(files) as any) {
+                const fileEntries = Object.entries(files);
+
+                // formidable turns JSON arrays into numerically keyed objects, so we convert them back
+                if ('0' in fields && fileEntries.length === 0 && Object.keys(fields).every((key, idx) => parseInt(key) === idx)) {
+                    return resolve(Object.values(fields));
+                }
+
+                for (const [name, file] of fileEntries as any) {
                     if (!file.filepath || 'string' !== typeof file.filepath) continue;
                     if (!file.size || 'number' !== typeof file.size) continue;
                     if (file.lastModifiedDate && !(file.lastModifiedDate instanceof Date)) continue;

--- a/packages/http/tests/router.spec.ts
+++ b/packages/http/tests/router.spec.ts
@@ -945,6 +945,15 @@ test('BodyValidation', async () => {
 
             throw new HttpBadRequestError('Invalid: ' + user.error.getErrorMessageForPath('username'));
         }
+
+        @http.POST('/action4')
+        action4(users: HttpBodyValidation<AddUserDto[]>): User[] {
+            if (users.valid()) {
+                return users.value;
+            }
+
+            throw new HttpBadRequestError('Invalid: ' + users.error.getErrorMessageForPath('0.username'));
+        }
     }
 
     const httpKernel = createHttpKernel([Controller]);
@@ -958,6 +967,9 @@ test('BodyValidation', async () => {
 
     expect((await httpKernel.request(HttpRequest.POST('/action3').json({ username: 'Peter' }))).json).toEqual({ username: 'Peter' });
     expect((await httpKernel.request(HttpRequest.POST('/action3').json({ username: 'Pe' }))).json.message).toEqual('Invalid: username(minLength): Min length is 3 caused by value "Pe"');
+
+    expect((await httpKernel.request(HttpRequest.POST('/action4').json([{ username: 'Peter' }]))).json).toEqual([{ username: 'Peter' }]);
+    expect((await httpKernel.request(HttpRequest.POST('/action4').json([{ username: 'Pe' }]))).json.message).toEqual('Invalid: 0.username(minLength): Min length is 3 caused by value "Pe"');
 });
 
 test('unpopulated entity without type information', async () => {


### PR DESCRIPTION
### Summary of changes
JSON array payloads are converted into objects by formidable.  This prevents HttpBody/HttpBodyValidator from properly validating the data (it doesn't pass the `isIterable` check, so `body` ends up being `undefined` after serialization).

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
