### PR TITLE
feat(http): added cookie helpers

### DIFF
--- a/packages/http/src/cookies.ts
+++ b/packages/http/src/cookies.ts
@@ -1,0 +1,62 @@
+import { HttpRequest } from './model.js';
+
+export type ParsedCookies = Record<string, string>;
+
+export function createLazyCookiesAccessor(requestHeaders: HttpRequest['headers']): ParsedCookies {
+    const cookieHeaderContents = requestHeaders['cookie'];
+    if (cookieHeaderContents === undefined) {
+        return {};
+    }
+
+    const parsedCookies: ParsedCookies = {};
+
+    let wasParsingPerformed = false;
+    function parseCookies() {
+        Object.assign(parsedCookies, parseCookiesFromCookieHeader(cookieHeaderContents as string))
+        wasParsingPerformed = true;
+    }
+
+    return new Proxy(parsedCookies, {
+        get(target, prop, receiver) {
+            if (!wasParsingPerformed) { parseCookies(); }
+            return Reflect.get(target, prop, receiver);
+        },
+
+        has(target, prop) {
+            if (!wasParsingPerformed) { parseCookies(); }
+            return Reflect.has(target, prop);
+        }
+    });
+}
+
+
+const validCookieNameRegExp = /^[\w!#$%&'*.^`|~+-]+$/;
+const validCookieValueRegExp = /^[ !#-:<-[\]-~]*$/;
+
+export function parseCookiesFromCookieHeader(cookieHeaderValue: string): ParsedCookies {
+    const pairs = cookieHeaderValue.trim().split(';');
+
+    return pairs.reduce<ParsedCookies>((parsedCookie, pairStr) => {
+        pairStr = pairStr.trim();
+
+        const valueStartPos = pairStr.indexOf('=');
+        if (valueStartPos === -1) {
+            return parsedCookie;
+        }
+
+        const cookieName = pairStr.substring(0, valueStartPos).trim();
+        if (!validCookieNameRegExp.test(cookieName)) {
+            return parsedCookie;
+        }
+
+        let cookieValue = pairStr.substring(valueStartPos + 1).trim();
+        if (cookieValue.startsWith('"') && cookieValue.endsWith('"')) {
+            cookieValue = cookieValue.slice(1, -1);
+        }
+        if (validCookieValueRegExp.test(cookieValue)) {
+            parsedCookie[cookieName] = decodeURIComponent(cookieValue);
+        }
+
+        return parsedCookie;
+    }, {});
+}

--- a/packages/http/src/model.ts
+++ b/packages/http/src/model.ts
@@ -224,6 +224,26 @@ export type HttpPath<T, Options extends { name?: string } = {}> = T & TypeAnnota
 export type HttpHeader<T, Options extends { name?: string } = {}> = T & TypeAnnotation<'httpHeader', Options>;
 
 /**
+ * Marks a parameter as HTTP cookie and reads the value from the request 'Cookie' header.
+ *
+ * @example
+ * ```typescript
+ * class Controller {
+ *    @http.GET('/api')
+ *    route(session: HttpCookie<string>) {
+ *         //authorization is string and required
+ *         //use `session?: HttpCookie<string>` to make it optional
+ *    }
+ * }
+ *
+ * // curl /api -H 'Cookie: session=123'
+ * ```
+ *
+ * To change the cookie name, use `param: HttpCookie<string, {name: 'cookieName'}>`.
+ */
+export type HttpCookie<T, Options extends { name?: string } = {}> = T & TypeAnnotation<'httpCookie', Options>;
+
+/**
  * Marks a parameter as HTTP query and reads the value from the request query string.
  *
  * @example

--- a/packages/http/src/module.ts
+++ b/packages/http/src/module.ts
@@ -20,7 +20,8 @@ function parameterRequiresRequest(parameter: ReflectionParameter): boolean {
         || metaAnnotation.getForName(parameter.type, 'httpBody')
         || metaAnnotation.getForName(parameter.type, 'httpRequestParser')
         || metaAnnotation.getForName(parameter.type, 'httpPath')
-        || metaAnnotation.getForName(parameter.type, 'httpHeader'));
+        || metaAnnotation.getForName(parameter.type, 'httpHeader')
+        || metaAnnotation.getForName(parameter.type, 'httpCookie'));
 }
 
 export class HttpModule extends createModule({

--- a/packages/http/src/router.ts
+++ b/packages/http/src/router.ts
@@ -33,6 +33,7 @@ import qs from 'qs';
 import { HtmlResponse, JSONResponse, Response } from './http.js';
 import { getRequestParserCodeForParameters, ParameterForRequestParser, parseRoutePathToRegex } from './request-parser.js';
 import { HttpConfig } from './module.config.js';
+import { createLazyCookiesAccessor } from './cookies';
 
 export type RouteParameterResolverForInjector = ((injector: InjectorContext) => HttpRequestPositionedParameters | Promise<HttpRequestPositionedParameters>);
 
@@ -704,6 +705,7 @@ export class HttpRouter {
         const compiler = new CompilerContext;
         compiler.context.set('ValidationError', ValidationError);
         compiler.context.set('qs', qs);
+        compiler.context.set('createLazyCookiesAccessor', createLazyCookiesAccessor);
 
         const code: string[] = [];
 
@@ -716,6 +718,7 @@ export class HttpRouter {
             const _method = request.method || 'GET';
             const _url = request.url || '/';
             const _headers = request.headers || {};
+            const _cookies = createLazyCookiesAccessor(_headers);
             const _qPosition = _url.indexOf('?');
             let uploadedFiles = {};
             const _path = _qPosition === -1 ? _url : _url.substr(0, _qPosition);


### PR DESCRIPTION
### Summary of changes

```ts
/**
 * Marks a parameter as HTTP cookie and reads the value from the request 'Cookie' header.
 *
 * @example
 * ```typescript
 * class Controller {
 *    @http.GET('/api')
 *    route(session: HttpCookie<string>) {
 *         //authorization is string and required
 *         //use `session?: HttpCookie<string>` to make it optional
 *    }
 * }
 *
 * // curl /api -H 'Cookie: session=123'
 * ```
 *
 * To change the cookie name, use `param: HttpCookie<string, {name: 'cookieName'}>`.
 */
export type HttpCookie<T, Options extends { name?: string } = {}> = T & TypeAnnotation<'httpCookie', Options>;
```


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
