### PR TITLE
fix(sql): fix queries where value legitimately begins with $

### DIFF
--- a/packages/sql/src/sql-builder.ts
+++ b/packages/sql/src/sql-builder.ts
@@ -459,3 +459,7 @@ export class SqlBuilder {
         return sql;
     }
 }
+
+export class SqlReference {
+    constructor(public readonly field: string) {}
+}

--- a/packages/sql/src/sql-filter-builder.ts
+++ b/packages/sql/src/sql-filter-builder.ts
@@ -20,6 +20,7 @@ import {
 } from '@deepkit/type';
 import { SqlPlaceholderStrategy } from './platform/default-platform.js';
 import { getPreparedEntity, PreparedAdapter, PreparedEntity } from './prepare.js';
+import { SqlReference } from './sql-builder.js';
 
 type Filter = { [name: string]: any };
 
@@ -111,10 +112,9 @@ export class SQLFilterBuilder {
         else if (comparison === 'regex') return this.regexpComparator(this.quoteIdWithTable(fieldName), value);
         else throw new Error(`Comparator ${comparison} not supported.`);
 
-        const referenceValue = 'string' === typeof value && value[0] === '$';
         let rvalue = '';
-        if (referenceValue) {
-            rvalue = `${this.quoteIdWithTable(value.substr(1))}`;
+        if (value instanceof SqlReference) {
+            rvalue = `${this.quoteIdWithTable(value.field)}`;
         } else {
             if (value === undefined || value === null) {
                 cmpSign = cmpSign === '!=' ? this.isNotNull() : this.isNull();

--- a/packages/sql/tests/sql-query.spec.ts
+++ b/packages/sql/tests/sql-query.spec.ts
@@ -6,7 +6,7 @@ import { splitDotPath, sql, SQLQueryModel } from '../src/sql-adapter.js';
 import { DefaultPlatform, SqlPlaceholderStrategy } from '../src/platform/default-platform.js';
 import { SchemaParser } from '../src/reverse/schema-parser.js';
 import { DatabaseModel } from '../src/schema/table.js';
-import { SqlBuilder } from '../src/sql-builder.js';
+import { SqlBuilder, SqlReference } from '../src/sql-builder.js';
 import { PreparedAdapter } from '../src/prepare.js';
 
 function quoteId(value: string): string {
@@ -110,7 +110,7 @@ test('QueryToSql', () => {
     const queryToSql = new SQLFilterBuilder(localAdapter, ReflectionClass.from(User), quoteId('user'), serializer, new SqlPlaceholderStrategy());
 
     expect(queryToSql.convert({ id: 123 })).toBe(`user.id = ?`);
-    expect(queryToSql.convert({ id: '$id' })).toBe(`user.id = user.id`);
+    expect(queryToSql.convert({ id: new SqlReference('id') })).toBe(`user.id = user.id`);
 
     expect(queryToSql.convert({ username: 'Peter' })).toBe(`user.username = ?`);
     expect(queryToSql.convert({ id: 44, username: 'Peter' })).toBe(`(user.id = ? AND user.username = ?)`);


### PR DESCRIPTION
### Summary of changes
There are legitimate cases where a value may begin with `$`, and the current reference implementation breaks those cases.  Example case, I have a query that looks for duplicate products named `$100 Gift Card`.  This should result in: 
```
WHERE `products`.`name` = ?
```
but it instead translates into:
```
WHERE `products`.`name` = `products`.`100 GC`
```

This PR introduces a new `SqlReference` class that can be used for cases where a reference is actually desired.

I only see a single usage case in the Deepkit source, and it's in the tests.  It's unclear how many Deepkit users this may impact, but I do think it's important to fix.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
