### PR TITLE
fix(sql): repair & enable @deepkit/sql tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,7 @@ jobs:
             packages/injector/ \
             packages/logger/ \
             packages/template/ \
+            packages/sql/ \
             packages/stopwatch/ \
             packages/workflow/ \
             packages/type/


### PR DESCRIPTION
### Summary of changes
@deepkit/sql tests should have been failing since the addition of:
https://github.com/deepkit/deepkit-framework/blame/v1.0.1-alpha.153/packages/sql/src/sql-filter-builder.ts#L31

where the following wasn't updated:
https://github.com/deepkit/deepkit-framework/blame/v1.0.1-alpha.153/packages/sql/tests/sql-query.spec.ts#L103

I discovered packages/sql isn't being tested.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
