### PR TITLE
fix(mysql): don't process delete PKs if no rows were affected

### DIFF
--- a/packages/mysql/src/mysql-adapter.ts
+++ b/packages/mysql/src/mysql-adapter.ts
@@ -427,9 +427,12 @@ export class MySQLQueryResolver<T extends OrmEntity> extends SQLQueryResolver<T>
             `;
 
             const rows = await connection.execAndReturnAll(sql, select.params);
-            const returning = rows[1];
-            const pk = returning[0]['@_pk'];
-            if (pk) deleteResult.primaryKeys = JSON.parse(pk).map(primaryKeyConverted);
+            const affectedRows = rows[0].affectedRows;
+            if (affectedRows) {
+                const returning = rows[1];
+                const pk = returning[0]['@_pk'];
+                deleteResult.primaryKeys = JSON.parse(pk).map(primaryKeyConverted);
+            }
             deleteResult.modified = deleteResult.primaryKeys.length;
         } catch (error: any) {
             error = new DatabaseDeleteError(this.classSchema, 'Could not delete in database', { cause: error });

--- a/packages/mysql/tests/mysql.spec.ts
+++ b/packages/mysql/tests/mysql.spec.ts
@@ -344,3 +344,43 @@ test('non-object null unions should not render as JSON', async () => {
         {name: 'Thomas', nickName: 'Tom', birthdate: new Date('1960-02-10T00:00:00Z')},
     ]);
 });
+
+test('updates & deletes should ignore previous @_pk session variable if no rows were affected', async () => {
+    @entity.name('model7')
+    class Model {
+        id: number & PrimaryKey & AutoIncrement = 0;
+
+        constructor(public name: string) {}
+    }
+
+    const database = await databaseFactory([Model]);
+    const model = new Model('Peter');
+    await database.persist(model);
+    expect(model.id).toEqual(expect.any(Number));
+
+    // perform update & delete in single database connection to ensure @_pk session variable is shared
+    // between multiple queries. outside a transaction, this is luck of the draw based on connection pooling.
+    await database.transaction(async txn => {
+        {
+            const result = await txn.query(Model).filter({id: model.id}).patchMany({name: 'Paul'});
+            expect(result.primaryKeys[0]).toEqual({ id: model.id });
+        }
+
+        {
+            const result = await txn.query(Model).filter({id: model.id}).deleteMany();
+            expect(result.primaryKeys[0]).toEqual({ id: model.id });
+        }
+
+        // there should be no ID returned if we try to update a non-existent record
+        {
+            const result = await txn.query(Model).filter({id: model.id}).patchMany({name: 'Simon'});
+            expect(result.primaryKeys[0]).toBeUndefined();
+        }
+
+        // there should be no ID returned if we try to delete a non-existent record
+        {
+            const result = await txn.query(Model).filter({id: model.id}).deleteMany();
+            expect(result.primaryKeys[0]).toBeUndefined();
+        }
+    });
+});


### PR DESCRIPTION
### Summary of changes

MySQL deletes aren't checking for a modified row count. As a result, if you perform a delete that affects 0 rows, and the `@_pk` session variable is set from a previous operation on that MySQL connection, `delete` returns incorrect values for its `primaryKeys` and `modified` result object properties.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
