### PR TITLE
fix(type-compiler): include enum annotations in .d.ts transformation

### DIFF
--- a/packages/type-compiler/src/compiler.ts
+++ b/packages/type-compiler/src/compiler.ts
@@ -2762,7 +2762,7 @@ export class DeclarationTransformer extends ReflectionTransformer {
         const visitor = (node: Node): any => {
             node = visitEachChild(node, visitor, this.context);
 
-            if ((isTypeAliasDeclaration(node) || isInterfaceDeclaration(node)) && hasModifier(node, SyntaxKind.ExportKeyword)) {
+            if ((isTypeAliasDeclaration(node) || isInterfaceDeclaration(node) || isEnumDeclaration(node)) && hasModifier(node, SyntaxKind.ExportKeyword)) {
                 const reflection = this.isWithReflection(sourceFile, node);
                 if (reflection) {
                     this.addExports.push({ identifier: getIdentifierName(this.getDeclarationVariableName(node.name)) });


### PR DESCRIPTION
### Summary of changes

Exported enums seem to not generate `__Ω` annotations in their respective `.d.ts` files. This leads to `Symbol ___Ω not found in...` type errors when other packages want to use those definitions.

Adding this check *seems* to have the desired effect and looks like one of the other checks above: https://github.com/deepkit/deepkit-framework/blob/master/packages/type-compiler/src/compiler.ts#L910

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
