### PR TITLE
fix(http): make the debug panel compatible with Yarn PnP installs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,8 @@ jobs:
             packages/sqlite/tsconfig.json \
             packages/topsort/tsconfig.json \
             packages/type/tsconfig.json \
-            packages/type-spec/tsconfig.json
+            packages/type-spec/tsconfig.json \
+            && mv packages/framework/dist/cjs/src/debug/resolve.cjs packages/framework/dist/cjs/src/debug/resolve.js
       - name: Test
         run: |
           npm run test:coverage \

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "node --max_old_space_size=3048 node_modules/jest/bin/jest.js --forceExit --no-cache",
     "test:coverage": "node --max_old_space_size=3048 node_modules/jest/bin/jest.js --coverage --forceExit --no-cache",
-    "build": "tsc --build tsconfig.json && tsc --build tsconfig.esm.json && lerna run build",
-    "build:esm": "tsc --build tsconfig.esm.json",
+    "build": "tsc --build tsconfig.json && mv packages/framework/dist/cjs/src/debug/resolve.cjs packages/framework/dist/cjs/src/debug/resolve.js && tsc --build tsconfig.esm.json && mv packages/framework/dist/esm/src/debug/resolve.mjs packages/framework/dist/esm/src/debug/resolve.js && lerna run build",
+    "build:esm": "tsc --build tsconfig.esm.json && tsc --build tsconfig.esm.json",
     "tsc": "tsc --build",
     "postinstall": "lefthook install && sh install-compiler.sh",
     "tsc-watch": "tsc --build --watch",

--- a/packages/framework-debug-gui/package.json
+++ b/packages/framework-debug-gui/package.json
@@ -18,6 +18,7 @@
   "files": [
     "dist"
   ],
+  "preferUnplugged": true,
   "devDependencies": {
     "@angular-devkit/build-angular": "^17.1.0",
     "@angular/animations": "^17.1.0",

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "test": "jest --coverage",
-    "tsc": "rm -rf dist && ../../node_modules/.bin/tsc",
+    "tsc": "rm -rf dist && ../../node_modules/.bin/tsc && mv dist/cjs/src/debug/resolve.cjs dist/cjs/src/debug/resolve.js",
     "tsc-watch": "rm -rf dist && tsc --watch"
   },
   "peerDependencies": {

--- a/packages/framework/src/debug/http-debug.controller.ts
+++ b/packages/framework/src/debug/http-debug.controller.ts
@@ -9,16 +9,19 @@
  */
 
 import { registerStaticHttpController } from '@deepkit/http';
-import { AppModule, findParentPath } from '@deepkit/app';
-import { dirname } from 'path';
-import { getCurrentFileName } from '@deepkit/core';
+import { AppModule } from '@deepkit/app';
+import { resolve } from './resolve.js';
 
 export function registerDebugHttpController(module: AppModule<any>, path: string): void {
-    const currentDir = dirname(getCurrentFileName());
-    const localPath = findParentPath('node_modules/@deepkit/framework-debug-gui/dist/framework-debug-gui', currentDir);
-    if (localPath) {
-        registerStaticHttpController(module, { path, localPath, groups: ['app-static'], controllerName: 'FrameworkDebuggerController' });
-    } else {
-        console.log('Warning: node_modules/@deepkit/framework-debug-gui no build found in ' + currentDir);
-    }
+    const localPath = (() => {
+        try {
+            return resolve('@deepkit/framework-debug-gui/dist/framework-debug-gui/index.html')
+        } catch (e) {
+            console.log('Warning: @deepkit/framework-debug-gui assets location not resolved.')
+            return null
+        }
+    })()
+    if (!localPath) return
+
+    registerStaticHttpController(module, { path, localPath, groups: ['app-static'], controllerName: 'FrameworkDebuggerController' });
 }

--- a/packages/framework/src/debug/resolve.cts
+++ b/packages/framework/src/debug/resolve.cts
@@ -1,0 +1,8 @@
+import { createRequire } from "module";
+import { dirname } from "path"
+import { pathToFileURL } from "url";
+
+export function resolve(assetName: string): string {
+    const require = createRequire(pathToFileURL(__filename).toString());
+    return dirname(require.resolve(assetName))
+}

--- a/packages/framework/src/debug/resolve.d.ts
+++ b/packages/framework/src/debug/resolve.d.ts
@@ -1,0 +1,1 @@
+export function resolve(assetName: string): string;

--- a/packages/framework/src/debug/resolve.mts
+++ b/packages/framework/src/debug/resolve.mts
@@ -1,0 +1,12 @@
+import { dirname } from "path"
+
+export function resolve(assetName: string): string {
+    // @ts-ignore
+    const assetUrl = import.meta.resolve(assetName)
+
+    if (!assetUrl.startsWith('file://')) {
+        throw new Error('Invalid local URL')
+    }
+
+    return dirname(assetUrl.substring('file://'.length))
+}

--- a/packages/framework/tsconfig.esm.json
+++ b/packages/framework/tsconfig.esm.json
@@ -4,6 +4,10 @@
     "outDir": "./dist/esm",
     "module": "ES2020"
   },
+  "exclude": [
+    "tests",
+    "src/debug/resolve.cts"
+  ],
   "references": [
     {
       "path": "../api-console-module/tsconfig.esm.json"

--- a/packages/framework/tsconfig.json
+++ b/packages/framework/tsconfig.json
@@ -37,7 +37,8 @@
     "loader.ts"
   ],
   "exclude": [
-    "tests"
+    "tests",
+    "src/debug/resolve.mts"
   ],
   "references": [
     {


### PR DESCRIPTION
I'm trying to get deepkit running with Yarn PnP (using [deepkit-node](https://github.com/LEW21/deepkit-node) - I might send a pull request with that later, when I figure out if it'll actually be usable).

### Summary of changes

Right now, running an app (`yarn node --import deepkit-node ./app.ts server:start`) with `FrameworkModule({ debug: true })` in a Yarn PnP environment produces a warning:
```
Warning: node_modules/@deepkit/framework-debug-gui no build found in /home/linus/dev/my-deepkit-app/.yarn/unplugged/@deepkit-framework-virtual-9069fc273b/node_modules/@deepkit/framework/dist/esm/src/debug
```
As a result, the debug panel doesn't work. This is because the `node_modules` path is hardcoded, and there is no `node_modules` on Yarn PnP.

With this change, it works. I'm using `import.meta.resolve` to resolve a path to index.html, and I'm forcing yarn to actually unzip ("unplug") the static files, so that it's possible to access them in a traditional way.

As `import.meta` is accessible only in the ESM mode, I'm doing some hack to do the resolution with `require.resolve` in CJS mode - I don't really like this solution, but I don't have any idea for a better one. Theoretically, this should be transparently handled by the ESM->CJS transpiler, but TypeScript doesn't support it.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
