### PR TITLE
docs(bun): setup bun test runner

### DIFF
--- a/packages/bun/README.md
+++ b/packages/bun/README.md
@@ -24,3 +24,12 @@ bun install @deepkit/type @deepkit/type-compiler @deepkit/core @deepkit/bun type
     "reflection": true
 }
 ```
+
+## Bun test runner
+
+To use the [bun test runner](https://bun.sh/docs/cli/test) instead of Jest add the following to file `bunfig.toml`:
+
+```toml
+[test]
+preload = ["@deepkit/bun"]
+```


### PR DESCRIPTION
### Motivation

Users of Bun most likely want to use the "battery included" test runner instead of separately installing Jest.

For newcomers that want to use Bun it might not be obvious that root `preload` doesn't apply for tests also and they get the error `No valid runtime type ... given` when running the tests.

### Summary of changes

Show how to setup this plugin to be able to use the bun test runner.


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
