### PR TITLE
fix(type): add scope in setter code to prevent `variable already declared #603

### DIFF
--- a/packages/type/src/serializer.ts
+++ b/packages/type/src/serializer.ts
@@ -1792,16 +1792,18 @@ export function handleUnion(type: TypeUnion, state: TemplateState) {
     ` : '';
 
     state.addCodeForSetter(`
-        const oldErrors = state.errors;
-        if (state.errors) state.errors = [];
+        {
+            const oldErrors = state.errors;
+            if (state.errors) state.errors = [];
 
-        //type guard for union
-        if (false) {} ${lines.join(' ')}
-        else {
-            ${handleErrors}
-            ${state.assignValidationError('type', 'No valid union member found. Valid: ' + stringifyResolvedType(type))}
+            //type guard for union
+            if (false) {} ${lines.join(' ')}
+            else {
+                ${handleErrors}
+                ${state.assignValidationError('type', 'No valid union member found. Valid: ' + stringifyResolvedType(type))}
+            }
+            state.errors = oldErrors;
         }
-        state.errors = oldErrors;
     `);
 }
 

--- a/packages/type/tests/issues/tuples.spec.ts
+++ b/packages/type/tests/issues/tuples.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@jest/globals';
+import { cast, validate } from '@deepkit/type';
+
+test('cast literal obj having typed tuple [number | null, number | null] as nested prop', () => {
+    type MinMax = [number | null, number | null];
+
+    class T {
+        building!: {
+            area: MinMax
+        };
+    }
+
+    // const d = JSON.parse('{"building":{"area":[120,null]}}');
+    const d = {
+        building: {
+            area: [120, null],
+        },
+    };
+
+    const errors = validate<T>(d);
+    expect(errors.length).toBe(0);
+
+    const casted: T = cast<T>(d);
+
+    expect(casted.building.area[0]).toBe(120);
+    expect(casted.building.area[1]).toBe(null);
+});
+
+test('cast literal obj to T containing typed tuple', () => {
+    type SomeData = [string | null, string, string | null];
+
+    class T {
+        tuple!: SomeData;
+    }
+
+    const d = {
+        tuple: [null, 'z', null],
+    };
+
+    const errors = validate<T>(d);
+    expect(errors.length).toBe(0);
+
+    const casted: T = cast<T>(d);
+
+    expect(casted.tuple[0]).toBe(null);
+    expect(casted.tuple[1]).toBe('z');
+    expect(casted.tuple[2]).toBe(null);
+});
+
+test("cast literal obj having typed tuple [number | null, number | null] as nested prop", () => {
+    type MinMax = [min: number | null, max: number | null];
+
+    class T {
+        building?: {
+            area?: MinMax
+        }
+    }
+
+    // const d = JSON.parse('{"building":{"area":[120,null]}}');
+
+    const data: T = cast<T>({
+        building: {
+            area: [120, null]
+        }
+    });
+
+    const errors = validate<T>(data);
+    expect(errors.length).toBe(0);
+});


### PR DESCRIPTION
- When a tuple definition contained "duplicated" union types like [number|null, number|null], the jitted function couldln't be build as some variable like `oldErrors` were already declared. Probably one block per number|null

### Summary of changes
Added scope 

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x ] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
