### PR TITLE
fix(type): convert TypeAnnotation into intrinsic type

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -16,6 +16,8 @@
  * ```
  *
  * Runtime type is `{ __meta?: never & [T, Options] };`
+ *
+ * @intrinsic
  */
 export type TypeAnnotation<T extends string, Options = never> = unknown;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,2 +1,23 @@
-export type InjectMeta<T = never> = { __meta?: never & ['inject', T] };
+/**
+ * Type to use for custom type annotations.
+ *
+ * Adds runtime meta information to a type without influencing the type itself.
+ * This is like an intrinsic type, but only for runtime.
+ *
+ * ```typescript
+ * import { TypeAnnotation } from '@deepkit/core';
+ * import { typeAnnotation } from '@deepkit/type';
+ *
+ * type PrimaryKey = TypeAnnotation<'primaryKey'>;
+ * type UserId = string & PrimaryKey;
+ *
+ * const type = typeOf<UserId>();
+ * const metaData = typeAnnotation.getType(type, 'primaryKey');
+ * ```
+ *
+ * Runtime type is `{ __meta?: never & [T, Options] };`
+ */
+export type TypeAnnotation<T extends string, Options = never> = unknown;
+
+export type InjectMeta<T = never> = TypeAnnotation<'inject', T>;
 export type Inject<Type, Token = never> = Type & InjectMeta<Token>;

--- a/packages/desktop-ui/src/components/app/state.ts
+++ b/packages/desktop-ui/src/components/app/state.ts
@@ -1,5 +1,23 @@
-import { deserialize, Excluded, metaAnnotation, ReflectionClass, ReflectionKind, resolveTypeMembers, serialize, Serializer, Type, TypeAnnotation, TypeClass } from '@deepkit/type';
-import { ClassType, getClassTypeFromInstance, getPathValue, setPathValue, throttleTime } from '@deepkit/core';
+import {
+    deserialize,
+    Excluded,
+    ReflectionClass,
+    ReflectionKind,
+    resolveTypeMembers,
+    serialize,
+    Serializer,
+    Type,
+    typeAnnotation,
+    TypeClass,
+} from '@deepkit/type';
+import {
+    ClassType,
+    getClassTypeFromInstance,
+    getPathValue,
+    setPathValue,
+    throttleTime,
+    TypeAnnotation,
+} from '@deepkit/core';
 import { EventToken } from '@deepkit/event';
 import { ApplicationRef, Injector } from '@angular/core';
 import { NavigationEnd, ResolveEnd, Router } from '@angular/router';
@@ -101,7 +119,7 @@ export function findPartsOfUrlForType(type: Type, paths: string[] = [], prefix: 
             if (property.type.kind === ReflectionKind.class || property.type.kind === ReflectionKind.objectLiteral) {
                 findPartsOfUrlForType(property.type, paths, (prefix ? prefix + '.' : '') + String(property.name), state);
             } else {
-                const meta = metaAnnotation.getForName(property.type, 'partOfUrl');
+                const meta = typeAnnotation.getType(property.type, 'partOfUrl');
                 if (meta) {
                     paths.push((prefix ? prefix + '.' : '') + String(property.name));
                 }

--- a/packages/http/src/model.ts
+++ b/packages/http/src/model.ts
@@ -12,8 +12,8 @@ import { IncomingMessage, OutgoingHttpHeader, OutgoingHttpHeaders, ServerRespons
 import { UploadedFile } from './router.js';
 import * as querystring from 'querystring';
 import { Writable } from 'stream';
-import { metaAnnotation, ReflectionKind, Type, TypeAnnotation, ValidationErrorItem } from '@deepkit/type';
-import { asyncOperation, isArray } from '@deepkit/core';
+import { ReflectionKind, Type, typeAnnotation, ValidationErrorItem } from '@deepkit/type';
+import { asyncOperation, isArray, TypeAnnotation } from '@deepkit/core';
 
 export class HttpResponse extends ServerResponse {
     status(code: number) {
@@ -276,13 +276,13 @@ export type HttpQueries<T, Options extends { name?: string } = {}> = T & TypeAnn
  * }
  * ```
  */
-export type HttpRegExp<T, Pattern extends string | RegExp> = T & { __meta?: never & ['httpRegExp', Pattern] };
+export type HttpRegExp<T, Pattern extends string | RegExp> = T & TypeAnnotation<'httpRegExp', Pattern>;
 
 export function getRegExp(type: Type): string | RegExp | undefined {
-    const options = metaAnnotation.getForName(type, 'httpRegExp');
-    if (!options || !options[0]) return;
-    if (options[0].kind === ReflectionKind.literal && 'string' === typeof options[0].literal) return options[0].literal;
-    if (options[0].kind === ReflectionKind.literal && options[0].literal instanceof RegExp) return options[0].literal;
+    const options = typeAnnotation.getType(type, 'httpRegExp');
+    if (!options) return;
+    if (options.kind === ReflectionKind.literal && 'string' === typeof options.literal) return options.literal;
+    if (options.kind === ReflectionKind.literal && options.literal instanceof RegExp) return options.literal;
     return;
 }
 

--- a/packages/http/src/module.ts
+++ b/packages/http/src/module.ts
@@ -10,17 +10,17 @@ import { HttpRequest, HttpResponse } from './model.js';
 import '@deepkit/type';
 import { httpClass } from './decorator.js';
 import { EventToken } from '@deepkit/event';
-import { metaAnnotation, ReflectionKind, ReflectionParameter, Type } from '@deepkit/type';
+import { ReflectionKind, ReflectionParameter, Type, typeAnnotation } from '@deepkit/type';
 import { buildRequestParser } from './request-parser.js';
 import { InjectorContext } from '@deepkit/injector';
 
 function parameterRequiresRequest(parameter: ReflectionParameter): boolean {
-    return Boolean(metaAnnotation.getForName(parameter.type, 'httpQueries')
-        || metaAnnotation.getForName(parameter.type, 'httpQuery')
-        || metaAnnotation.getForName(parameter.type, 'httpBody')
-        || metaAnnotation.getForName(parameter.type, 'httpRequestParser')
-        || metaAnnotation.getForName(parameter.type, 'httpPath')
-        || metaAnnotation.getForName(parameter.type, 'httpHeader'));
+    return Boolean(typeAnnotation.getType(parameter.type, 'httpQueries')
+        || typeAnnotation.getType(parameter.type, 'httpQuery')
+        || typeAnnotation.getType(parameter.type, 'httpBody')
+        || typeAnnotation.getType(parameter.type, 'httpRequestParser')
+        || typeAnnotation.getType(parameter.type, 'httpPath')
+        || typeAnnotation.getType(parameter.type, 'httpHeader'));
 }
 
 
@@ -72,7 +72,7 @@ export class HttpModule extends createModuleClass({
         const params = listener.reflection.getParameters().slice(1);
 
         for (const parameter of params) {
-            if (metaAnnotation.getForName(parameter.type, 'httpBody')) needsAsync = true;
+            if (typeAnnotation.getType(parameter.type, 'httpBody')) needsAsync = true;
             if (parameterRequiresRequest(parameter)) requiresHttpRequest = true;
         }
 
@@ -90,7 +90,7 @@ export class HttpModule extends createModuleClass({
             //change the reflection type so that we create a unique injection token for that type.
             const unique = Symbol('event.parameter:' + parameter.name);
             const uniqueType: Type = { kind: ReflectionKind.literal, literal: unique };
-            metaAnnotation.registerType(parameter.type, { name: 'inject', options: [uniqueType] });
+            typeAnnotation.registerType(parameter.type, { name: 'inject', options: uniqueType });
             let i = index;
 
             this.addProvider({

--- a/packages/http/src/request-parser.ts
+++ b/packages/http/src/request-parser.ts
@@ -7,13 +7,13 @@ import {
     getValidatorFunction,
     hasDefaultValue,
     isOptional,
-    metaAnnotation,
     ReflectionKind,
     ReflectionParameter,
     resolveReceiveType,
     serializer,
     stringifyType,
     Type,
+    typeAnnotation,
     typeToObject,
     ValidationError,
 } from '@deepkit/type';
@@ -91,21 +91,21 @@ export class ParameterForRequestParser {
     }
 
     get body() {
-        return metaAnnotation.getForName(this.parameter.type, 'httpBody') !== undefined;
+        return typeAnnotation.getType(this.parameter.type, 'httpBody') !== undefined;
     }
 
     get requestParser() {
-        return metaAnnotation.getForName(this.parameter.type, 'httpRequestParser') !== undefined;
+        return typeAnnotation.getType(this.parameter.type, 'httpRequestParser') !== undefined;
     }
 
     get bodyValidation() {
-        return metaAnnotation.getForName(this.parameter.type, 'httpBodyValidation') !== undefined;
+        return typeAnnotation.getType(this.parameter.type, 'httpBodyValidation') !== undefined;
     }
 
     getType(): Type {
-        const parser = metaAnnotation.getForName(this.parameter.type, 'httpRequestParser');
-        if (parser && parser[0]) {
-            return parser[0];
+        const parser = typeAnnotation.getType(this.parameter.type, 'httpRequestParser');
+        if (parser) {
+            return parser;
         }
 
         if (this.bodyValidation) {
@@ -118,22 +118,22 @@ export class ParameterForRequestParser {
     }
 
     get header() {
-        return metaAnnotation.getForName(this.parameter.type, 'httpHeader') !== undefined;
+        return typeAnnotation.getType(this.parameter.type, 'httpHeader') !== undefined;
     }
 
     get query() {
-        return metaAnnotation.getForName(this.parameter.type, 'httpQuery') !== undefined;
+        return typeAnnotation.getType(this.parameter.type, 'httpQuery') !== undefined;
     }
 
     get queries() {
-        return metaAnnotation.getForName(this.parameter.type, 'httpQueries') !== undefined;
+        return typeAnnotation.getType(this.parameter.type, 'httpQueries') !== undefined;
     }
 
     get typePath(): string | undefined {
-        const typeOptions = metaAnnotation.getForName(this.parameter.type, 'httpQueries') || metaAnnotation.getForName(this.parameter.type, 'httpQuery')
-            || metaAnnotation.getForName(this.parameter.type, 'httpPath') || metaAnnotation.getForName(this.parameter.type, 'httpHeader');
+        const typeOptions = typeAnnotation.getType(this.parameter.type, 'httpQueries') || typeAnnotation.getType(this.parameter.type, 'httpQuery')
+            || typeAnnotation.getType(this.parameter.type, 'httpPath') || typeAnnotation.getType(this.parameter.type, 'httpHeader');
         if (!typeOptions) return;
-        const options = typeToObject(typeOptions[0]);
+        const options = typeToObject(typeOptions);
         if (isObject(options)) return options.name;
         return;
     }
@@ -143,7 +143,7 @@ export class ParameterForRequestParser {
     }
 
     isPartOfPath(): boolean {
-        return metaAnnotation.getForName(this.parameter.type, 'httpPath') !== undefined || this.regexPosition !== undefined;
+        return typeAnnotation.getType(this.parameter.type, 'httpPath') !== undefined || this.regexPosition !== undefined;
     }
 }
 

--- a/packages/http/tests/router.spec.ts
+++ b/packages/http/tests/router.spec.ts
@@ -4,9 +4,9 @@ import { getActions, http, httpClass } from '../src/decorator.js';
 import { HtmlResponse, HttpAccessDeniedError, HttpBadRequestError, HttpNotFoundError, HttpUnauthorizedError, httpWorkflow, JSONResponse, Response } from '../src/http.js';
 import { eventDispatcher } from '@deepkit/event';
 import { HttpBody, HttpBodyValidation, HttpHeader, HttpPath, HttpQueries, HttpQuery, HttpRegExp, HttpRequest, HttpRequestParser, MemoryHttpResponse } from '../src/model.js';
-import { getClassName, isObject, sleep } from '@deepkit/core';
+import { getClassName, isObject, sleep, TypeAnnotation } from '@deepkit/core';
 import { createHttpKernel } from './utils.js';
-import { Excluded, Group, integer, JSONEntity, Maximum, metaAnnotation, MinLength, Positive, PrimaryKey, Reference, serializer, Type, typeSettings, UnpopulatedCheck } from '@deepkit/type';
+import { Excluded, Group, integer, JSONEntity, Maximum, MinLength, Positive, PrimaryKey, Reference, serializer, Type, typeAnnotation, typeSettings, UnpopulatedCheck } from '@deepkit/type';
 import { Readable } from 'stream';
 import { provide } from '@deepkit/injector';
 
@@ -1034,10 +1034,10 @@ test('unpopulated entity without type information', async () => {
 });
 
 test('extend with custom type', async () => {
-    type StringifyTransport = { __meta?: never & ['stringifyTransport'] };
+    type StringifyTransport = TypeAnnotation<'stringifyTransport'>;
 
     function isStringifyTransportType(type: Type): boolean {
-        return !!metaAnnotation.getForName(type, 'stringifyTransport');
+        return !!typeAnnotation.getType(type, 'stringifyTransport');
     }
 
     serializer.serializeRegistry.addPostHook((type, state) => {

--- a/packages/injector/src/injector.ts
+++ b/packages/injector/src/injector.ts
@@ -10,13 +10,30 @@ import {
     TagRegistry,
     Token,
 } from './provider.js';
-import { AbstractClassType, ClassType, CompilerContext, CustomError, getClassName, getPathValue, isArray, isClass, isFunction, isPrototypeOfBase } from '@deepkit/core';
-import { ConfigurationProviderRegistry, ConfigureProviderEntry, findModuleForConfig, getScope, InjectorModule, PreparedProvider } from './module.js';
+import {
+    AbstractClassType,
+    ClassType,
+    CompilerContext,
+    CustomError,
+    getClassName,
+    getPathValue,
+    isArray,
+    isClass,
+    isFunction,
+    isPrototypeOfBase,
+} from '@deepkit/core';
+import {
+    ConfigurationProviderRegistry,
+    ConfigureProviderEntry,
+    findModuleForConfig,
+    getScope,
+    InjectorModule,
+    PreparedProvider,
+} from './module.js';
 import {
     isOptional,
     isType,
     isWithAnnotations,
-    metaAnnotation,
     ReceiveType,
     reflect,
     ReflectionClass,
@@ -25,6 +42,7 @@ import {
     resolveReceiveType,
     stringifyType,
     Type,
+    typeAnnotation,
 } from '@deepkit/type';
 
 export class InjectorError extends CustomError {
@@ -166,9 +184,9 @@ export interface InjectorInterface {
  * Returns the injector token type if the given type was decorated with `Inject<T>`.
  */
 export function getInjectOptions(type: Type): Type | undefined {
-    const annotations = metaAnnotation.getForName(type, 'inject');
+    const annotations = typeAnnotation.getType(type, 'inject');
     if (!annotations) return;
-    const t = annotations[0];
+    const t = annotations;
     return t && t.kind !== ReflectionKind.never ? t : type;
 }
 

--- a/packages/injector/src/types.ts
+++ b/packages/injector/src/types.ts
@@ -1,7 +1,7 @@
 import { reflect, ReflectionKind, Type } from '@deepkit/type';
-import { getParentClass } from '@deepkit/core';
+import { getParentClass, TypeAnnotation } from '@deepkit/core';
 
-export type InjectMeta<T = never> = { __meta?: never & ['inject', T] }
+export type InjectMeta<T = never> = TypeAnnotation<'inject', T>;
 export type Inject<Type, Token = never> = Type & InjectMeta<Token>
 
 /**

--- a/packages/type-compiler/src/compiler.ts
+++ b/packages/type-compiler/src/compiler.ts
@@ -8,7 +8,7 @@
  * You should have received a copy of the MIT License along with this program.
  */
 
-import {
+import ts, {
     __String,
     ArrayTypeNode,
     ArrowFunction,
@@ -76,7 +76,6 @@ import {
     TypeReferenceNode,
     UnionTypeNode,
 } from 'typescript';
-import ts from 'typescript';
 
 import {
     ensureImportIsEmitted,
@@ -279,7 +278,7 @@ class CompilerProgram {
     protected activeCoRoutines: { ops: ReflectionOp[] }[] = [];
     protected coRoutines: { ops: ReflectionOp[] }[] = [];
 
-    constructor(public forNode: Node, public sourceFile: SourceFile) {
+    constructor(public forNode: Node, public sourceFile?: SourceFile) {
     }
 
     buildPackStruct() {
@@ -506,7 +505,7 @@ export class ReflectionTransformer implements CustomTransformer {
      * Types added to this map will get a type program at the top root level of the program.
      * This is for imported types, which need to be inlined into the current file, as we do not emit type imports (TS will omit them).
      */
-    protected embedDeclarations = new Map<Node, { name: EntityName, sourceFile: SourceFile }>();
+    protected embedDeclarations = new Map<Node, { name: EntityName, sourceFile?: SourceFile }>();
 
     /**
      * When a node was embedded or compiled (from the maps above), we store it here to know to not add it again.
@@ -530,6 +529,7 @@ export class ReflectionTransformer implements CustomTransformer {
      */
     protected tempResultIdentifier?: Identifier;
     protected parseConfigHost: ParseConfigHost;
+    protected intrinsicMetaDeclaration: Declaration;
 
     constructor(
         protected context: TransformationContext,
@@ -539,7 +539,7 @@ export class ReflectionTransformer implements CustomTransformer {
         this.nodeConverter = new NodeConverter(this.f);
         // It is important to not have undefined values like {paths: undefined} because it would override the read tsconfig.json.
         // Important to create a copy since we will modify it.
-        this.compilerOptions = {...filterUndefined(context.getCompilerOptions())};
+        this.compilerOptions = { ...filterUndefined(context.getCompilerOptions()) };
         // compilerHost has no internal cache and is cheap to build, so no cache needed.
         // Resolver loads SourceFile which has cache implemented.
         this.host = createCompilerHost(this.compilerOptions);
@@ -553,6 +553,36 @@ export class ReflectionTransformer implements CustomTransformer {
                 return this.host.readDirectory(path, extensions || [], exclude, include || [], depth);
             },
         };
+
+        {
+            // TypeAnnotation<T, Options> = { __meta?: never & [T, Options] }
+            const T = this.f.createIdentifier('T');
+            const Options = this.f.createIdentifier('Options');
+            this.intrinsicMetaDeclaration = this.f.createTypeAliasDeclaration(
+                [],
+                'TypeAnnotation',
+                [
+                    this.f.createTypeParameterDeclaration([], T),
+                    this.f.createTypeParameterDeclaration([], Options, undefined, this.f.createTypeReferenceNode('never')),
+                ],
+                this.f.createTypeLiteralNode([
+                    this.f.createPropertySignature(
+                        undefined,
+                        '__meta',
+                        this.f.createToken(SyntaxKind.QuestionToken),
+                        this.f.createIntersectionTypeNode(
+                            [
+                                this.f.createTypeReferenceNode('never'),
+                                this.f.createTupleTypeNode([
+                                    this.f.createTypeReferenceNode(T),
+                                    this.f.createTypeReferenceNode(Options),
+                                ]),
+                            ],
+                        ),
+                    ),
+                ]),
+            );
+        }
     }
 
     forHost(host: CompilerHost): this {
@@ -567,8 +597,8 @@ export class ReflectionTransformer implements CustomTransformer {
             const mode = reflectionModeMatcher(config, path);
             return { mode, tsConfigPath: '' };
         };
-        const configResolver: ResolvedConfig = {...config, path: '', mergeStrategy: 'replace', compilerOptions: this.compilerOptions};
-        this.overriddenConfigResolver = {config: configResolver, match};
+        const configResolver: ResolvedConfig = { ...config, path: '', mergeStrategy: 'replace', compilerOptions: this.compilerOptions };
+        this.overriddenConfigResolver = { config: configResolver, match };
         return this;
     }
 
@@ -604,9 +634,10 @@ export class ReflectionTransformer implements CustomTransformer {
         return configResolver.match(sourceFile.fileName);
     }
 
-    protected isWithReflection(sourceFile: SourceFile, node: Node & { __deepkitConfig?: ReflectionConfig }): boolean {
+    protected isWithReflection(sourceFile: SourceFile | undefined, node: Node & { __deepkitConfig?: ReflectionConfig }): boolean {
         const mode = this.getExplicitReflectionMode(sourceFile, node);
         if (mode === false) return false;
+        if (!sourceFile) return true; // intrinsic types are always with reflection
         const reflection = this.getReflectionConfig(sourceFile);
         // explicit means reflection needs to be enabled per Node/File via @reflection
         if (reflection.mode === 'explicit') return mode === true;
@@ -634,7 +665,7 @@ export class ReflectionTransformer implements CustomTransformer {
         Object.assign(this.compilerOptions, configResolver.config.compilerOptions);
 
         if (reflection.mode === 'never') {
-            debug(`Transform file with reflection=${reflection.mode} took ${Date.now()-start}ms (${this.getModuleType()}) ${sourceFile.fileName} via config ${reflection.tsConfigPath || 'none'}.`);
+            debug(`Transform file with reflection=${reflection.mode} took ${Date.now() - start}ms (${this.getModuleType()}) ${sourceFile.fileName} via config ${reflection.tsConfigPath || 'none'}.`);
             return sourceFile;
         }
 
@@ -1140,7 +1171,7 @@ export class ReflectionTransformer implements CustomTransformer {
         return node;
     }
 
-    protected createProgramVarFromNode(node: Node, name: EntityName, sourceFile: SourceFile): Statement[] {
+    protected createProgramVarFromNode(node: Node, name: EntityName, sourceFile?: SourceFile): Statement[] {
         const typeProgram = new CompilerProgram(node, sourceFile);
 
         if ((isTypeAliasDeclaration(node) || isInterfaceDeclaration(node)) && node.typeParameters) {
@@ -1220,7 +1251,7 @@ export class ReflectionTransformer implements CustomTransformer {
             case SyntaxKind.NewExpression: {
                 const call = node as NewExpression;
                 if (isIdentifier(call.expression)) {
-                    const map: {[name: string]: ReflectionOp} = {
+                    const map: { [name: string]: ReflectionOp } = {
                         'Date': ReflectionOp.date,
                         'RegExp': ReflectionOp.regexp,
                         'Uint8Array': ReflectionOp.uint8Array,
@@ -2145,20 +2176,20 @@ export class ReflectionTransformer implements CustomTransformer {
 
                 //non-existing references are ignored.
                 program.pushOp(ReflectionOp.never);
-                debug2(`Could not resolve ${getNameAsString(typeName)} in ${program.sourceFile.fileName}`);
+                debug2(`Could not resolve ${getNameAsString(typeName)} in ${program.sourceFile?.fileName || 'intrinsic'}`);
                 return;
             }
 
             let declaration: Node = resolved.declaration;
             const declarationSourceFile = findSourceFile(declaration);
 
-            if (!declarationSourceFile) {
-                program.pushOp(ReflectionOp.never);
-                debug2(`Could not find source file for ${getNameAsString(typeName)} in ${program.sourceFile.fileName}`);
-                return;
-            }
+            // if (!declarationSourceFile) {
+            //     program.pushOp(ReflectionOp.never);
+            //     debug2(`Could not find source file for ${getNameAsString(typeName)} in ${program.sourceFile.fileName}`);
+            //     return;
+            // }
 
-            const isGlobal = resolved.importDeclaration === undefined && declarationSourceFile.fileName !== this.sourceFile.fileName;
+            const isGlobal = !declarationSourceFile || (resolved.importDeclaration === undefined && declarationSourceFile.fileName !== this.sourceFile.fileName);
             const isFromImport = resolved.importDeclaration !== undefined;
 
             if (isVariableDeclaration(declaration)) {
@@ -2222,7 +2253,7 @@ export class ReflectionTransformer implements CustomTransformer {
 
                 //to break recursion, we track which declaration has already been compiled
                 if (!this.compiledDeclarations.has(declaration) && !this.compileDeclarations.has(declaration)) {
-                    if (this.isExcluded(declarationSourceFile.fileName)) {
+                    if (declarationSourceFile && this.isExcluded(declarationSourceFile.fileName)) {
                         program.pushOp(ReflectionOp.any);
                         return;
                     }
@@ -2340,7 +2371,7 @@ export class ReflectionTransformer implements CustomTransformer {
                 // If a function/class declarations comes from a built library (e.g. node_modules), then we
                 // declarationSourceFile is a d.ts file. We do know if they are built in runtime by checking `xy.__type`.
                 // Otherwise, check if the file will be built with runtime types.
-                const reflection = declarationSourceFile.fileName.endsWith('.d.ts') || this.isWithReflection(program.sourceFile, declaration);
+                const reflection = declarationSourceFile?.fileName.endsWith('.d.ts') || this.isWithReflection(program.sourceFile, declaration);
                 if (!reflection) {
                     this.resolveTypeOnlyImport(typeName, program);
                     return;
@@ -2567,6 +2598,11 @@ export class ReflectionTransformer implements CustomTransformer {
             return;
         }
 
+        if (importOrExport.moduleSpecifier.text === '@deepkit/core' && declarationName === 'TypeAnnotation') {
+            // TypeAnnotation<T> is like an intrinsic type, so we don't need to resolve it, but return a custom made Declaration
+            return this.intrinsicMetaDeclaration;
+        }
+
         const source: SourceFile | ModuleDeclaration | undefined = this.resolver.resolve(sourceFile, importOrExport);
 
         if (!source) {
@@ -2619,10 +2655,11 @@ export class ReflectionTransformer implements CustomTransformer {
                                             const importOrExport = declaration.parent.parent.parent;
                                             const found = this.resolveImportSpecifier(
                                                 element.propertyName ? getEscapedText(element.propertyName) : declarationName,
-                                                importOrExport, sourceFile
+                                                importOrExport, sourceFile,
                                             );
                                             if (found) return found;
-                                        } else if (declaration) {}
+                                        } else if (declaration) {
+                                        }
                                         return declaration;
                                     }
                                 }
@@ -2783,13 +2820,13 @@ export class ReflectionTransformer implements CustomTransformer {
      * Checks if reflection was disabled/enabled in file via JSDoc attribute for a particular
      * Node, e.g `@reflection no`. If nothing is found, "reflection" config option needs to be used.
      */
-    protected getExplicitReflectionMode(sourceFile: SourceFile, node: Node): boolean | undefined {
+    protected getExplicitReflectionMode(sourceFile: SourceFile | undefined, node: Node): boolean | undefined {
         let current: Node | undefined = node;
 
         let reflectionComment: string | undefined = undefined;
 
         while ('undefined' === typeof reflectionComment && current) {
-            const next = extractJSDocAttribute(sourceFile, current, 'reflection');
+            const next = sourceFile && extractJSDocAttribute(sourceFile, current, 'reflection');
             if ('undefined' !== typeof next) reflectionComment = next;
             current = current.parent;
         }

--- a/packages/type-compiler/tests/transpile.spec.ts
+++ b/packages/type-compiler/tests/transpile.spec.ts
@@ -592,16 +592,3 @@ test('infer type', () => {
     console.log(res.app);
     expect(res.app).toContain(`'a'`);
 });
-
-test('Meta<T>', () => {
-    const res = transpile({
-        'app': `
-        import { Meta } from '@deepkit/core';
-
-        export type T = string & Meta<'foo'>;
-        `
-    });
-    console.log(res.app);
-    expect(res.app).toContain(`const __ΩMeta = `);
-    expect(res.app).toContain(`[() => __ΩMeta`);
-});

--- a/packages/type-compiler/tests/transpile.spec.ts
+++ b/packages/type-compiler/tests/transpile.spec.ts
@@ -592,3 +592,16 @@ test('infer type', () => {
     console.log(res.app);
     expect(res.app).toContain(`'a'`);
 });
+
+test('Meta<T>', () => {
+    const res = transpile({
+        'app': `
+        import { Meta } from '@deepkit/core';
+
+        export type T = string & Meta<'foo'>;
+        `
+    });
+    console.log(res.app);
+    expect(res.app).toContain(`const __ΩMeta = `);
+    expect(res.app).toContain(`[() => __ΩMeta`);
+});

--- a/packages/type/src/reflection/type.ts
+++ b/packages/type/src/reflection/type.ts
@@ -1675,7 +1675,7 @@ export const entityAnnotation = new class extends AnnotationDefinition<EntityOpt
         return data;
     }
 }('entity');
-export const mapNameAnnotation = new AnnotationDefinition<{ name: string, serializer?: string }>('entity');
+export const mapNameAnnotation = new AnnotationDefinition<{ name: string, serializer?: string }>('mapName');
 
 export const autoIncrementAnnotation = new AnnotationDefinition('autoIncrement');
 export const primaryKeyAnnotation = new class extends AnnotationDefinition {

--- a/packages/type/src/reflection/type.ts
+++ b/packages/type/src/reflection/type.ts
@@ -19,6 +19,7 @@ import {
     isArray,
     isClass,
     isGlobalClass,
+    TypeAnnotation,
 } from '@deepkit/core';
 import { TypeNumberBrand } from '@deepkit/type-spec';
 import { getProperty, ReceiveType, reflect, ReflectionClass, resolveReceiveType, toSignature } from './reflection.js';
@@ -533,7 +534,9 @@ export type Widen<T> =
                 : T extends boolean ? boolean
                     : T extends symbol ? symbol : T;
 
-export type FindType<T extends Type, LOOKUP extends ReflectionKind> = T extends { kind: infer K } ? K extends LOOKUP ? T : never : never;
+export type FindType<T extends Type, LOOKUP extends ReflectionKind> = T extends {
+    kind: infer K
+} ? K extends LOOKUP ? T : never : never;
 
 /**
  * Merge dynamic runtime types with static types. In the type-system resolves as any, in runtime as the correct type.
@@ -578,8 +581,14 @@ export function isPropertyMemberType(type: Type): type is TypePropertySignature 
  *
  * If a non-property parameter is in the constructor, the type is given instead, e.g. `constructor(public title: string, anotherOne:number)` => [TypeProperty, TypeNumber]
  */
-export function getConstructorProperties(type: TypeClass | TypeObjectLiteral): { parameters: (TypeProperty | Type)[], properties: TypeProperty[] } {
-    const result: { parameters: (TypeProperty | Type)[], properties: TypeProperty[] } = { parameters: [], properties: [] };
+export function getConstructorProperties(type: TypeClass | TypeObjectLiteral): {
+    parameters: (TypeProperty | Type)[],
+    properties: TypeProperty[]
+} {
+    const result: { parameters: (TypeProperty | Type)[], properties: TypeProperty[] } = {
+        parameters: [],
+        properties: [],
+    };
     if (type.kind === ReflectionKind.objectLiteral) return result;
     const constructor = findMember('constructor', resolveTypeMembers(type)) as TypeMethod | undefined;
     if (!constructor) return result;
@@ -924,7 +933,7 @@ export function unboxUnion(union: TypeUnion): Type {
 }
 
 export function findMember(
-    index: string | number | symbol | TypeTemplateLiteral, types: Type[]
+    index: string | number | symbol | TypeTemplateLiteral, types: Type[],
 ): TypePropertySignature | TypeMethodSignature | TypeMethod | TypeProperty | TypeIndexSignature | undefined {
     const indexType = typeof index;
 
@@ -996,7 +1005,10 @@ export class CartesianProduct {
 
     toGroup(type: Type): Type[] {
         if (type.kind === ReflectionKind.boolean) {
-            return [{ kind: ReflectionKind.literal, literal: 'false' }, { kind: ReflectionKind.literal, literal: 'true' }];
+            return [{ kind: ReflectionKind.literal, literal: 'false' }, {
+                kind: ReflectionKind.literal,
+                literal: 'true',
+            }];
         } else if (type.kind === ReflectionKind.null) {
             return [{ kind: ReflectionKind.literal, literal: 'null' }];
         } else if (type.kind === ReflectionKind.undefined) {
@@ -1103,7 +1115,10 @@ export function indexAccess(container: Type, index: Type): Type {
             if (restPosition === -1 || index.literal < restPosition) {
                 const sub = container.types[index.literal];
                 if (!sub) return { kind: ReflectionKind.undefined };
-                if (sub.optional) return { kind: ReflectionKind.union, types: [sub.type, { kind: ReflectionKind.undefined }] };
+                if (sub.optional) return {
+                    kind: ReflectionKind.union,
+                    types: [sub.type, { kind: ReflectionKind.undefined }],
+                };
                 return sub.type;
             }
 
@@ -1362,7 +1377,11 @@ export function getMember(type: TypeObjectLiteral | TypeClass, memberName: numbe
 
 export function getTypeObjectLiteralFromTypeClass<T extends Type>(type: T): T extends TypeClass ? TypeObjectLiteral : T {
     if (type.kind === ReflectionKind.class) {
-        const objectLiteral: TypeObjectLiteral = { kind: ReflectionKind.objectLiteral, id: state.nominalId++, types: [] };
+        const objectLiteral: TypeObjectLiteral = {
+            kind: ReflectionKind.objectLiteral,
+            id: state.nominalId++,
+            types: [],
+        };
         for (const member of type.types) {
             if (member.kind === ReflectionKind.indexSignature) {
                 objectLiteral.types.push(member);
@@ -1540,28 +1559,6 @@ export interface EntityOptions {
 }
 
 /**
- * Type to use for custom type annotations.
- *
- *
- * ```typescript
- * type MyType<T extends string> = TypeAnnotation<'myType', T>;
- *
- * interface User {
- *    id: number & MyType<'yes'>;
- * }
- *
- * const reflection = ReflectionClass.from<User>();
- * const id = reflection.getProperty('id');
- *
- * // data is set when `id` used `MyType` and contains the type of 'yes' as type object
- * // which can be converted to JS with `typeToObject`
- * const data = metaAnnotation.getForName(id.type, 'myType');
- * const param1 = typeToObject(data[0]); //yes
- * ```
- */
-export type TypeAnnotation<T extends string, Options = never> = { __meta?: never & [T, Options] };
-
-/**
  * Type to decorate an interface/object literal with entity information.
  *
  * ```typescript
@@ -1571,7 +1568,7 @@ export type TypeAnnotation<T extends string, Options = never> = { __meta?: never
  * }
  * ```
  */
-export type Entity<T extends EntityOptions> = TypeAnnotation<'entity', T>
+export type Entity<T extends EntityOptions> = {} & TypeAnnotation<'entity', T>
 
 /**
  * Marks a property as primary key.
@@ -1660,7 +1657,7 @@ export type BackReference<Options extends BackReferenceOptions = {}> = TypeAnnot
 export type EmbeddedMeta<Options> = TypeAnnotation<'embedded', Options>;
 export type Embedded<T, Options extends { prefix?: string } = {}> = T & EmbeddedMeta<Options>;
 
-export type MapName<Alias extends string, ForSerializer extends string = ''> = { __meta?: never & ['mapName', Alias, ForSerializer] };
+export type MapName<Alias extends string, ForSerializer extends string = ''> = TypeAnnotation<'mapName', [Alias, ForSerializer]>;
 
 export const referenceAnnotation = new AnnotationDefinition<ReferenceOptions>('reference');
 export const entityAnnotation = new class extends AnnotationDefinition<EntityOptions> {
@@ -1851,7 +1848,7 @@ export type Excluded<Name extends string = '*'> = TypeAnnotation<'excluded', Nam
  * }
  * ```
  */
-export type Data<Name extends string, Value> = { __meta?: never & ['data', Name, Value] };
+export type Data<Name extends string, Value> = TypeAnnotation<'data', [Name, Value]>;
 
 /**
  * Resets an already set decorator to undefined.
@@ -1941,7 +1938,7 @@ export interface PostgresOptions extends DatabaseFieldOptions {
 export interface SqliteOptions extends DatabaseFieldOptions {
 }
 
-type Database<Name extends string, Options extends { [name: string]: any }> = { __meta?: never & ['database', Name, Options] };
+type Database<Name extends string, Options extends { [name: string]: any }> = TypeAnnotation<'database', [Name, Options]>;
 export type MySQL<Options extends MySQLOptions> = Database<'mysql', Options>;
 export type Postgres<Options extends PostgresOptions> = Database<'postgres', Options>;
 export type SQLite<Options extends SqliteOptions> = Database<'sqlite', Options>;
@@ -1973,16 +1970,34 @@ export const dataAnnotation = new class extends AnnotationDefinition<{ [name: st
         return data[key];
     }
 }('data');
-export const metaAnnotation = new class extends AnnotationDefinition<{ name: string, options: Type[] }> {
-    getForName(type: Type, metaName: string): Type[] | undefined {
+
+/**
+ * All raw data from `TypeAnnotation<Name, Options>` types.
+ */
+export const typeAnnotation = new class extends AnnotationDefinition<{ name: string, options: Type }> {
+    /**
+     * Returns the parsed Type to JS objects, e.g. `{name: string}` => `{name: 'xy'}`
+     */
+    getOption(type: Type, name: string): any {
+        const options = this.getType(type, name);
+        return options ? typeToObject(options) : undefined;
+    }
+
+    /**
+     * Returns the Type object of the annotation which can be parsed with `typeToObject`.
+     */
+    getType(type: Type, name: string): Type | undefined {
         for (const v of this.getAnnotations(type)) {
-            if (v.name === metaName) return v.options;
+            if (v.name === name) return v.options;
         }
         return;
     }
 }('meta');
 export const indexAnnotation = new AnnotationDefinition<IndexOptions>('index');
-export const databaseAnnotation = new class extends AnnotationDefinition<{ name: string, options: { [name: string]: any } }> {
+export const databaseAnnotation = new class extends AnnotationDefinition<{
+    name: string,
+    options: { [name: string]: any }
+}> {
     getDatabase<T extends DatabaseFieldOptions>(type: Type, name: string): T | undefined {
         let options: T | undefined = undefined;
         for (const annotation of this.getAnnotations(type)) {
@@ -2017,7 +2032,7 @@ export function registerTypeDecorator(decorator: TypeDecorator) {
  * type lowLevel2<T> = { __meta?: never & ['myAnnotation', T] }
  * ```
  */
-export function getAnnotationMeta(type: TypeObjectLiteral): { id: string, params: Type[] } | undefined {
+export function getAnnotationMeta(type: TypeObjectLiteral): { id: string, options: Type } | undefined {
     const meta = getProperty(type, '__meta');
     if (!meta || !meta.optional) return;
     let tuple: TypeTuple | undefined = undefined;
@@ -2040,9 +2055,9 @@ export function getAnnotationMeta(type: TypeObjectLiteral): { id: string, params
 
     const id = tuple.types[0];
     if (!id || id.type.kind !== ReflectionKind.literal || 'string' !== typeof id.type.literal) return;
-    const params = tuple.types.slice(1).map(v => v.type);
+    const optionsMember = tuple.types[1];
 
-    return { id: id.type.literal, params };
+    return { id: id.type.literal, options: optionsMember?.type };
 }
 
 export const typeDecorators: TypeDecorator[] = [
@@ -2052,23 +2067,22 @@ export const typeDecorators: TypeDecorator[] = [
 
         switch (meta.id) {
             case 'reference': {
-                const optionsType = meta.params[0];
+                const optionsType = meta.options;
                 if (!optionsType || optionsType.kind !== ReflectionKind.objectLiteral) return false;
                 const options = typeToObject(optionsType);
                 referenceAnnotation.replace(annotations, [options]);
                 return true;
             }
             case 'entity': {
-                const optionsType = meta.params[0];
+                const optionsType = meta.options;
                 if (!optionsType || optionsType.kind !== ReflectionKind.objectLiteral) return false;
                 const options = typeToObject(optionsType);
                 entityAnnotation.replace(annotations, [options]);
                 return true;
             }
             case 'mapName': {
-                if (!meta.params[0]) return false;
-                const name = typeToObject(meta.params[0]);
-                const serializer = meta.params[1] ? typeToObject(meta.params[1]) : undefined;
+                if (!meta.options) return false;
+                const [name, serializer] = typeToObject(meta.options);
 
                 if ('string' === typeof name && (!serializer || 'string' === typeof serializer)) {
                     mapNameAnnotation.replace(annotations, [{ name, serializer }]);
@@ -2094,42 +2108,37 @@ export const typeDecorators: TypeDecorator[] = [
                 uuidAnnotation.register(annotations, true);
                 return true;
             case 'embedded': {
-                const optionsType = meta.params[0];
+                const optionsType = meta.options;
                 if (!optionsType || optionsType.kind !== ReflectionKind.objectLiteral) return false;
                 const options = typeToObject(optionsType);
                 embeddedAnnotation.replace(annotations, [options]);
                 return true;
             }
             case 'group': {
-                const nameType = meta.params[0];
+                const nameType = meta.options;
                 if (!nameType || nameType.kind !== ReflectionKind.literal || 'string' !== typeof nameType.literal) return false;
                 groupAnnotation.register(annotations, nameType.literal);
                 return true;
             }
             case 'index': {
-                const optionsType = meta.params[0];
+                const optionsType = meta.options;
                 if (!optionsType || optionsType.kind !== ReflectionKind.objectLiteral) return false;
                 const options = typeToObject(optionsType);
                 indexAnnotation.replace(annotations, [options]);
                 return true;
             }
             case 'database': {
-                const nameType = meta.params[0];
-                if (!nameType || nameType.kind !== ReflectionKind.literal || 'string' !== typeof nameType.literal) return false;
-                const optionsType = meta.params[1];
-                if (!optionsType || optionsType.kind !== ReflectionKind.objectLiteral) return false;
-                const options = typeToObject(optionsType);
-                databaseAnnotation.register(annotations, { name: nameType.literal, options });
+                const [name, options] = typeToObject(meta.options);
+                databaseAnnotation.register(annotations, { name: name, options });
                 return true;
             }
             case 'excluded': {
-                const nameType = meta.params[0];
-                if (!nameType || nameType.kind !== ReflectionKind.literal || 'string' !== typeof nameType.literal) return false;
-                excludedAnnotation.register(annotations, nameType.literal);
+                const name = typeToObject(meta.options);
+                excludedAnnotation.register(annotations, name);
                 return true;
             }
             case 'reset': {
-                const name = typeToObject(meta.params[0]);
+                const name = typeToObject(meta.options);
                 if ('string' !== typeof name) return false;
                 const map: { [name: string]: AnnotationDefinition<any> } = {
                     primaryKey: primaryKeyAnnotation,
@@ -2145,14 +2154,16 @@ export const typeDecorators: TypeDecorator[] = [
                     backReference: backReferenceAnnotation,
                     validator: validationAnnotation,
                 };
-                const annotation = map[name] || metaAnnotation;
+                const annotation = map[name] || typeAnnotation;
                 annotation.reset(annotations);
                 return true;
             }
             case 'data': {
-                const nameType = meta.params[0];
+                const tuple = meta.options;
+                if (!tuple || tuple.kind !== ReflectionKind.tuple) return false;
+                const nameType = tuple.types[0].type;
                 if (!nameType || nameType.kind !== ReflectionKind.literal || 'string' !== typeof nameType.literal) return false;
-                const dataType = meta.params[1];
+                const dataType = tuple.types[1].type;
                 if (!dataType) return false;
 
                 annotations[dataAnnotation.symbol] ||= [];
@@ -2168,7 +2179,7 @@ export const typeDecorators: TypeDecorator[] = [
                 return true;
             }
             case 'backReference': {
-                const optionsType = meta.params[0];
+                const optionsType = meta.options;
                 if (!optionsType || optionsType.kind !== ReflectionKind.objectLiteral) return false;
 
                 const options = typeToObject(optionsType);
@@ -2180,11 +2191,13 @@ export const typeDecorators: TypeDecorator[] = [
                 return true;
             }
             case 'validator': {
-                const nameType = meta.params[0];
+                const tuple = meta.options;
+                if (!tuple || tuple.kind !== ReflectionKind.tuple) return false;
+                const nameType = tuple.types[0].type;
                 if (!nameType || nameType.kind !== ReflectionKind.literal || 'string' !== typeof nameType.literal) return false;
                 const name = nameType.literal;
 
-                const argsType = meta.params[1];
+                const argsType = tuple.types[1].type;
                 if (!argsType || argsType.kind !== ReflectionKind.tuple) return false;
                 const args: Type[] = argsType.types.map(v => v.type);
 
@@ -2193,11 +2206,11 @@ export const typeDecorators: TypeDecorator[] = [
                 return true;
             }
             default: {
-                metaAnnotation.register(annotations, { name: meta.id, options: meta.params });
+                typeAnnotation.register(annotations, { name: meta.id, options: meta.options });
                 return true;
             }
         }
-    }
+    },
 ];
 
 export function typeToObject(type?: Type, state: { stack: Type[] } = { stack: [] }): any {
@@ -2322,7 +2335,7 @@ export function stringifyResolvedType(type: Type): string {
 }
 
 export function stringifyShortResolvedType(type: Type, stateIn: Partial<StringifyTypeOptions> = {}): string {
-    return stringifyType(type, { ...stateIn, showNames: false, showFullDefinition: false, });
+    return stringifyType(type, { ...stateIn, showNames: false, showFullDefinition: false });
 }
 
 /**
@@ -2385,7 +2398,7 @@ export function stringifyType(type: Type, stateIn: Partial<StringifyTypeOptions>
         showDescription: false,
         showHeritage: false,
         showFullDefinition: false,
-        ...stateIn
+        ...stateIn,
     };
     const stack: { type?: Type, defaultValue?: any, before?: string, after?: string, depth?: number }[] = [];
     stack.push({ type, defaultValue: state.defaultValues, depth: 1 });
@@ -2608,7 +2621,11 @@ export function stringifyType(type: Type, stateIn: Partial<StringifyTypeOptions>
                                 if (type.extendsArguments && type.extendsArguments.length) {
                                     stack.push({ before: '>' });
                                     for (let i = type.extendsArguments.length - 1; i >= 0; i--) {
-                                        stack.push({ type: type.extendsArguments[i], before: i === 0 ? undefined : ', ', depth: depth + 1 });
+                                        stack.push({
+                                            type: type.extendsArguments[i],
+                                            before: i === 0 ? undefined : ', ',
+                                            depth: depth + 1,
+                                        });
                                     }
                                     stack.push({ before: '<' });
                                 }
@@ -2624,7 +2641,11 @@ export function stringifyType(type: Type, stateIn: Partial<StringifyTypeOptions>
                     if ((!state.showFullDefinition || type.types.length === 0) && typeArguments && typeArguments.length) {
                         stack.push({ before: '>' });
                         for (let i = typeArguments.length - 1; i >= 0; i--) {
-                            stack.push({ type: typeArguments[i], before: i === 0 ? undefined : ', ', depth: depth + 1 });
+                            stack.push({
+                                type: typeArguments[i],
+                                before: i === 0 ? undefined : ', ',
+                                depth: depth + 1,
+                            });
                         }
                         stack.push({ before: '<' });
                     }

--- a/packages/type/src/validator.ts
+++ b/packages/type/src/validator.ts
@@ -1,11 +1,11 @@
 import { ReceiveType } from './reflection/reflection.js';
 import { getValidatorFunction, is } from './typeguard.js';
-import { CustomError } from '@deepkit/core';
+import { CustomError, TypeAnnotation } from '@deepkit/core';
 import { stringifyType, Type } from './reflection/type.js';
 import { entity } from './decorator.js';
 import { serializer, Serializer } from './serializer.js';
 
-export type ValidatorMeta<Name extends string, Args extends [...args: any[]] = []> = { __meta?: never & ['validator', Name, Args] }
+export type ValidatorMeta<Name extends string, Args extends [...args: any[]] = []> = TypeAnnotation<'validator', [Name, Args]>;
 
 export type ValidateFunction = (value: any, type: Type, options: any) => ValidatorError | void;
 export type Validate<T extends ValidateFunction, Options extends Parameters<T>[2] = unknown> = ValidatorMeta<'function', [T, Options]>;

--- a/packages/type/tests/integration2.spec.ts
+++ b/packages/type/tests/integration2.spec.ts
@@ -29,7 +29,6 @@ import {
     Index,
     integer,
     MapName,
-    metaAnnotation,
     MySQL,
     Postgres,
     PrimaryKey,
@@ -41,6 +40,7 @@ import {
     SQLite,
     stringifyResolvedType,
     Type,
+    typeAnnotation,
     TypeClass,
     TypeFunction,
     TypeIndexSignature,
@@ -48,7 +48,7 @@ import {
     TypeNumber,
     TypeObjectLiteral,
     TypeTuple,
-    Unique
+    Unique,
 } from '../src/reflection/type.js';
 import { TypeNumberBrand } from '@deepkit/type-spec';
 import { validate, ValidatorError } from '../src/validator.js';
@@ -1341,7 +1341,7 @@ test('type annotation with union', () => {
     type a = HttpQuery<number | string>;
     const type = typeOf<a>();
     assertType(type, ReflectionKind.union);
-    expect(metaAnnotation.getAnnotations(type)).toEqual([{ name: 'httpQuery', options: [] }]);
+    expect(typeAnnotation.getAnnotations(type)).toEqual([{ name: 'httpQuery', options: undefined }]);
 });
 
 test('simple brands', () => {

--- a/packages/type/tests/issues/test.spec.ts
+++ b/packages/type/tests/issues/test.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from '@jest/globals';
 import { typeOf } from '../../src/reflection/reflection';
-import { metaAnnotation } from '../../src/reflection/type';
+import { typeAnnotation } from '../../src/reflection/type';
 
 test('test', () => {
     type MyAnnotation = { __meta?: never & ['myAnnotation'] };
     type Username = string & MyAnnotation;
     const type = typeOf<Username>();
-    const data = metaAnnotation.getForName(type, 'myAnnotation');
-    expect(data).toEqual([]);
+    const data = typeAnnotation.getType(type, 'myAnnotation');
+    expect(data).toEqual(undefined);
 });

--- a/packages/type/tests/issues/type-annotation.spec.ts
+++ b/packages/type/tests/issues/type-annotation.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@jest/globals';
+import { typeOf } from '../../src/reflection/reflection';
+import { assertType, MapName, ReflectionKind, typeAnnotation, validationAnnotation } from '../../src/reflection/type';
+
+import { TypeAnnotation } from '@deepkit/core';
+import { MinLength } from '../../src/validator';
+
+test('Meta', () => {
+    type T = string & TypeAnnotation<'foo', { foo: 1, bar: true }>;
+    const type = typeOf<T>();
+    const meta = typeAnnotation.getOption(type, 'foo');
+    console.log(type);
+    expect(meta).toEqual({ foo: 1, bar: true });
+});
+
+test('standalone', () => {
+    type t1 = (string & MinLength<1>) | null;
+    const type = typeOf<t1>();
+    assertType(type, ReflectionKind.union);
+    assertType(type.types[0], ReflectionKind.string);
+    assertType(type.types[1], ReflectionKind.null);
+
+    const data = validationAnnotation.getAnnotations(type.types[0]);
+    expect(data[0].name).toBe('minLength');
+
+    expect(validationAnnotation.getAnnotations(type.types[1])).toEqual([]);
+});
+
+test('on property', () => {
+    class Test {
+        prop: (string & MinLength<1>) | null = null;
+    }
+
+    const clazz = typeOf<Test>();
+    assertType(clazz, ReflectionKind.class);
+    assertType(clazz.types[0], ReflectionKind.property);
+
+    const type = clazz.types[0].type;
+
+    assertType(type, ReflectionKind.union);
+    assertType(type.types[0], ReflectionKind.string);
+    assertType(type.types[1], ReflectionKind.null);
+
+    const data = validationAnnotation.getAnnotations(type.types[0]);
+    expect(data[0].name).toBe('minLength');
+
+    expect(validationAnnotation.getAnnotations(type.types[1])).toEqual([]);
+});
+
+test('property serialization validation', () => {
+    class Test {
+        public firstname: (string | null) & MapName<"first_name"> = null;
+
+        prop: (string & MinLength<1>) | null = null;
+    }
+    const test = new Test();
+    test.firstname = null;
+    test.firstname = 'peter';
+
+    // expect(serialize<Test>({ prop: null })).toEqual({ prop: null });
+    // expect(serialize<Test>({ prop: '1' })).toEqual({ prop: '1' });
+    // expect(cast<Test>({ prop: '1' })).toEqual({ prop: '1' });
+    // expect(cast<Test>({ prop: '' })).toEqual({ prop: '' });
+});

--- a/packages/type/tests/performance-issue1.spec.ts
+++ b/packages/type/tests/performance-issue1.spec.ts
@@ -11,7 +11,7 @@ import { test } from '@jest/globals';
 import { AbstractClassType, arrayRemoveItem, ClassType, CompilerContext, CustomError, getClassName, isClass, isFunction, urlJoin } from '@deepkit/core';
 import { isExtendable } from '../src/reflection/extends.js';
 import { ReceiveType, reflect, resolveReceiveType } from '../src/reflection/reflection.js';
-import { isType, ReflectionKind, Type, typeAnnotation } from '../src/reflection/type.js';
+import { isType, Type } from '../src/reflection/type.js';
 import { IncomingMessage, ServerResponse } from 'http';
 import { Writable } from 'stream';
 import querystring from 'querystring';
@@ -786,19 +786,6 @@ export interface InjectorInterface {
     get<T>(token: T, scope?: Scope): ResolveToken<T>;
 }
 
-/**
- * Returns the injector token type if the given type was decorated with `Inject<T>`.
- */
-function getInjectOptions(type: Type): Type | undefined {
-    const annotations = typeAnnotation.getAnnotations(type);
-    for (const annotation of annotations) {
-        if (annotation.name === 'inject') {
-            const t = annotation.options as Type;
-            return t.kind !== ReflectionKind.never ? t : type;
-        }
-    }
-    return;
-}
 
 /**
  * This is the actual dependency injection container.

--- a/packages/type/tests/performance-issue1.spec.ts
+++ b/packages/type/tests/performance-issue1.spec.ts
@@ -11,7 +11,7 @@ import { test } from '@jest/globals';
 import { AbstractClassType, arrayRemoveItem, ClassType, CompilerContext, CustomError, getClassName, isClass, isFunction, urlJoin } from '@deepkit/core';
 import { isExtendable } from '../src/reflection/extends.js';
 import { ReceiveType, reflect, resolveReceiveType } from '../src/reflection/reflection.js';
-import { isType, metaAnnotation, ReflectionKind, Type } from '../src/reflection/type.js';
+import { isType, ReflectionKind, Type, typeAnnotation } from '../src/reflection/type.js';
 import { IncomingMessage, ServerResponse } from 'http';
 import { Writable } from 'stream';
 import querystring from 'querystring';
@@ -790,10 +790,10 @@ export interface InjectorInterface {
  * Returns the injector token type if the given type was decorated with `Inject<T>`.
  */
 function getInjectOptions(type: Type): Type | undefined {
-    const annotations = metaAnnotation.getAnnotations(type);
+    const annotations = typeAnnotation.getAnnotations(type);
     for (const annotation of annotations) {
         if (annotation.name === 'inject') {
-            const t = annotation.options[0] as Type;
+            const t = annotation.options as Type;
             return t.kind !== ReflectionKind.never ? t : type;
         }
     }

--- a/packages/type/tests/serializer.spec.ts
+++ b/packages/type/tests/serializer.spec.ts
@@ -22,19 +22,19 @@ import {
     isCustomTypeClass,
     isTypeClassOf,
     MapName,
-    metaAnnotation,
     PrimaryKey,
     Reference,
     ReflectionKind,
     SignedBinaryBigInt,
     stringifyResolvedType,
     Type,
+    typeAnnotation,
     TypeProperty,
     TypePropertySignature,
 } from '../src/reflection/type.js';
 import { createSerializeFunction, getSerializeFunction, NamingStrategy, Serializer, serializer, underscoreNamingStrategy } from '../src/serializer.js';
 import { cast, deserialize, patch, serialize } from '../src/serializer-facade.js';
-import { getClassName } from '@deepkit/core';
+import { getClassName, TypeAnnotation } from '@deepkit/core';
 import { entity, t } from '../src/decorator.js';
 import { Alphanumeric, MaxLength, MinLength, ValidationError } from '../src/validator.js';
 import { StatEnginePowerUnit, StatWeightUnit } from './types.js';
@@ -1256,10 +1256,10 @@ test('patch', () => {
 });
 
 test('extend with custom type', () => {
-    type StringifyTransport = { __meta?: never & ['stringifyTransport'] };
+    type StringifyTransport = TypeAnnotation<'stringifyTransport'>;
 
     function isStringifyTransportType(type: Type): boolean {
-        return !!metaAnnotation.getForName(type, 'stringifyTransport');
+        return !!typeAnnotation.getType(type, 'stringifyTransport');
     }
 
     serializer.serializeRegistry.addPostHook((type, state) => {

--- a/packages/type/tsconfig.json
+++ b/packages/type/tsconfig.json
@@ -25,9 +25,6 @@
     "src",
     "index.ts"
   ],
-  "exclude": [
-    "tests"
-  ],
   "references": [
     {
       "path": "../type-spec/tsconfig.json"


### PR DESCRIPTION
this makes TypeAnnotation not interfere with the type system at all. Previously we had all sorts of issues, especially with property inheritance and union grouping (type collapsing). This fixes now all of that

closes #626

### Summary of changes


<!-- My summary here. -->


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
