### PR TITLE
refactor: call transformError when error is thrown outside of actions

### DIFF
--- a/packages/rpc/src/protocol.ts
+++ b/packages/rpc/src/protocol.ts
@@ -737,5 +737,9 @@ export function rpcDecodeError(error: EncodedError): Error {
     const e = new Error(error.message);
     e.stack = error.stack + '\nat ___SERVER___';
 
+    if(error.stack === "") {
+        e.stack = ""
+    }
+
     return e;
 }

--- a/packages/rpc/src/server/kernel.ts
+++ b/packages/rpc/src/server/kernel.ts
@@ -528,7 +528,7 @@ export class RpcKernelConnection extends RpcKernelBaseConnection {
                     return await this.actionHandler.handle(message, response);
             }
         } catch (error: any) {
-            response.error(error);
+            response.error(this.security.transformError(error));
         }
     }
 

--- a/packages/rpc/tests/security.spec.ts
+++ b/packages/rpc/tests/security.spec.ts
@@ -102,6 +102,36 @@ test('authentication errors', async () => {
     expect(memoryLogger.messages.length).toBe(1);
 });
 
+test('authentication errors and calls transformError', async () => {
+    let transformedError: Error | null = null;
+
+    class MyKernelSecurity extends RpcKernelSecurity {
+        async authenticate(token: any): Promise<Session> {
+           throw new Error('Malformed token');
+        }
+
+        override transformError(err: Error) {
+            transformedError = new Error("Transformed");
+            transformedError.stack = "";
+            return transformedError;
+        }
+    }
+
+    const kernel = new RpcKernel([{ provide: RpcKernelSecurity, useClass: MyKernelSecurity, scope: 'rpc' }]);
+    const client = new DirectClient(kernel);
+
+    client.token.set('generic');
+
+    try {
+        await client.connect()
+    } catch(e: any) {
+        expect(e.stack).toBe('');
+    }
+
+    expect(transformedError).toBeInstanceOf(Error);
+    expect(transformedError!.message).toBe('Transformed');
+});
+
 
 test('onAuthenticate controllers', async () => {
     class AuthenticatedSession extends Session {


### PR DESCRIPTION
### Summary of changes

- Previously transformError was not called when an error occured in kernel.authenticate() for instance
- Enable better sanitization of errors

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
