### PR TITLE
feat(rpc): auto-GC observables, event system, statistics

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "test": "node --max_old_space_size=3048 node_modules/jest/bin/jest.js --forceExit --no-cache",
-    "test:coverage": "node --max_old_space_size=3048 node_modules/jest/bin/jest.js --coverage --forceExit --no-cache",
+    "test": "node --expose-gc --max_old_space_size=3048 node_modules/jest/bin/jest.js --forceExit --no-cache",
+    "test:coverage": "node --expose-gc --max_old_space_size=3048 node_modules/jest/bin/jest.js --coverage --forceExit --no-cache",
     "build": "tsc --build tsconfig.json && tsc --build tsconfig.esm.json && lerna run build",
     "build:esm": "tsc --build tsconfig.esm.json",
     "tsc": "tsc --build",

--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -15,10 +15,11 @@ import { AppModule, RootModuleDefinition } from './module.js';
 import { EnvConfiguration } from './configuration.js';
 import {
     DataEventToken,
+    DispatchArguments,
     EventDispatcher,
+    EventDispatcherDispatchType,
     EventListener,
     EventListenerCallback,
-    EventOfEventToken,
     EventToken,
 } from '@deepkit/event';
 import { ReceiveType, ReflectionClass, ReflectionKind } from '@deepkit/type';
@@ -292,14 +293,14 @@ export class App<T extends RootModuleDefinition> {
      *
      * order: The lower the order, the sooner the listener is called. Default is 0.
      */
-    listen<T extends EventToken<any>, DEPS extends any[]>(eventToken: T, callback: EventListenerCallback<T['event']>, order: number = 0): this {
-        const listener: EventListener<any> = { callback, order, eventToken };
+    listen<T extends EventToken<any>>(eventToken: T, callback: EventListenerCallback<T['event']>, order: number = 0): this {
+        const listener: EventListener = { callback, order, eventToken };
         this.appModule.listeners.push(listener);
         return this;
     }
 
-    public async dispatch<T extends EventToken<any>>(eventToken: T, event?: EventOfEventToken<T>, injector?: InjectorContext): Promise<void> {
-        return await this.get(EventDispatcher).dispatch(eventToken, event, injector);
+    dispatch<T extends EventToken<any>>(eventToken: T, ...args: DispatchArguments<T>): EventDispatcherDispatchType<T> {
+        return this.get(EventDispatcher).dispatch(eventToken, ...args);
     }
 
     /**

--- a/packages/app/src/module.ts
+++ b/packages/app/src/module.ts
@@ -12,15 +12,7 @@ import { InjectorModule, InjectorModuleConfig, NormalizedProvider, ProviderWithS
 import { AbstractClassType, ClassType, CustomError, ExtractClassType, isClass } from '@deepkit/core';
 import { EventListener, EventToken } from '@deepkit/event';
 import { WorkflowDefinition } from '@deepkit/workflow';
-import {
-    getPartialSerializeFunction,
-    reflect,
-    ReflectionFunction,
-    ReflectionMethod,
-    serializer,
-    Type,
-    TypeClass,
-} from '@deepkit/type';
+import { getPartialSerializeFunction, reflect, ReflectionFunction, ReflectionMethod, serializer, Type, TypeClass } from '@deepkit/type';
 import { ControllerConfig } from './service-container.js';
 
 export type DefaultObject<T> = T extends undefined ? {} : T;
@@ -137,7 +129,7 @@ export interface ModuleDefinition {
      * }
      * ```
      */
-    listeners?: (EventListener<any> | ClassType)[];
+    listeners?: (EventListener | ClassType)[];
 
     /**
      * HTTP middlewares.
@@ -253,7 +245,7 @@ export function createModule<T extends CreateModuleDefinition>(options: T): AppM
     return new (createModuleClass(options))();
 }
 
-export type ListenerType = EventListener<any> | ClassType;
+export type ListenerType = EventListener | ClassType;
 
 /**
  * The AppModule is the base class for all modules.
@@ -409,7 +401,7 @@ export class AppModule<C extends InjectorModuleConfig = any> extends InjectorMod
         return this;
     }
 
-    addListener(...listener: (EventListener<any> | ClassType)[]): this {
+    addListener(...listener: (EventListener | ClassType)[]): this {
         this.assertInjectorNotBuilt();
 
         for (const l of listener) {

--- a/packages/broker/src/kernel.ts
+++ b/packages/broker/src/kernel.ts
@@ -17,6 +17,7 @@ import {
     RpcMessage,
     RpcMessageBuilder,
     RpcMessageRouteType,
+    RpcStats,
     TransportConnection,
 } from '@deepkit/rpc';
 import { Logger } from '@deepkit/logger';
@@ -52,6 +53,8 @@ import cluster from 'cluster';
 import { closeSync, openSync, renameSync, writeSync } from 'fs';
 import { snapshotState } from './snapshot.js';
 import { handleMessageDeduplication } from './utils.js';
+import { InjectorContext } from '@deepkit/injector';
+import { EventDispatcher } from '@deepkit/event';
 
 export interface Queue {
     currentId: number;
@@ -66,12 +69,15 @@ export class BrokerConnection extends RpcKernelBaseConnection {
     protected locks = new Map<number, ProcessLock>();
 
     constructor(
+        stats: RpcStats,
         logger: Logger,
         transportConnection: TransportConnection,
-        protected connections: RpcKernelConnections,
+        connections: RpcKernelConnections,
+        injector: InjectorContext,
+        eventDispatcher: EventDispatcher,
         protected state: BrokerState,
     ) {
-        super(logger, transportConnection, connections);
+        super(stats, logger, transportConnection, connections, injector, eventDispatcher);
     }
 
     public close(): void {
@@ -569,6 +575,6 @@ export class BrokerKernel extends RpcKernel {
     protected state: BrokerState = new BrokerState;
 
     createConnection(transport: TransportConnection): BrokerConnection {
-        return new BrokerConnection(this.logger, transport, this.connections, this.state);
+        return new BrokerConnection(this.stats, this.logger, transport, this.connections, this.injector, this.getEventDispatcher(), this.state);
     }
 }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -604,6 +604,13 @@ export function mergeStack(error: Error, stack: string) {
     }
 }
 
+/**
+ * Makes sure the given value is an error. If it's not an error, it creates a new error with the given value as message.
+ */
+export function ensureError(error?: any, classType: ClassType = Error): Error {
+    return error instanceof Error || error instanceof AggregateError ? error : new classType(error);
+}
+
 export function collectForMicrotask<T>(callback: (args: T[]) => void): (arg: T) => void {
     let items: T[] = [];
     let taskScheduled = false;

--- a/packages/event/README.md
+++ b/packages/event/README.md
@@ -1,3 +1,3 @@
 # @deepkit/event
 
-Deepkit async event dispatcher.
+Deepkit async/sync event dispatcher.

--- a/packages/event/package.json
+++ b/packages/event/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@deepkit/event",
   "version": "1.0.2",
-  "description": "Deepkit async event dispatcher",
+  "description": "Deepkit event dispatcher",
   "type": "commonjs",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/framework/src/module.ts
+++ b/packages/framework/src/module.ts
@@ -17,15 +17,7 @@ import { DebugDIController } from './cli/debug-di.js';
 import { ServerStartController } from './cli/server-start.js';
 import { DebugController } from './debug/debug.controller.js';
 import { registerDebugHttpController } from './debug/http-debug.controller.js';
-import {
-    http,
-    HttpLogger,
-    HttpModule,
-    HttpRegExp,
-    HttpRequest,
-    HttpResponse,
-    serveStaticListener,
-} from '@deepkit/http';
+import { http, HttpLogger, HttpModule, HttpRegExp, HttpRequest, HttpResponse, serveStaticListener } from '@deepkit/http';
 import { InjectorContext, ProviderWithScope, Token } from '@deepkit/injector';
 import { BrokerConfig, FrameworkConfig } from './module.config.js';
 import { Logger } from '@deepkit/logger';
@@ -44,15 +36,7 @@ import {
 } from '@deepkit/sql/commands';
 import { FileStopwatchStore } from './debug/stopwatch/store.js';
 import { DebugProfileFramesCommand } from './cli/debug-debug-frames.js';
-import {
-    rpcClass,
-    RpcHooks,
-    RpcKernel,
-    RpcKernelBaseConnection,
-    RpcKernelConnection,
-    RpcKernelSecurity,
-    SessionState,
-} from '@deepkit/rpc';
+import { rpcClass, RpcKernel, RpcKernelBaseConnection, RpcKernelConnection, RpcKernelSecurity, SessionState } from '@deepkit/rpc';
 import { DebugConfigController } from './cli/app-config.js';
 import { Zone } from './zone.js';
 import { DebugBrokerBus } from './debug/broker.js';
@@ -77,7 +61,6 @@ export class FrameworkModule extends createModuleClass({
         ApplicationServer,
         WebWorkerFactory,
         RpcServer,
-        RpcHooks,
         MigrationProvider,
         DebugController,
         BrokerServer,
@@ -158,7 +141,6 @@ export class FrameworkModule extends createModuleClass({
         SessionState,
         RpcKernelConnection,
         RpcKernelBaseConnection,
-        RpcHooks,
 
         BrokerDeepkitAdapter,
         BrokerCache,

--- a/packages/framework/src/rpc.ts
+++ b/packages/framework/src/rpc.ts
@@ -66,7 +66,7 @@ export class RpcServerActionWithStopwatch extends RpcServerAction {
 }
 
 export class RpcKernelConnectionWithStopwatch extends RpcKernelConnection {
-    protected actionHandler = new RpcServerActionWithStopwatch(this.cache, this, this.controllers, this.injector, this.security, this.sessionState, this.logger, this.hooks);
+    protected actionHandler = new RpcServerActionWithStopwatch(this.stats, this.cache, this, this.controllers, this.injector, this.eventDispatcher, this.security, this.sessionState, this.logger);
     stopwatch?: Stopwatch;
 
     setStopwatch(stopwatch: Stopwatch) {

--- a/packages/framework/src/worker.ts
+++ b/packages/framework/src/worker.ts
@@ -8,13 +8,7 @@
  * You should have received a copy of the MIT License along with this program.
  */
 
-import {
-    RpcKernel,
-    RpcKernelBaseConnection,
-    RpcKernelConnection,
-    SessionState,
-    TransportConnection,
-} from '@deepkit/rpc';
+import { RpcKernel, RpcKernelBaseConnection, RpcKernelConnection, SessionState, TransportConnection } from '@deepkit/rpc';
 import http, { Server } from 'http';
 import https from 'https';
 import type { Server as WebSocketServer, ServerOptions as WebSocketServerOptions } from 'ws';
@@ -134,11 +128,15 @@ export class RpcServer implements RpcServerInterface {
                 }
             }, req);
 
-            ws.on('message', async (message: Uint8Array) => {
+            ws.on('message', (message: Uint8Array) => {
                 connection.feed(message);
             });
 
-            ws.on('close', async () => {
+            ws.on('error', (error) => {
+                connection.close(error);
+            });
+
+            ws.on('close', () => {
                 connection.close();
             });
         });

--- a/packages/http/tests/utils.ts
+++ b/packages/http/tests/utils.ts
@@ -9,7 +9,7 @@ import { HttpRouterRegistry } from '../src/router.js';
 export function createHttpKernel(
     controllers: (ClassType | { module: AppModule<any>, controller: ClassType })[] | ((registry: HttpRouterRegistry) => void) = [],
     providers: ProviderWithScope[] = [],
-    listeners: (EventListener<any> | ClassType)[] = [],
+    listeners: (EventListener | ClassType)[] = [],
     middlewares: MiddlewareFactory[] = [],
     modules: AppModule<any>[] = []
 ) {
@@ -21,7 +21,7 @@ export function createHttpKernel(
 export function createHttpApp(
     controllers: (ClassType | { module: AppModule<any>, controller: ClassType })[] | ((registry: HttpRouterRegistry) => void) = [],
     providers: ProviderWithScope[] = [],
-    listeners: (EventListener<any> | ClassType)[] = [],
+    listeners: (EventListener | ClassType)[] = [],
     middlewares: MiddlewareFactory[] = [],
     modules: AppModule<any>[] = []
 ) {

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -335,9 +335,15 @@ export class ConsoleLogger extends Logger {
 export class MemoryLogger extends Logger {
     public memory = new MemoryLoggerTransport();
 
-    constructor() {
-        super([]);
-        this.transporter.push(this.memory);
+    constructor(
+        transporter: LoggerTransport[] = [],
+        formatter: LoggerFormatter[] = [],
+        scope: string = ''
+    ) {
+        super(transporter || [], formatter, scope);
+        if (transporter.length === 0) {
+            this.transporter.push(this.memory);
+        }
     }
 
     getOutput(): string {

--- a/packages/logger/tests/logger.spec.ts
+++ b/packages/logger/tests/logger.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals';
-import { JSONTransport, Logger, LoggerLevel, ScopedLogger, ScopeFormatter } from '../src/logger.js';
+import { JSONTransport, Logger, LoggerLevel, MemoryLogger, ScopedLogger, ScopeFormatter } from '../src/logger.js';
 import { MemoryLoggerTransport } from '../src/memory-logger.js';
 import { Injector, ServiceNotFoundError, TransientInjectionTarget } from '@deepkit/injector';
 
@@ -32,7 +32,7 @@ test('log message', () => {
     expect(memory.messageStrings).toEqual(['Peter']);
 });
 
-test('log scope', () => {
+test('log scope 1', () => {
     const memory = new MemoryLoggerTransport();
     const logger = new Logger([memory], [new ScopeFormatter()]);
     logger.level = LoggerLevel.error;
@@ -42,6 +42,17 @@ test('log scope', () => {
     scoped.error('Peter');
 
     expect(memory.messageStrings).toEqual(['(database) Peter']);
+    expect(scoped.level).toBe(LoggerLevel.error);
+});
+
+test('log scope 2', () => {
+    const logger = new MemoryLogger(undefined, [new ScopeFormatter()]);
+    logger.level = LoggerLevel.error;
+
+    const scoped = logger.scoped('database');
+    scoped.error('Peter');
+
+    expect(logger.memory.messageStrings).toEqual(['(database) Peter']);
     expect(scoped.level).toBe(LoggerLevel.error);
 });
 

--- a/packages/orm/src/database.ts
+++ b/packages/orm/src/database.ts
@@ -8,13 +8,7 @@
  * You should have received a copy of the MIT License along with this program.
  */
 
-import {
-    AbstractClassType,
-    ClassType,
-    forwardTypeArguments,
-    getClassName,
-    getClassTypeFromInstance,
-} from '@deepkit/core';
+import { AbstractClassType, ClassType, forwardTypeArguments, getClassName, getClassTypeFromInstance } from '@deepkit/core';
 import {
     entityAnnotation,
     EntityOptions,
@@ -200,7 +194,12 @@ export class Database<ADAPTER extends DatabaseAdapter = DatabaseAdapter> {
         return C;
     }
 
-    listen<T extends EventToken<any>, DEPS extends any[]>(eventToken: T, callback: EventListenerCallback<T['event']>, order: number = 0): EventDispatcherUnsubscribe {
+    /**
+     * Register a new event listener for given token.
+     *
+     * order: The lower the order, the sooner the listener is called. Default is 0.
+     */
+    listen<T extends EventToken<any>>(eventToken: T, callback: EventListenerCallback<T>, order: number = 0): EventDispatcherUnsubscribe {
         return this.eventDispatcher.listen(eventToken, callback, order);
     }
 

--- a/packages/rpc-tcp/src/server.ts
+++ b/packages/rpc-tcp/src/server.ts
@@ -40,7 +40,7 @@ export class RpcTcpServer {
             this.server.on('connection', (socket: Socket) => {
                 const connection = this.kernel?.createConnection({
                     write(b: RpcMessageDefinition) {
-                        connection!.sendBinary(b, (data) => socket.write(data));
+                        connection.sendBinary(b, (data) => socket.write(data));
                     },
                     clientAddress(): string {
                         return socket.remoteAddress || '';
@@ -54,15 +54,15 @@ export class RpcTcpServer {
                 });
 
                 socket.on('data', (data: Uint8Array) => {
-                    connection!.feed(data);
+                    connection.feed(data);
                 });
 
                 socket.on('close', () => {
-                    connection!.close();
+                    connection.close();
                 });
 
-                socket.on('error', () => {
-                    connection!.close();
+                socket.on('error', (error) => {
+                    connection.close(error);
                 });
             });
 
@@ -118,12 +118,16 @@ export class RpcWebSocketServer {
                 },
             });
 
-            ws.on('message', async (message: Uint8Array) => {
+            ws.on('message', (message: Uint8Array) => {
                 connection.feed(message);
             });
 
-            ws.on('close', async () => {
+            ws.on('close', () => {
                 connection.close();
+            });
+
+            ws.on('error', (error) => {
+                connection.close(error);
             });
         });
     }

--- a/packages/rpc/src/client/action.ts
+++ b/packages/rpc/src/client/action.ts
@@ -13,6 +13,7 @@ import { BehaviorSubject, Observable, Subject, Subscriber } from 'rxjs';
 import { skip } from 'rxjs/operators';
 import { Collection, CollectionQueryModelInterface, CollectionState } from '../collection.js';
 import {
+    ActionMode,
     ActionObservableTypes,
     IdInterface,
     rpcActionObservableNext,
@@ -28,13 +29,15 @@ import {
     WrappedV,
 } from '../model.js';
 import { rpcDecodeError, RpcMessage } from '../protocol.js';
-import { ClientProgress } from '../progress.js';
 import type { WritableClient } from './client.js';
 import { EntityState, EntitySubjectStore } from './entity-state.js';
 import { assertType, deserializeType, ReflectionKind, Type, TypeObjectLiteral, typeOf } from '@deepkit/type';
+import { RpcMessageSubject } from './message-subject.js';
+import { ClientProgress, Progress } from '../progress.js';
 import { ProgressTracker, ProgressTrackerState } from '@deepkit/core-rxjs';
 
 type ControllerStateActionTypes = {
+    mode: ActionMode;
     callSchema: TypeObjectLiteral, //with args, method, and controller as property
     resultSchema: TypeObjectLiteral, //with v as property
     observableNextSchema?: Type, //with v as property
@@ -67,19 +70,385 @@ export class RpcControllerState {
     }
 }
 
-// function setReturnType(types: ControllerStateActionTypes, serializedTypes: SerializedTypes) {
-//     const method = deserializeType(serializedTypes);
-//     assertType(method, ReflectionKind.method);
-//
-//     if (method.return.kind === ReflectionKind.class) {
-//         types.classType = method.return.classType;
-//     } else if (method.return.kind === ReflectionKind.promise && method.return.type.kind === ReflectionKind.class) {
-//         types.classType = method.return.type.classType;
-//     }
-// }
+interface ActionState {
+    action: string;
+    progress?: Progress;
+    finalizer: FinalizationRegistry<any>;
+    entityState?: EntityState,
+    observableRef?: WeakRef<Observable<any>>;
+    observableSubjectRef?: WeakRef<Subject<any>>;
+
+    //necessary for BehaviorSubject, since we get ObservableNext before the Observable type call
+    firstObservableNextCalled?: true;
+    firstObservableNext?: any;
+
+    collectionRef?: WeakRef<Collection<any>> | undefined;
+    collectionEntityStore?: EntitySubjectStore<any>
+    types: ControllerStateActionTypes;
+
+    subscriberId?: number;
+    subscribers?: { [id: number]: Subscriber<any> };
+
+    resolve?: (v: any) => void;
+    reject?: (error: any) => void;
+}
+
+function handleCollection(entityStore: EntitySubjectStore<any>, types: ControllerStateActionTypes, collection: Collection<any>, messages: RpcMessage[]) {
+    for (const next of messages) {
+        switch (next.type) {
+            case RpcTypes.ResponseActionCollectionState: {
+                const state = next.parseBody<CollectionState>();
+                collection.setState(state);
+                break;
+            }
+
+            case RpcTypes.ResponseActionCollectionSort: {
+                const body = next.parseBody<rpcResponseActionCollectionSort>();
+                collection.setSort(body.ids);
+                break;
+            }
+
+            case RpcTypes.ResponseActionCollectionModel: {
+                if (!types.collectionQueryModel) throw new RpcError('No collectionQueryModel set');
+                collection.model.set(next.parseBody(types.collectionQueryModel));
+                break;
+            }
+
+            case RpcTypes.ResponseActionCollectionUpdate:
+            case RpcTypes.ResponseActionCollectionAdd: {
+                if (!types.collectionSchema) continue;
+                const incomingItems = next.parseBody<WrappedV>(types.collectionSchema).v as IdInterface[];
+                const items: IdInterface[] = [];
+
+                for (const item of incomingItems) {
+                    if (!entityStore.isRegistered(item.id)) entityStore.register(item);
+                    if (next.type === RpcTypes.ResponseActionCollectionUpdate) {
+                        entityStore.onSet(item.id, item);
+                    }
+
+                    let fork = collection.entitySubjects.get(item.id);
+                    if (!fork) {
+                        fork = entityStore.createFork(item.id);
+                        collection.entitySubjects.set(item.id, fork);
+                    }
+                    items.push(fork.value);
+
+                    //fork is automatically unsubscribed once removed from the collection
+                    fork.pipe(skip(1)).subscribe(i => {
+                        if (fork!.deleted) return; //we get deleted already
+                        collection.deepChange.next(i);
+                        collection.loaded();
+                    });
+                }
+
+                if (next.type === RpcTypes.ResponseActionCollectionAdd) {
+                    collection.add(items);
+                } else if (next.type === RpcTypes.ResponseActionCollectionUpdate) {
+                    collection.update(items);
+                }
+                break;
+            }
+
+            case RpcTypes.ResponseActionCollectionRemove: {
+                const ids = next.parseBody<rpcResponseActionCollectionRemove>().ids;
+                collection.remove(ids); //this unsubscribes its EntitySubject as well
+                break;
+            }
+
+            case RpcTypes.ResponseActionCollectionSet: {
+                if (!types.collectionSchema) continue;
+                const incomingItems = next.parseBody<WrappedV>(types.collectionSchema).v as IdInterface[];
+                const items: IdInterface[] = [];
+                for (const item of incomingItems) {
+                    if (!entityStore.isRegistered(item.id)) entityStore.register(item);
+                    const fork = entityStore.createFork(item.id);
+                    collection.entitySubjects.set(item.id, fork);
+                    items.push(fork.value);
+
+                    //fork is automatically unsubscribed once removed from the collection
+                    fork.pipe(skip(1)).subscribe(i => {
+                        if (fork.deleted) return; //we get deleted already
+                        collection.deepChange.next(i);
+                        collection.loaded();
+                    });
+                }
+
+                collection.set(items);
+                break;
+            }
+        }
+    }
+    collection.loaded();
+}
+
+
+function rejectAction(state: ActionState, error: any) {
+    if (!state.reject) return;
+    state.reject(error);
+
+    // important to free Promise
+    state.reject = undefined;
+    state.resolve = undefined;
+}
+
+function resolveAction(state: ActionState, result: any) {
+    if (!state.resolve) return;
+    state.resolve(result);
+
+    // important to free Promise
+    state.reject = undefined;
+    state.resolve = undefined;
+}
+
+function actionProtocolError(reply: RpcMessage, subject: RpcMessageSubject, state: ActionState) {
+    subject.release();
+    const error = reply.getError();
+    if (state.subscribers) {
+        for (const sub of Object.values(state.subscribers)) {
+            sub.error(error);
+        }
+    }
+    rejectAction(state, error);
+}
+
+function actionProtocolFull(reply: RpcMessage, subject: RpcMessageSubject, state: ActionState) {
+    switch (reply.type) {
+        case RpcTypes.ResponseActionSimple: {
+            try {
+                const result = reply.parseBody<WrappedV>(state.types.resultSchema);
+                resolveAction(state, result.v);
+            } catch (error: any) {
+                console.log('parse error, got', reply.parseBody<WrappedV>());
+                throw error;
+            }
+            subject.release();
+            break;
+        }
+
+
+        case RpcTypes.ResponseEntity: {
+            if (!state.types.classType || !state.entityState) throw new RpcError('No classType returned by the rpc action');
+            resolveAction(state, state.entityState.createEntitySubject(state.types.classType, state.types.resultSchema, reply));
+            break;
+        }
+
+        case RpcTypes.ResponseActionCollectionChange: {
+            if (!state.collectionRef) throw new RpcError('No collection loaded yet');
+            if (!state.types.collectionSchema) throw new RpcError('no collectionSchema loaded yet');
+            if (!state.collectionEntityStore) throw new RpcError('no collectionEntityStore loaded yet');
+
+            const collection = state.collectionRef.deref();
+            if (state.collectionEntityStore && collection) {
+                handleCollection(state.collectionEntityStore, state.types, collection, reply.getBodies());
+            }
+
+            break;
+        }
+
+        case RpcTypes.ResponseActionCollection: {
+            if (!state.types.classType) throw new RpcError('No classType returned by the rpc action');
+            if (!state.types.collectionQueryModel) throw new RpcError('No collectionQueryModel returned by the rpc action');
+            if (!state.entityState) throw new RpcError('No entityState set');
+            const collection = new Collection(state.types.classType);
+            state.collectionRef = new WeakRef(collection);
+            state.collectionEntityStore = state.entityState.getStore(state.types.classType);
+
+            collection.model.change.subscribe(() => {
+                subject.send(RpcTypes.ActionCollectionModel, collection!.model, state.types.collectionQueryModel);
+            });
+
+            collection.addTeardown(() => {
+                subject.send(RpcTypes.ActionCollectionUnsubscribe);
+                subject.release();
+            });
+
+            handleCollection(state.collectionEntityStore, state.types, collection, reply.getBodies());
+
+            resolveAction(state, collection);
+            break;
+        }
+
+        case RpcTypes.ResponseActionObservableError: {
+            const body = reply.parseBody<rpcResponseActionObservableSubscriptionError>();
+            const error = rpcDecodeError(body);
+            if (state.observableRef) {
+                if (!state.subscribers?.[body.id]) return; //we silently ignore this
+                state.subscribers![body.id].error(error);
+            } else if (state.observableSubjectRef) {
+                state.observableSubjectRef.deref()?.error(error);
+                subject.release();
+            }
+            break;
+        }
+
+        case RpcTypes.ResponseActionObservableComplete: {
+            const body = reply.parseBody<rpcActionObservableSubscribeId>();
+
+            if (state.observableRef) {
+                if (!state.subscribers?.[body.id]) return; //we silently ignore this
+                state.subscribers[body.id].complete();
+            } else if (state.observableSubjectRef) {
+                state.observableSubjectRef.deref()?.complete();
+                subject.release();
+            }
+            break;
+        }
+
+        case RpcTypes.ResponseActionObservableNext: {
+            if (!state.types.observableNextSchema) throw new RpcError('No observableNextSchema set');
+
+            const body = reply.parseBody<rpcActionObservableNext>(state.types.observableNextSchema);
+
+            if (state.observableRef) {
+                if (!state.subscribers?.[body.id]) return; //we silently ignore this
+                state.subscribers[body.id].next(body.v);
+            } else if (state.observableSubjectRef) {
+                const s = state.observableSubjectRef.deref();
+                if (s && !s.closed) s.next(body.v);
+            } else {
+                state.firstObservableNext = body.v;
+                state.firstObservableNextCalled = true;
+            }
+
+            break;
+        }
+
+        case RpcTypes.ResponseActionObservable: {
+            if (state.observableRef) break;
+            const body = reply.parseBody<rpcResponseActionObservable>();
+
+            // this observable can be subscribed multiple times now
+            // each time we need to call the server again, since it's not a Subject
+            if (body.type === ActionObservableTypes.observable) {
+                state.subscriberId = 0;
+                state.subscribers = {};
+                const observable = new Observable((observer) => {
+                    const id = state.subscriberId!++;
+                    state.subscribers![id] = observer;
+                    subject.send<rpcActionObservableSubscribeId>(RpcTypes.ActionObservableSubscribe, { id });
+
+                    return {
+                        unsubscribe: () => {
+                            delete state.subscribers![id];
+                            subject.send<rpcActionObservableSubscribeId>(RpcTypes.ActionObservableUnsubscribe, { id });
+                        },
+                    };
+                });
+                state.observableRef = new WeakRef(observable);
+                state.finalizer.register(observable, () => {
+                    subject.send(RpcTypes.ActionObservableDisconnect);
+                    subject.release();
+                });
+                resolveAction(state, observable);
+            } else if (body.type === ActionObservableTypes.subject) {
+                const observableSubject = new Subject();
+                let freed = false;
+                state.observableSubjectRef = new WeakRef(observableSubject);
+
+                // we have to monkey patch unsubscribe, because there is no other way to hook into that
+                // note: subject.subscribe().add(T), T is not called when subject.unsubscribe() is called.
+                observableSubject.unsubscribe = function() {
+                    Subject.prototype.unsubscribe.call(this);
+                    if (!freed) {
+                        freed = true;
+                        subject.send(RpcTypes.ActionObservableSubjectUnsubscribe);
+                        state.finalizer.unregister(this);
+                        subject.release();
+                    }
+                };
+
+                observableSubject.complete = function() {
+                    Subject.prototype.complete.call(this);
+                    if (!freed) {
+                        freed = true;
+                        subject.send(RpcTypes.ActionObservableSubjectUnsubscribe);
+                        state.finalizer.unregister(this);
+                        subject.release();
+                    }
+                };
+
+                if (state.firstObservableNextCalled) {
+                    observableSubject.next(state.firstObservableNext);
+                    state.firstObservableNext = undefined;
+                }
+
+                state.finalizer.register(observableSubject, () => {
+                    subject.send(RpcTypes.ActionObservableSubjectUnsubscribe);
+                    freed = true;
+                    subject.release();
+                });
+                resolveAction(state, observableSubject);
+            } else if (body.type === ActionObservableTypes.behaviorSubject || body.type === ActionObservableTypes.progressTracker) {
+                const classType = body.type === ActionObservableTypes.progressTracker ? ProgressTracker : BehaviorSubject;
+                const observableSubject = new classType(state.firstObservableNext);
+                state.observableSubjectRef = new WeakRef(observableSubject);
+                state.firstObservableNext = undefined;
+                let freed = false;
+
+                // we have to monkey patch unsubscribe, because there is no other way to hook into that
+                // note: subject.subscribe().add(T), T is not called when subject.unsubscribe() is called.
+                observableSubject.unsubscribe = function() {
+                    Subject.prototype.unsubscribe.call(this);
+                    if (!freed) {
+                        freed = true;
+                        subject.send(RpcTypes.ActionObservableSubjectUnsubscribe);
+                        state.finalizer.unregister(this);
+                    }
+                };
+
+                observableSubject.complete = function() {
+                    Subject.prototype.complete.call(this);
+                    if (!freed) {
+                        freed = true;
+                        subject.send(RpcTypes.ActionObservableSubjectUnsubscribe);
+                        state.finalizer.unregister(this);
+                    }
+                };
+
+                if (observableSubject instanceof ProgressTracker) {
+                    // whenever the client changes something, it's synced back to the server.
+                    // this is important to handle the stop signal.
+                    const oldChanged = observableSubject.changed;
+                    observableSubject.changed = function(this: ProgressTracker) {
+                        subject.send(RpcTypes.ActionObservableProgressNext, this.value, typeOf<ProgressTrackerState[]>());
+                        return oldChanged.apply(this);
+                    };
+                }
+
+                state.finalizer.register(observableSubject, () => {
+                    subject.send(RpcTypes.ActionObservableSubjectUnsubscribe);
+                    subject.release();
+                });
+                resolveAction(state, observableSubject);
+            }
+
+            break;
+        }
+        case RpcTypes.Error: {
+            actionProtocolError(reply, subject, state);
+            break;
+        }
+        default: {
+            console.log(`Unexpected type received ${reply.type} ${RpcTypes[reply.type]}`);
+        }
+    }
+}
+
+function actionProtocol(reply: RpcMessage, subject: RpcMessageSubject, state: ActionState) {
+    try {
+        actionProtocolFull(reply, subject, state);
+    } catch (error) {
+        console.warn('reply error', reply.id, RpcTypes[reply.type], error);
+        rejectAction(state, `Reply failed for ${state.action}: ${error}`);
+    }
+}
 
 export class RpcActionClient {
     public entityState = new EntityState;
+
+    private finalizer = new FinalizationRegistry<() => void>((heldValue) => {
+        heldValue();
+    });
 
     constructor(protected client: WritableClient) {
     }
@@ -92,328 +461,35 @@ export class RpcActionClient {
         const progress = ClientProgress.getNext();
 
         return asyncOperation<any>(async (resolve, reject) => {
-            try {
-                const types = controller.getState(method)?.types || await this.loadActionTypes(controller, method, options);
+            const types = controller.getState(method)?.types || await this.loadActionTypes(controller, method, options);
 
-                let observable: Observable<any> | undefined;
-                let observableSubject: Subject<any> | undefined;
+            // forwarded caught progress to client sendMessage
+            ClientProgress.nextProgress = progress;
 
-                //necessary for BehaviorSubject, since we get ObservableNext before the Observable type call
-                let firstObservableNextCalled = false;
-                let firstObservableNext: any;
+            const state: ActionState = {
+                action: `${controller.controller}.${method}`,
+                finalizer: this.finalizer,
+                types,
+                entityState: this.entityState,
+                resolve,
+                reject,
+                progress,
+            };
 
-                let collection: Collection<any> | undefined;
-                let collectionEntityStore: EntitySubjectStore<any> | undefined;
-
-                let subscriberId = 0;
-                const subscribers: { [id: number]: Subscriber<any> } = {};
-
-                ClientProgress.nextProgress = progress;
-
-                const subject = this.client.sendMessage(RpcTypes.Action, {
-                    controller: controller.controller,
-                    method: method,
-                    args,
-                }, types.callSchema, {
-                    peerId: controller.peerId,
-                    dontWaitForConnection: options.dontWaitForConnection,
-                    timeout: options.timeout,
-                }).onRejected(reject).onReply((reply) => {
-                    try {
-                        // console.log('client: answer', RpcTypes[reply.type], reply.composite);
-
-                        switch (reply.type) {
-                            case RpcTypes.ResponseEntity: {
-                                if (!types.classType) throw new RpcError('No classType returned by the rpc action');
-                                resolve(this.entityState.createEntitySubject(types.classType, types.resultSchema, reply));
-                                break;
-                            }
-
-                            case RpcTypes.ResponseActionSimple: {
-                                subject.release();
-                                try {
-                                    const result = reply.parseBody<WrappedV>(types.resultSchema);
-                                    resolve(result.v);
-                                } catch (error: any) {
-                                    console.log('parse error, got', reply.parseBody<WrappedV>());
-                                    throw error;
-                                }
-                                break;
-                            }
-
-                            case RpcTypes.ResponseActionObservableError: {
-                                const body = reply.parseBody<rpcResponseActionObservableSubscriptionError>();
-                                const error = rpcDecodeError(body);
-                                if (observable) {
-                                    if (!subscribers[body.id]) return; //we silently ignore this
-                                    subscribers[body.id].error(error);
-                                } else if (observableSubject) {
-                                    observableSubject.error(error);
-                                }
-                                break;
-                            }
-
-                            case RpcTypes.ResponseActionObservableComplete: {
-                                const body = reply.parseBody<rpcActionObservableSubscribeId>();
-
-                                if (observable) {
-                                    if (!subscribers[body.id]) return; //we silently ignore this
-                                    subscribers[body.id].complete();
-                                } else if (observableSubject) {
-                                    observableSubject.complete();
-                                }
-                                break;
-                            }
-
-                            case RpcTypes.ResponseActionObservableNext: {
-                                if (!types.observableNextSchema) throw new RpcError('No observableNextSchema set');
-
-                                const body = reply.parseBody<rpcActionObservableNext>(types.observableNextSchema);
-
-                                if (observable) {
-                                    if (!subscribers[body.id]) return; //we silently ignore this
-                                    subscribers[body.id].next(body.v);
-                                } else if (observableSubject) {
-                                    observableSubject.next(body.v);
-                                } else {
-                                    firstObservableNext = body.v;
-                                    firstObservableNextCalled = true;
-                                }
-
-                                break;
-                            }
-
-                            case RpcTypes.ResponseActionBehaviorSubject: {
-                                if (!types.observableNextSchema) throw new RpcError('No observableNextSchema set');
-
-                                const body = reply.parseBody<WrappedV>(types.observableNextSchema);
-                                observableSubject = new BehaviorSubject(body.v);
-                                resolve(observableSubject);
-                                break;
-                            }
-
-                            case RpcTypes.ResponseActionObservable: {
-                                if (observable) console.error('Already got ActionResponseObservable');
-                                const body = reply.parseBody<rpcResponseActionObservable>();
-
-                                //this observable can be subscribed multiple times now
-                                // each time we need to call the server again, since its not a Subject
-                                if (body.type === ActionObservableTypes.observable) {
-                                    observable = new Observable((observer) => {
-                                        const id = subscriberId++;
-                                        subscribers[id] = observer;
-                                        subject.send<rpcActionObservableSubscribeId>(RpcTypes.ActionObservableSubscribe, { id });
-
-                                        return {
-                                            unsubscribe: () => {
-                                                delete subscribers[id];
-                                                subject.send<rpcActionObservableSubscribeId>(RpcTypes.ActionObservableUnsubscribe, { id });
-                                            },
-                                        };
-                                    });
-                                    (observable as any).disconnect = () => {
-                                        for (const sub of Object.values(subscribers)) {
-                                            sub.complete();
-                                        }
-                                        subject.send(RpcTypes.ActionObservableDisconnect);
-                                    };
-                                    resolve(observable);
-                                } else if (body.type === ActionObservableTypes.subject) {
-                                    observableSubject = new Subject<any>();
-                                    //we have to monkey patch unsubscribe, because they is no other way to hook into that
-                                    // note: subject.subscribe().add(T), T is not called when subject.unsubscribe() is called.
-                                    observableSubject.unsubscribe = () => {
-                                        Subject.prototype.unsubscribe.call(observableSubject);
-                                        subject.send(RpcTypes.ActionObservableSubjectUnsubscribe);
-                                    };
-
-                                    observableSubject.complete = () => {
-                                        Subject.prototype.complete.call(observableSubject);
-                                        subject.send(RpcTypes.ActionObservableSubjectUnsubscribe);
-                                    };
-
-                                    if (firstObservableNextCalled) {
-                                        observableSubject.next(firstObservableNext);
-                                        firstObservableNext = undefined;
-                                    }
-                                    resolve(observableSubject);
-                                } else if (body.type === ActionObservableTypes.behaviorSubject || body.type === ActionObservableTypes.progressTracker) {
-                                    const classType = body.type === ActionObservableTypes.progressTracker ? ProgressTracker : BehaviorSubject;
-                                    observableSubject = new classType(firstObservableNext);
-                                    firstObservableNext = undefined;
-
-                                    //we have to monkey patch unsubscribe, because there is no other way to hook into that
-                                    // note: subject.subscribe().add(T), T is not called when subject.unsubscribe() is called.
-                                    observableSubject.unsubscribe = () => {
-                                        Subject.prototype.unsubscribe.call(observableSubject);
-                                        subject.send(RpcTypes.ActionObservableSubjectUnsubscribe);
-                                    };
-
-                                    observableSubject.complete = () => {
-                                        Subject.prototype.complete.call(observableSubject);
-                                        subject.send(RpcTypes.ActionObservableSubjectUnsubscribe);
-                                    };
-
-                                    if (observableSubject instanceof ProgressTracker) {
-                                        //whenever the client changes something, it's synced back to the server.
-                                        //this is important to handle the stop signal.
-                                        const oldChanged = observableSubject.changed;
-                                        observableSubject.changed = function(this: ProgressTracker) {
-                                            subject.send(RpcTypes.ActionObservableProgressNext, this.value, typeOf<ProgressTrackerState[]>());
-                                            return oldChanged.apply(this);
-                                        };
-                                    }
-
-                                    resolve(observableSubject);
-                                }
-
-                                break;
-                            }
-
-                            case RpcTypes.ResponseActionCollectionChange: {
-                                if (!collection) throw new RpcError('No collection loaded yet');
-                                if (!types.collectionSchema) throw new RpcError('no collectionSchema loaded yet');
-                                if (!collectionEntityStore) throw new RpcError('no collectionEntityStore loaded yet');
-
-                                this.handleCollection(collectionEntityStore, types, collection, reply.getBodies());
-
-                                break;
-                            }
-
-                            case RpcTypes.ResponseActionCollection: {
-                                const bodies = reply.getBodies();
-
-                                if (!types.classType) throw new RpcError('No classType returned by the rpc action');
-                                if (!types.collectionQueryModel) throw new RpcError('No collectionQueryModel returned by the rpc action');
-                                collection = new Collection(types.classType);
-                                collectionEntityStore = this.entityState.getStore(types.classType);
-
-                                collection.model.change.subscribe(() => {
-                                    subject.send(RpcTypes.ActionCollectionModel, collection!.model, types.collectionQueryModel);
-                                });
-
-                                collection.addTeardown(() => {
-                                    subject.send(RpcTypes.ActionCollectionUnsubscribe);
-                                });
-
-                                this.handleCollection(collectionEntityStore, types, collection, bodies);
-
-                                resolve(collection);
-                                break;
-                            }
-
-                            case RpcTypes.Error: {
-                                subject.release();
-                                const error = reply.getError();
-                                // console.debug('Client received error', error);
-                                for (const sub of Object.values(subscribers)) {
-                                    sub.error(error);
-                                }
-                                reject(error);
-                                break;
-                            }
-
-                            default: {
-                                console.log(`Unexpected type received ${reply.type} ${RpcTypes[reply.type]}`);
-                            }
-                        }
-                    } catch (error) {
-                        console.warn('reply error', reply.id, RpcTypes[reply.type], error);
-                        reject(`Reply failed for ${controller.controller}.${method}: ${error}`);
-                    }
-                });
-            } catch (error) {
-                reject(error);
-            }
+            this.client.sendMessage(RpcTypes.Action, {
+                controller: controller.controller,
+                method: method,
+                args,
+            }, types.callSchema, {
+                peerId: controller.peerId,
+                dontWaitForConnection: options.dontWaitForConnection,
+                timeout: options.timeout,
+            }).onRejected((error) => {
+                rejectAction(state, error);
+            }).onReply(function(reply: RpcMessage, subject: RpcMessageSubject) {
+                actionProtocol(reply, subject, state);
+            });
         });
-    }
-
-    protected handleCollection(entityStore: EntitySubjectStore<any>, types: ControllerStateActionTypes, collection: Collection<any>, messages: RpcMessage[]) {
-        for (const next of messages) {
-            switch (next.type) {
-                case RpcTypes.ResponseActionCollectionState: {
-                    const state = next.parseBody<CollectionState>();
-                    collection.setState(state);
-                    break;
-                }
-
-                case RpcTypes.ResponseActionCollectionSort: {
-                    const body = next.parseBody<rpcResponseActionCollectionSort>();
-                    collection.setSort(body.ids);
-                    break;
-                }
-
-                case RpcTypes.ResponseActionCollectionModel: {
-                    if (!types.collectionQueryModel) throw new RpcError('No collectionQueryModel set');
-                    collection.model.set(next.parseBody(types.collectionQueryModel));
-                    break;
-                }
-
-                case RpcTypes.ResponseActionCollectionUpdate:
-                case RpcTypes.ResponseActionCollectionAdd: {
-                    if (!types.collectionSchema) continue;
-                    const incomingItems = next.parseBody<WrappedV>(types.collectionSchema).v as IdInterface[];
-                    const items: IdInterface[] = [];
-
-                    for (const item of incomingItems) {
-                        if (!entityStore.isRegistered(item.id)) entityStore.register(item);
-                        if (next.type === RpcTypes.ResponseActionCollectionUpdate) {
-                            entityStore.onSet(item.id, item);
-                        }
-
-                        let fork = collection.entitySubjects.get(item.id);
-                        if (!fork) {
-                            fork = entityStore.createFork(item.id);
-                            collection.entitySubjects.set(item.id, fork);
-                        }
-                        items.push(fork.value);
-
-                        //fork is automatically unsubscribed once removed from the collection
-                        fork.pipe(skip(1)).subscribe(i => {
-                            if (fork!.deleted) return; //we get deleted already
-                            collection.deepChange.next(i);
-                            collection.loaded();
-                        });
-                    }
-
-                    if (next.type === RpcTypes.ResponseActionCollectionAdd) {
-                        collection.add(items);
-                    } else if (next.type === RpcTypes.ResponseActionCollectionUpdate) {
-                        collection.update(items);
-                    }
-                    break;
-                }
-
-                case RpcTypes.ResponseActionCollectionRemove: {
-                    const ids = next.parseBody<rpcResponseActionCollectionRemove>().ids;
-                    collection.remove(ids); //this unsubscribes its EntitySubject as well
-                    break;
-                }
-
-                case RpcTypes.ResponseActionCollectionSet: {
-                    if (!types.collectionSchema) continue;
-                    const incomingItems = next.parseBody<WrappedV>(types.collectionSchema).v as IdInterface[];
-                    const items: IdInterface[] = [];
-                    for (const item of incomingItems) {
-                        if (!entityStore.isRegistered(item.id)) entityStore.register(item);
-                        const fork = entityStore.createFork(item.id);
-                        collection.entitySubjects.set(item.id, fork);
-                        items.push(fork.value);
-
-                        //fork is automatically unsubscribed once removed from the collection
-                        fork.pipe(skip(1)).subscribe(i => {
-                            if (fork.deleted) return; //we get deleted already
-                            collection.deepChange.next(i);
-                            collection.loaded();
-                        });
-                    }
-
-                    collection.set(items);
-                    break;
-                }
-            }
-        }
-        collection.loaded();
     }
 
     public async loadActionTypes(controller: RpcControllerState, method: string, options: {
@@ -472,6 +548,7 @@ export class RpcActionClient {
                 }
 
                 state.types = {
+                    mode: parsed.mode,
                     classType,
                     collectionQueryModel,
                     collectionSchema,

--- a/packages/rpc/src/client/client-websocket.ts
+++ b/packages/rpc/src/client/client-websocket.ts
@@ -13,6 +13,8 @@ import { ClientTransportAdapter, RpcClient } from './client.js';
 import { TransportClientConnection } from '../transport.js';
 import { RpcError } from '../model.js';
 
+declare const location: { protocol: string, host: string, origin: string };
+
 /**
  * A RpcClient that connects via WebSocket transport.
  */

--- a/packages/rpc/src/client/http.ts
+++ b/packages/rpc/src/client/http.ts
@@ -5,6 +5,8 @@ import { RpcError, RpcTypes } from '../model.js';
 import { HttpRpcMessage } from '../server/http.js';
 import { serialize } from '@deepkit/type';
 
+declare const location: { protocol: string, host: string, origin: string };
+
 export interface RpcHttpResponseInterface {
     status: number;
     headers: { [name: string]: string };

--- a/packages/rpc/src/events.ts
+++ b/packages/rpc/src/events.ts
@@ -1,0 +1,112 @@
+import { DataEvent, EventToken, EventTokenSync } from '@deepkit/event';
+import { InjectorContext } from '@deepkit/injector';
+import { RpcKernelBaseConnection } from './server/kernel';
+import { RpcControllerAccess, Session } from './server/security';
+
+export type WithFail<T> = Omit<T, 'phase'> & { phase: 'fail'; error: Error };
+
+export interface RpcConnectionEvent {
+    context: {
+        connection: RpcKernelBaseConnection;
+        injector: InjectorContext;
+    };
+}
+
+export const onRpcConnection = new EventTokenSync<DataEvent<RpcConnectionEvent>>('rpc.connection');
+
+export interface RpcConnectionCloseEvent extends RpcConnectionEvent {
+    /**
+     * There could be multiple reasons why a connection is closed. This could be a normal
+     * close, an error, or a timeout.
+     * If the connection was closed because of an error, this property contains the error object.
+     */
+    reason: string | Error;
+}
+
+export const onRpcConnectionClose = new EventTokenSync<DataEvent<RpcConnectionCloseEvent>>('rpc.connectionClose');
+
+/**
+ * All times are in milliseconds (using performance.now()).
+ */
+export interface RpcActionTimings {
+    /**
+     * The start of the action (performance.now())
+     */
+    start: number;
+
+    /**
+     * The end of the action (performance.now())
+     */
+    end: number;
+
+    /**
+     * Time it took to check the controller access (since start)
+     */
+    types?: number;
+
+    /**
+     * Time it took to parse the body (since start)
+     */
+    parseBody?: number;
+
+    /**
+     * Time it took to validate the parameters (since start)
+     */
+    validate?: number;
+
+    /**
+     * Time it took to check the controller access (since start)
+     */
+    controllerAccess?: number;
+}
+
+export interface RpcActionEventBase extends RpcConnectionEvent {
+    phase: 'start' | 'success';
+    controller: RpcControllerAccess;
+    timing: RpcActionTimings;
+}
+
+export type RpcActionEvent = RpcActionEventBase | WithFail<RpcActionEventBase>;
+
+export const onRpcAction = new EventTokenSync<DataEvent<RpcActionEvent>>('rpc.action');
+
+export interface RpcAuthEventStart extends RpcConnectionEvent {
+    token: any;
+    phase: 'start';
+    /**
+     * Set this to the session object if the authentication was successful.
+     * If set this will bypass RpcKernelSecurity and directly use this session.
+     */
+    session?: Session;
+}
+
+export interface RpcAuthEventSuccess extends RpcConnectionEvent {
+    token: any;
+    phase: 'success';
+    session: Session;
+}
+
+export type RpcAuthEvent = RpcAuthEventStart | RpcAuthEventSuccess | WithFail<RpcAuthEventStart>;
+
+export const onRpcAuth = new EventToken<DataEvent<RpcAuthEvent>>('rpc.auth');
+
+export interface RpcControllerAccessEventStart extends RpcConnectionEvent {
+    phase: 'start';
+    session: Session;
+    controller: RpcControllerAccess;
+    /**
+     * Set this to true if you want to grant access to the controller.
+     * If set this will bypass RpcKernelSecurity and directly grant access.
+     */
+    granted?: boolean;
+}
+
+export interface RpcControllerAccessEventBase extends RpcConnectionEvent {
+    phase: 'success' | 'denied';
+    session: Session;
+    controller: RpcControllerAccess;
+}
+
+export type RpcControllerAccessEvent = RpcControllerAccessEventStart | RpcControllerAccessEventBase | WithFail<RpcControllerAccessEventBase>;
+
+export const onRpcControllerAccess = new EventToken<DataEvent<RpcControllerAccessEvent>>('rpc.controllerAccess');

--- a/packages/rpc/src/model.ts
+++ b/packages/rpc/src/model.ts
@@ -27,6 +27,81 @@ export interface IdVersionInterface extends IdInterface {
     version: number;
 }
 
+type Writeable<T> = { -readonly [P in keyof T]: T[P] };
+
+export type NumericKeys<T> = {
+    [K in keyof T]: T[K] extends number ? K : never;
+}[keyof T];
+
+export class RpcTransportStats {
+    readonly incomingBytes: number = 0;
+    readonly outgoingBytes: number = 0;
+
+    /**
+     * Amount of incoming and outgoing messages.
+     */
+    public readonly incoming: number = 0;
+    public readonly outgoing: number = 0;
+
+    public increase(name: NumericKeys<RpcTransportStats>, count: number) {
+        (this as Writeable<this>)[name] += count;
+    }
+}
+
+export class ActionStats {
+    readonly observables: number = 0;
+    readonly subjects: number = 0;
+    readonly behaviorSubjects: number = 0;
+    readonly progressTrackers: number = 0;
+    readonly subscriptions: number = 0;
+
+    public increase(name: NumericKeys<ActionStats>, count: number) {
+        (this as Writeable<this>)[name] += count;
+    }
+}
+
+export class ForwardedActionStats extends ActionStats {
+    constructor(protected forward: ActionStats) {
+        super();
+    }
+
+    public increase(name: NumericKeys<ActionStats>, count: number) {
+        this.forward.increase(name, count);
+        super.increase(name, count);
+    }
+}
+
+export class RpcStats extends RpcTransportStats {
+    public readonly connections: number = 0;
+    public readonly totalConnections: number = 0;
+
+    /**
+     * How many actions have been executed.
+     */
+    public readonly actions: number = 0;
+
+    public readonly active: ActionStats = new ActionStats;
+    public readonly total: ActionStats = new ActionStats;
+
+    public increase(name: NumericKeys<RpcStats>, count: number) {
+        (this as Writeable<this>)[name] += count;
+    }
+}
+
+export class ForwardedRpcStats extends RpcStats {
+    public readonly active = new ForwardedActionStats(this.forward.active);
+    public readonly total = new ForwardedActionStats(this.forward.total);
+
+    constructor(protected forward: RpcStats) {
+        super();
+    }
+
+    public increase(name: NumericKeys<RpcStats>, count: number) {
+        this.forward.increase(name, count);
+        super.increase(name, count);
+    }
+}
+
 export class StreamBehaviorSubject<T> extends BehaviorSubject<T> {
     public readonly appendSubject = new Subject<T>();
     protected nextChange?: Subject<void>;
@@ -262,7 +337,11 @@ export enum RpcTypes {
     ActionObservableSubjectUnsubscribe,
 
     ResponseActionObservable,
+    /**
+     * @deprecated not used anymore
+     */
     ResponseActionBehaviorSubject,
+
     ResponseActionObservableNext,
     ResponseActionObservableComplete,
     ResponseActionObservableError,
@@ -402,10 +481,7 @@ export interface rpcEntityPatch {
     };
 }
 
-export class AuthenticationError extends Error {
-    constructor(message: string = 'Authentication failed') {
-        super(message);
-    }
+export class AuthenticationError extends CustomError {
 }
 
 export interface WrappedV {

--- a/packages/rpc/src/server/kernel.ts
+++ b/packages/rpc/src/server/kernel.ts
@@ -8,18 +8,21 @@
  * You should have received a copy of the MIT License along with this program.
  */
 
-import { arrayRemoveItem, bufferToString, ClassType, createBuffer, getClassName } from '@deepkit/core';
+import { arrayRemoveItem, bufferToString, ClassType, createBuffer, ensureError, getClassName } from '@deepkit/core';
 import { ReceiveType, ReflectionKind, resolveReceiveType, serialize, stringifyUuid, Type, typeOf, writeUuid } from '@deepkit/type';
 import { RpcMessageSubject } from '../client/message-subject.js';
 import {
     AuthenticationError,
     ControllerDefinition,
+    ForwardedRpcStats,
     rpcAuthenticate,
     rpcClientId,
     RpcError,
     rpcError,
     rpcPeerRegister,
     rpcResponseAuthenticate,
+    RpcStats,
+    RpcTransportStats,
     RpcTypes,
 } from '../model.js';
 import {
@@ -35,7 +38,7 @@ import {
     RpcMessageRouteType,
     serializeBinaryRpcMessage,
 } from '../protocol.js';
-import { ActionTypes, RpcActionHook, RpcActionHookError, RpcActionHookSuccess, RpcServerAction } from './action.js';
+import { ActionTypes, RpcServerAction } from './action.js';
 import { RpcKernelSecurity, SessionState } from './security.js';
 import { RpcActionClient, RpcControllerState } from '../client/action.js';
 import { RemoteController } from '../client/client.js';
@@ -52,6 +55,8 @@ import {
 } from '../transport.js';
 import { HttpRpcMessage, RpcHttpRequest, RpcHttpResponse } from './http.js';
 import { SingleProgress } from '../progress.js';
+import { DataEvent, EventDispatcher, EventDispatcherUnsubscribe, EventListenerCallback, EventToken } from '@deepkit/event';
+import { onRpcAuth, onRpcConnection, onRpcConnectionClose, RpcAuthEventStart } from '../events';
 
 const anyType: Type = { kind: ReflectionKind.any };
 
@@ -63,6 +68,7 @@ export class RpcCompositeMessage {
     public errorLabel: string = 'Error in serialization';
 
     constructor(
+        protected stats: RpcTransportStats,
         protected logger: Logger,
         public type: number,
         protected id: number,
@@ -84,7 +90,7 @@ export class RpcCompositeMessage {
 
     write(message: RpcMessageDefinition): void {
         try {
-            this.writer(message, this.transportOptions);
+            this.writer(message, this.transportOptions, this.stats);
         } catch (error) {
             if (this.logValidationErrors) {
                 this.logger.warn(this.errorLabel, error);
@@ -112,6 +118,7 @@ export class RpcMessageBuilder {
     public errorLabel: string = 'Error in serialization';
 
     constructor(
+        protected stats: RpcTransportStats,
         protected logger: Logger,
         protected writer: TransportMessageWriter,
         protected transportOptions: TransportOptions,
@@ -136,7 +143,7 @@ export class RpcMessageBuilder {
 
     write(message: RpcMessageDefinition): void {
         try {
-            this.writer(message, this.transportOptions);
+            this.writer(message, this.transportOptions, this.stats);
         } catch (error: any) {
             if (this.logValidationErrors) {
                 this.logger.warn(this.errorLabel, error);
@@ -167,7 +174,7 @@ export class RpcMessageBuilder {
     }
 
     composite(type: number): RpcCompositeMessage {
-        const composite = new RpcCompositeMessage(this.logger, type, this.id, this.writer, this.transportOptions, this.clientId, this.source);
+        const composite = new RpcCompositeMessage(this.stats, this.logger, type, this.id, this.writer, this.transportOptions, this.clientId, this.source);
         composite.strictSerialization = this.strictSerialization;
         composite.logValidationErrors = this.logValidationErrors;
         composite.errorLabel = this.errorLabel;
@@ -231,10 +238,18 @@ export abstract class RpcKernelBaseConnection {
     protected reader = new RpcBinaryMessageReader(
         this.handleMessage.bind(this),
         (id: number) => {
-            this.writer(createRpcMessage(id, RpcTypes.ChunkAck), this.transportOptions);
+            this.writer(createRpcMessage(id, RpcTypes.ChunkAck), this.transportOptions, this.stats);
         },
     );
 
+    /**
+     * Statistics about the server->client communication.
+     */
+    public clientStats: RpcStats = new RpcStats();
+
+    /**
+     * When the server wants to execute an action on the client, it uses the actionClient.
+     */
     protected actionClient: RpcActionClient = new RpcActionClient(this);
 
     protected id: Uint8Array = writeUuid(createBuffer(16));
@@ -249,10 +264,15 @@ export abstract class RpcKernelBaseConnection {
     public closed: boolean = false;
 
     constructor(
+        public stats: RpcStats,
         protected logger: Logger,
         public transportConnection: TransportConnection,
         protected connections: RpcKernelConnections,
+        protected injector: InjectorContext,
+        protected eventDispatcher: EventDispatcher,
     ) {
+        this.stats.increase('connections', 1);
+        this.stats.increase('totalConnections', 1);
         this.writer = createWriter(transportConnection, this.transportOptions, this.reader);
 
         this.connections.connections.push(this);
@@ -262,7 +282,7 @@ export abstract class RpcKernelBaseConnection {
     }
 
     write(message: RpcMessageDefinition): void {
-        this.writer(message, this.transportOptions);
+        this.writer(message, this.transportOptions, this.stats);
     }
 
     /**
@@ -279,7 +299,7 @@ export abstract class RpcKernelBaseConnection {
     }
 
     createMessageBuilder(): RpcMessageBuilder {
-        return new RpcMessageBuilder(this.logger, this.writer, this.transportOptions, this.messageId++);
+        return new RpcMessageBuilder(this.stats, this.logger, this.writer, this.transportOptions, this.messageId++);
     }
 
     /**
@@ -294,12 +314,19 @@ export abstract class RpcKernelBaseConnection {
         return timer;
     }
 
-    public close(): void {
+    public close(reason: string | Error = 'closed'): void {
+        if (this.closed) return;
+
         this.closed = true;
         for (const subject of this.replies.values()) {
             subject.disconnect();
         }
         this.replies.clear();
+        this.stats.increase('connections', -1);
+        this.eventDispatcher.dispatch(onRpcConnectionClose, () => ({
+            reason,
+            context: { connection: this, injector: this.injector },
+        }), this.injector);
         for (const timeout of this.timeoutTimers) clearTimeout(timeout);
         if (this.onCloseResolve) this.onCloseResolve();
         arrayRemoveItem(this.connections.connections, this);
@@ -307,10 +334,12 @@ export abstract class RpcKernelBaseConnection {
     }
 
     public feed(buffer: Uint8Array, bytes?: number): void {
+        this.stats.increase('incomingBytes', bytes ?? buffer.byteLength);
         this.reader.feed(buffer, bytes);
     }
 
     public handleMessage(message: RpcMessage): void {
+        this.stats.increase('incoming', 1);
         if (message.routeType === RpcMessageRouteType.server) {
             //initiated by the server, so we check replies
             const callback = this.replies.get(message.id);
@@ -320,7 +349,7 @@ export abstract class RpcKernelBaseConnection {
             }
         }
 
-        const response = new RpcMessageBuilder(this.logger, this.writer, this.transportOptions, message.id);
+        const response = new RpcMessageBuilder(this.stats, this.logger, this.writer, this.transportOptions, message.id);
         this.onMessage(message, response);
     }
 
@@ -353,7 +382,7 @@ export abstract class RpcKernelBaseConnection {
             //send a message with the same id. Don't use sendMessage() again as this would lead to a memory leak
             // and a new id generated. We want to use the same id.
             const message = createRpcMessage(id, type, body, RpcMessageRouteType.server, receiveType);
-            this.writer(message, this.transportOptions);
+            this.writer(message, this.transportOptions, this.stats);
         };
 
         const subject = new RpcMessageSubject(continuation, () => {
@@ -363,7 +392,7 @@ export abstract class RpcKernelBaseConnection {
         this.replies.set(id, subject);
 
         const message = createRpcMessage(id, type, body, RpcMessageRouteType.server, receiveType);
-        this.writer(message, this.transportOptions);
+        this.writer(message, this.transportOptions, this.stats);
 
         return subject;
     }
@@ -372,9 +401,11 @@ export abstract class RpcKernelBaseConnection {
 export class RpcKernelConnections {
     public connections: RpcKernelBaseConnection[] = [];
 
+    public stats: RpcTransportStats = new RpcTransportStats;
+
     broadcast(buffer: RpcMessageDefinition) {
         for (const connection of this.connections) {
-            connection.writer(buffer, connection.transportOptions);
+            connection.writer(buffer, connection.transportOptions, this.stats);
         }
     }
 }
@@ -385,33 +416,39 @@ export class RpcCache {
 
 export class RpcKernelConnection extends RpcKernelBaseConnection {
     public myPeerId?: string;
-    protected actionHandler = new RpcServerAction(this.cache, this, this.controllers, this.injector, this.security, this.sessionState, this.logger, this.hooks);
+    protected actionHandler = new RpcServerAction(this.stats, this.cache, this, this.controllers, this.injector, this.eventDispatcher, this.security, this.sessionState, this.logger);
 
     public routeType: RpcMessageRouteType.client | RpcMessageRouteType.server = RpcMessageRouteType.client;
+    protected context: { connection: RpcKernelBaseConnection, injector: InjectorContext } = { connection: this, injector: this.injector };
 
     constructor(
+        stats: RpcStats,
         logger: Logger,
         transport: TransportConnection,
         connections: RpcKernelConnections,
+        injector: InjectorContext,
+        eventDispatcher: EventDispatcher,
         protected cache: RpcCache,
         protected controllers: Map<string, { controller: ClassType, module?: InjectorModule }>,
         protected security = new RpcKernelSecurity(),
-        protected injector: InjectorContext,
         protected peerExchange: RpcPeerExchange,
-        protected hooks: RpcHooks,
     ) {
-        super(logger, transport, connections);
+        super(stats, logger, transport, connections, injector, eventDispatcher);
         this.onClose.then(async () => {
             try {
                 await this.peerExchange.deregister(this.id);
                 await this.actionHandler.onClose();
-                this.hooks.onClose(this, this.injector);
             } catch (e) {
-                logger.scoped('RPC').error('Could no deregister/action close: ' + e);
+                logger.error('Could no deregister/action close: ' + e);
             }
         });
         //register the current client so it can receive messages
         this.peerExchange.register(this.id, this.transportConnection);
+    }
+
+
+    public close(): void {
+        super.close();
     }
 
     async onRequest(basePath: string, request: RpcHttpRequest, response: RpcHttpResponse) {
@@ -423,7 +460,7 @@ export class RpcKernelConnection extends RpcKernelBaseConnection {
         const url = new URL(request.url || '', 'http://localhost/' + basePath);
 
         try {
-            const messageResponse = new RpcMessageBuilder(this.logger, (message: RpcMessageDefinition, options: TransportOptions, progress?: SingleProgress) => {
+            const messageResponse = new RpcMessageBuilder(this.stats, this.logger, (message: RpcMessageDefinition, options: TransportOptions, stats: RpcTransportStats, progress?: SingleProgress) => {
                 response.setHeader('Content-Type', 'application/json');
                 response.setHeader('X-Message-Type', message.type);
                 response.setHeader('X-Message-Composite', String(!!message.composite));
@@ -484,7 +521,7 @@ export class RpcKernelConnection extends RpcKernelBaseConnection {
         if (message.routeType == RpcMessageRouteType.peer && message.getPeerId() !== this.myPeerId) {
             // console.log('Redirect peer message', RpcTypes[message.type]);
             if (!await this.security.isAllowedToSendToPeer(this.sessionState.getSession(), message.getPeerId())) {
-                new RpcMessageBuilder(this.logger, this.writer, this.transportOptions, message.id).error(new RpcError('Access denied'));
+                new RpcMessageBuilder(this.stats, this.logger, this.writer, this.transportOptions, message.id).error(new RpcError('Access denied'));
                 return;
             }
             this.peerExchange.redirect(message);
@@ -498,12 +535,12 @@ export class RpcKernelConnection extends RpcKernelBaseConnection {
         }
 
         if (message.type === RpcTypes.Ping) {
-            this.writer(createRpcMessage(message.id, RpcTypes.Pong), this.transportOptions);
+            this.writer(createRpcMessage(message.id, RpcTypes.Pong), this.transportOptions, this.stats);
             return;
         }
 
         //all outgoing replies need to be routed to the source via sourceDest messages.
-        const response = new RpcMessageBuilder(this.logger, this.writer, this.transportOptions, message.id, this.id, message.routeType === RpcMessageRouteType.peer ? message.getSource() : undefined);
+        const response = new RpcMessageBuilder(this.stats, this.logger, this.writer, this.transportOptions, message.id, this.id, message.routeType === RpcMessageRouteType.peer ? message.getSource() : undefined);
         response.routeType = this.routeType;
 
         try {
@@ -535,14 +572,29 @@ export class RpcKernelConnection extends RpcKernelBaseConnection {
 
     protected async authenticate(message: RpcMessage, response: RpcMessageBuilder) {
         const body = message.parseBody<rpcAuthenticate>();
+        const event = new DataEvent<RpcAuthEventStart>({
+            phase: 'start', context: this.context, token: body.token,
+        });
+        await this.eventDispatcher.dispatch(onRpcAuth, event, this.injector);
+
         try {
-            const session = await this.security.authenticate(body.token, this);
+            let session = event.data.session;
+            if ('undefined' === typeof session) {
+                session = await this.security.authenticate(body.token, this);
+            }
+            await this.eventDispatcher.dispatch(onRpcAuth, () => ({
+                phase: 'success', context: this.context, token: body.token, session,
+            }), this.injector);
             this.sessionState.setSession(session);
+
             response.reply<rpcResponseAuthenticate>(RpcTypes.AuthenticateResponse, { username: session.username });
         } catch (error) {
+            await this.eventDispatcher.dispatch(onRpcAuth, () => ({
+                phase: 'fail', context: this.context, token: body.token, error: ensureError(error, RpcError),
+            }), this.injector);
             if (error instanceof AuthenticationError) throw new RpcError(error.message);
             this.logger.error('authenticate failed', error);
-            throw new AuthenticationError();
+            throw new AuthenticationError('Authentication failed', { cause: error });
         }
     }
 
@@ -587,31 +639,12 @@ export class RpcKernelConnection extends RpcKernelBaseConnection {
 
 export type OnConnectionCallback = (connection: RpcKernelConnection, injector: InjectorContext, logger: LoggerInterface) => void;
 
-export class RpcHooks {
-    onConnection(connection: RpcKernelConnection, injector: InjectorContext) {
-
-    }
-
-    onClose(connection: RpcKernelConnection, injector: InjectorContext) {
-
-    }
-
-    onAction(action: RpcActionHook, injector: InjectorContext) {
-
-    }
-
-    onActionSuccess(action: RpcActionHookSuccess, injector: InjectorContext) {
-
-    }
-
-    onActionError(action: RpcActionHookError, injector: InjectorContext) {
-
-    }
-}
 
 /**
  * The kernel is responsible for parsing the message header, redirecting to peer if necessary, loading the body parser,
  * and encode/send outgoing messages.
+ *
+ * @reflection never
  */
 export class RpcKernel {
     public readonly controllers = new Map<string, { controller: ClassType, module: InjectorModule }>();
@@ -626,14 +659,9 @@ export class RpcKernel {
     protected onConnectionListeners: OnConnectionCallback[] = [];
     protected autoInjector: boolean = false;
 
+    public stats = new RpcStats();
+
     public injector: InjectorContext;
-
-    private _hooks?: RpcHooks;
-
-    public get hooks(): RpcHooks {
-        if (this._hooks) return this._hooks;
-        return this._hooks = this.injector.get(RpcHooks);
-    }
 
     constructor(
         injector?: InjectorContext | NormalizedProvider[],
@@ -643,19 +671,35 @@ export class RpcKernel {
             this.injector = injector;
         } else {
             this.injector = InjectorContext.forProviders([
+                EventDispatcher,
                 { provide: SessionState, scope: 'rpc' },
                 { provide: RpcKernelSecurity, scope: 'rpc' },
 
                 //will be provided when scope is created
                 { provide: RpcKernelConnection, scope: 'rpc', useValue: undefined },
+                { provide: RpcKernelBaseConnection, scope: 'rpc', useValue: undefined },
 
-                { provide: RpcHooks },
                 { provide: Logger, useValue: logger },
 
                 ...(injector || []),
             ]);
             this.autoInjector = true;
         }
+    }
+
+    /**
+     * Register a new event listener for given token.
+     *
+     * order: The lower the order, the sooner the listener is called. Default is 0.
+     */
+    listen<T extends EventToken<any>>(eventToken: T, callback: EventListenerCallback<T>, order: number = 0): EventDispatcherUnsubscribe {
+        return this.getEventDispatcher().listen(eventToken, callback, order);
+    }
+
+    public getEventDispatcher(): EventDispatcher {
+        const result = this.injector.get(EventDispatcher);
+        this.getEventDispatcher = () => result;
+        return result;
     }
 
     public onConnection(callback: OnConnectionCallback) {
@@ -690,10 +734,22 @@ export class RpcKernel {
     createConnection(transport: TransportConnection, injector?: InjectorContext): RpcKernelBaseConnection {
         if (!injector) injector = this.injector.createChildScope('rpc');
 
-        const connection = new this.RpcKernelConnection(this.logger, transport, this.connections, this.cache, this.controllers, injector.get(RpcKernelSecurity), injector, this.peerExchange, this.hooks);
+        const connection = new this.RpcKernelConnection(
+            new ForwardedRpcStats(this.stats),
+            this.logger.scoped('rpc:connection'),
+            transport,
+            this.connections,
+            injector,
+            this.getEventDispatcher(),
+            this.cache,
+            this.controllers,
+            injector.get(RpcKernelSecurity),
+            this.peerExchange,
+        );
         injector.set(RpcKernelConnection, connection);
+        injector.set(RpcKernelBaseConnection, connection);
         for (const on of this.onConnectionListeners) on(connection, injector, this.logger);
-        this.hooks.onConnection(connection, injector);
+        this.getEventDispatcher().dispatch(onRpcConnection, { context: { connection, injector } });
         return connection;
     }
 }

--- a/packages/rpc/src/utils.ts
+++ b/packages/rpc/src/utils.ts
@@ -13,6 +13,10 @@ import { isFunction } from '@deepkit/core';
  *
  * Teardown is also called when the producer errors or completes.
  *
+ * You should normally prefer using Observables (with instantObservable)
+ * over Subjects, as Subjects are not lazy and start emitting values
+ * immediately when created.
+ *
  * ```typescript
  * class Controller {
  *   @rpc.action()
@@ -58,7 +62,8 @@ async function resolveProducer<T>(producer: InstanceProducer<T>): Promise<T> {
 
 /**
  * Returns a Subject that is immediately subscribed to the given producer.
- * The producer can be a Promise, a function that returns a Promise, or a Subject.
+ *
+ * The producer can be a Promise or a function that returns a Promise.
  *
  * Note that the Subject will be requested from the Promise right away.
  *
@@ -86,16 +91,24 @@ export function instantSubject<T>(producer: InstanceProducer<Subject<T>>): Subje
 }
 
 /**
- * Returns an Observable that, when subscribed to, calls the producer and subscribes to the returned Observable.
- * The producer can be a Promise, a function that returns a Promise, or an Observable.
+ * Creates an Observable that resolves the given producer when subscribed to.
+ * It also automatically disconnects the Observable when unsubscribed from.
  *
- * The Observable from the RPC on the server will be automatically subscribed and unsubscribed.
+ * The producer can be a Promise or a function that returns a Promise.
+ *
+ * This function takes care of disconnecting the Observable when
+ * unsubscribed from. This is the preferred way to handle Observables from RPC
+ * actions since it cleans up resources on the server when done working with
+ * the Observable.
+ *
+ * @see disconnectObservable
  *
  * ```typescript
  * const client = new RpcClient();
  * const controller = client.controller<MyController>('controller');
  *
- * // normally you would do this:
+ * // normally you would do this. Note that you are the owner of the Observable
+ * // and you need to call unsubscribe() when you are done with it.
  * const observable = await controller.subscribeChats('asd');
  *
  * // but with instantObservable you can do this, allowing you to get
@@ -105,13 +118,51 @@ export function instantSubject<T>(producer: InstanceProducer<Subject<T>>): Subje
  * // or with a function, which is useful when you only want to do RPC calls
  * // when the Observable is actually subscribed to.
  * const observable = instantObservable(() => controller.subscribeChats('asd'));
+ * ```
  */
 export function instantObservable<T>(producer: InstanceProducer<Observable<T>>): Observable<T> {
     return new Observable<T>((observer) => {
+        let active: Observable<T> | undefined;
         resolveProducer(producer).then((o) => {
             o.subscribe(observer);
+            active = o;
         }, (error) => {
             observer.error(error);
         });
+        return () => {
+            if (active) disconnectObservable(active);
+        }
     });
+}
+
+/**
+ * Every Observable that was created from an RPC action needs to be disconnected
+ * when done working with it. In normal RXJS environment the garbage collector
+ * would take care of this, but in the RPC world we need to manually disconnect
+ * the Observable to free up resources on the server.
+ *
+ * Note: The server has to keep the Observable alive as long as the client
+ * is connected. This is required to be able to subscribe to the Observable
+ * again. When the client disconnects, the server disconnects the Observable
+ * automatically. But when the client is connected for a longer time, the client
+ * should manually disconnect the Observable when done working with it.
+ *
+ * This means concretely that if you call an RPC action that returns an
+ * Observable 100x, we need to keep 100 Observables alive on the server.
+ * When the client disconnects, the server will automatically disconnect
+ * all 100 Observables, but if the client stays connected, the server will
+ * keep all 100 Observables alive. This is why it's important to disconnect
+ * Observables when done working with them.
+ *
+ * An alternative way to make this more explicit is working with Subjects
+ * instead of Observables. Whenever a Subject is created from an RPC action,
+ * the client has to call subject.complete() when done working with it.
+ * This has other drawbacks though, like the client can't resubscribe to
+ * the Subject again, and the Subject starts emitting values immediately
+ * when created without waiting for a subscription.
+ */
+export function disconnectObservable<T>(observable: Observable<T>): void {
+    if ('disconnect' in observable && isFunction((observable as any).disconnect)) {
+        (observable as any).disconnect();
+    }
 }

--- a/packages/rpc/tests/connection.spec.ts
+++ b/packages/rpc/tests/connection.spec.ts
@@ -2,6 +2,9 @@ import { expect, test } from '@jest/globals';
 import { RpcKernel } from '../src/server/kernel.js';
 import { RpcClient } from '../src/client/client.js';
 import { TransportClientConnection } from '../src/transport.js';
+import { rpc } from '../src/decorators';
+import { DirectClient } from '../src/client/client-direct';
+import { sleep } from '@deepkit/core';
 
 test('connect', async () => {
     const kernel = new RpcKernel();
@@ -48,4 +51,49 @@ test('connect', async () => {
     connections[0].onError(new Error('test'));
     expect(errors[0].message).toEqual('test');
     expect(client.transporter.isConnected()).toBe(false);
+});
+
+test('stats', async () => {
+    class Controller {
+        @rpc.action()
+        test1(name: string) {
+
+        }
+    }
+
+    const kernel = new RpcKernel();
+    kernel.registerController(Controller, 'main');
+
+    async function createClient(callback: (client: RpcClient) => Promise<void>) {
+        const client = new DirectClient(kernel);
+        await callback(client);
+        await sleep(0);
+        return client;
+    }
+
+    expect(kernel.stats.connections).toBe(0);
+    const c1 = await createClient(async (client) => {
+        await client.connect();
+    });
+
+    expect(kernel.stats.connections).toBe(1);
+    expect(kernel.stats.actions).toBe(0);
+
+    //due to handshake
+    expect(kernel.stats.incoming).toBe(1);
+    expect(kernel.stats.incomingBytes).toBe(12);
+    expect(kernel.stats.outgoing).toBe(1);
+    expect(kernel.stats.outgoingBytes).toBeGreaterThan(12);
+
+    const c2 = await createClient(async (client) => {
+        await client.controller<Controller>('main').test1('Peter');
+    });
+    expect(kernel.stats.connections).toBe(2);
+    expect(kernel.stats.actions).toBe(1);
+
+    await c1.disconnect();
+    expect(kernel.stats.connections).toBe(1);
+    await c2.disconnect();
+    expect(kernel.stats.connections).toBe(0);
+    expect(kernel.stats.totalConnections).toBe(2);
 });

--- a/packages/rpc/tests/controller.spec.ts
+++ b/packages/rpc/tests/controller.spec.ts
@@ -2,7 +2,7 @@ import { assertType, entity, Minimum, Positive, ReflectionClass, ReflectionKind 
 import { expect, test } from '@jest/globals';
 import { DirectClient, RpcDirectClientAdapter } from '../src/client/client-direct.js';
 import { getActions, rpc, RpcController } from '../src/decorators.js';
-import { RpcHooks, RpcKernel, RpcKernelConnection } from '../src/server/kernel.js';
+import { RpcKernel, RpcKernelConnection } from '../src/server/kernel.js';
 import { Session, SessionState } from '../src/server/security.js';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { getClassName, sleep } from '@deepkit/core';
@@ -11,7 +11,8 @@ import { Logger, MemoryLogger } from '@deepkit/logger';
 import { RpcClient } from '../src/client/client.js';
 import { InjectorContext } from '@deepkit/injector';
 import { RpcControllerState } from '../src/client/action.js';
-import { RpcActionHook, RpcActionHookError, RpcActionHookSuccess } from '../src/server/action.js';
+import { onRpcAction, onRpcAuth, onRpcConnection, onRpcConnectionClose, onRpcControllerAccess } from '../src/events.js';
+import { eventWatcher } from '@deepkit/event';
 
 test('default name', () => {
     @rpc.controller()
@@ -854,8 +855,7 @@ test('Observable<Buffer>', async () => {
     }
 });
 
-
-test('hooks', async () => {
+test('events', async () => {
     class Controller {
         @rpc.action()
         async test1(): Promise<string> {
@@ -869,72 +869,73 @@ test('hooks', async () => {
         }
     }
 
-    let _connection: RpcKernelConnection | undefined;
-    let _action: RpcActionHook | undefined;
-    let _actionSuccess: RpcActionHookSuccess | undefined;
-    let _actionError: RpcActionHookError | undefined;
-
-    class MyRpcHooks extends RpcHooks {
-        onConnection(connection: RpcKernelConnection, injector: InjectorContext) {
-            expect(connection).toBeInstanceOf(RpcKernelConnection);
-            expect(injector).toBeInstanceOf(InjectorContext);
-            _connection = connection;
-        }
-
-        onClose(connection: RpcKernelConnection, injector: InjectorContext) {
-            expect(connection).toBeInstanceOf(RpcKernelConnection);
-            expect(injector).toBeInstanceOf(InjectorContext);
-            _connection = undefined;
-        }
-
-        onAction(action: RpcActionHook, injector: InjectorContext) {
-            expect(injector).toBeInstanceOf(InjectorContext);
-            _action = action;
-        }
-
-        onActionSuccess(action: RpcActionHookSuccess, injector: InjectorContext) {
-            expect(injector).toBeInstanceOf(InjectorContext);
-            _actionSuccess = action;
-        }
-
-        onActionError(action: RpcActionHookError, injector: InjectorContext) {
-            expect(injector).toBeInstanceOf(InjectorContext);
-            _actionError = action;
-        }
-    }
-
-    const kernel = new RpcKernel([
-        { provide: RpcHooks, useClass: MyRpcHooks },
-    ]);
+    const kernel = new RpcKernel();
     kernel.registerController(Controller, 'myController');
+    kernel.listen(onRpcAuth, event => {
+        event.data.session = new Session('abc', event.data.token);
+    });
     const client = new DirectClient(kernel);
     const controller = client.controller<Controller>('myController');
 
+    const watcher = eventWatcher(kernel.getEventDispatcher(), [
+        onRpcConnection,
+        onRpcAction,
+        onRpcConnectionClose,
+        onRpcControllerAccess,
+        onRpcAuth,
+    ]);
+
     await controller.test1();
 
-    expect(_connection).toBeInstanceOf(RpcKernelConnection);
-    expect(_action).toEqual({
-        actionData: {}, actionGroups: [],
-        actionName: 'test1',
-        connection: _connection, controllerClassType: Controller,
-        controllerName: 'myController',
-    });
-    expect(_actionSuccess).toMatchObject({
-        actionData: {}, actionGroups: [],
-        actionName: 'test1',
-        connection: _connection, controllerClassType: Controller,
-        controllerName: 'myController',
-    });
-    expect(_actionSuccess!.start).toBeLessThan(_actionSuccess!.end);
-    expect(_actionSuccess!.types).toBeGreaterThan(0);
-    expect(_actionSuccess!.parseBody).toBeGreaterThan(0);
-    expect(_actionSuccess!.validate).toBeGreaterThan(0);
-    expect(_actionSuccess!.controllerAccess).toBeGreaterThan(0);
-    expect(_actionSuccess!.result).toBe('test1');
+    await client.disconnect();
 
-    await expect(controller.test2()).rejects.toThrow('test2');
-    expect(_actionError!.error).toBeInstanceOf(Error);
-    expect(_actionError!.error).toMatchObject({ message: 'test2' });
+    expect(watcher.messages).toEqual([
+        'rpc.connection',
+        'rpc.action phase=start',
+        'rpc.controllerAccess phase=start',
+        'rpc.controllerAccess phase=success',
+        'rpc.action phase=success',
+        'rpc.connectionClose reason=closed',
+    ]);
+
+    expect(kernel.stats).toMatchObject({
+        actions: 1,
+        connections: 0,
+        totalConnections: 1,
+    });
+
+    expect(watcher.get(onRpcAction, (event) => event.phase === 'success').timing)
+        .toEqual({
+            start: expect.any(Number),
+            end: expect.any(Number),
+            types: expect.any(Number),
+            parseBody: expect.any(Number),
+            validate: expect.any(Number),
+            controllerAccess: expect.any(Number),
+        });
+
+    client.token.set('abc');
+    watcher.clear();
+    await controller.test1();
+    await client.disconnect();
+
+    expect(watcher.messages).toEqual([
+        'rpc.connection',
+        'rpc.auth phase=start token=abc',
+        'rpc.auth phase=success token=abc',
+        'rpc.action phase=start',
+        'rpc.controllerAccess phase=start',
+        'rpc.controllerAccess phase=success',
+        'rpc.action phase=success',
+        'rpc.connectionClose reason=closed',
+    ]);
+
+    expect(kernel.stats).toMatchObject({
+        actions: 2,
+        connections: 0,
+        totalConnections: 2,
+    });
+
 });
 
 test('connection disconnect client', async () => {

--- a/packages/rpc/tests/entity-state.spec.ts
+++ b/packages/rpc/tests/entity-state.spec.ts
@@ -4,9 +4,7 @@ import { EntitySubject, rpcEntityPatch, RpcTypes } from '../src/model.js';
 import { DirectClient } from '../src/client/client-direct.js';
 import { EntitySubjectStore } from '../src/client/entity-state.js';
 import { rpc } from '../src/decorators.js';
-import { RpcHooks, RpcKernel, RpcKernelConnection } from '../src/server/kernel.js';
-import { InjectorContext } from '@deepkit/injector';
-import { RpcKernelSecurity } from '../src/server/security.js';
+import { RpcKernel, RpcKernelConnection } from '../src/server/kernel.js';
 
 test('EntitySubjectStore multi', () => {
     class MyModel {
@@ -101,15 +99,11 @@ test('controller', async () => {
         }
     }
 
-    const kernel = new RpcKernel(InjectorContext.forProviders([
-        { provide: RpcKernelConnection, scope: 'rpc', useValue: undefined },
-        { provide: RpcKernelSecurity, scope: 'rpc' },
-        { provide: Controller, scope: 'rpc' },
-        { provide: RpcHooks },
-    ]));
+    const kernel = new RpcKernel();
     kernel.registerController(Controller, 'myController');
 
     const client = new DirectClient(kernel);
+    await client.connect();
     const controller = client.controller<Controller>('myController');
 
     {

--- a/packages/rpc/tsconfig.json
+++ b/packages/rpc/tsconfig.json
@@ -18,6 +18,10 @@
       "dot-prop",
       "fs-extra",
       "node"
+    ],
+    "lib": [
+      "es2020",
+      "es2021.weakref"
     ]
   },
   "reflection": true,

--- a/packages/type/tests/serializer-api.spec.ts
+++ b/packages/type/tests/serializer-api.spec.ts
@@ -1,5 +1,14 @@
 import { expect, test } from '@jest/globals';
-import { EmptySerializer, executeTemplates, SerializationError, serializer, Serializer, TemplateRegistry, TemplateState, TypeGuardRegistry } from '../src/serializer.js';
+import {
+    EmptySerializer,
+    executeTemplates,
+    SerializationError,
+    serializer,
+    Serializer,
+    TemplateRegistry,
+    TemplateState,
+    TypeGuardRegistry,
+} from '../src/serializer.js';
 import { ReflectionKind, stringifyResolvedType } from '../src/reflection/type.js';
 import { CompilerContext } from '@deepkit/core';
 import { cast, deserialize, serialize } from '../src/serializer-facade.js';


### PR DESCRIPTION
feat(rpc): automatically garbage collect observables + new event system + stats collection

- Fixed various soft memory leaks and hard to untangle circular references (making GC easier)

- All observables are now tracked via WeakRef and FinalizationRegistry, and frees them up on the server automatically when the client garbage collected them.
  - previously it was required that all clients unsubscribe from observables and subjects otherwise there will always be a state on the server for these objects. now, the client can just use the received observable/subject and once they are no longer used (garbage collected by the javascript engine) the rpc client detects it and frees the resources on the server automatically.

- Added new event system to track and control what the rpc kernel and connections do.
`onRpcConnection`, `onRpcConnectionClose`, `onRpcAction`, `onRpcAuth`, `onRpcControllerAccess`

This not only allows to hook into various stages but also allows to replace RpcKernelSecurity for authentication and controller access:

```typescript
const kernel = new RpcKernel();

kernel.listen(onRpcConnection, (event, logger: Logger) => {
    logger.log(`New Connection`);
});

kernel.listen(onRpcAction, (event, logger: Logger) => {
    logger.log(`action ${event.data.action}`, event.data.phase, event.data.timing);
});

kernel.listen(onRpcAuth, (event, logger: Logger) => {
    logger.log(`authenticating`);
    if (event.data.token === 'secret')  {
       event.data.session = new Session('Admin', '');
    }
});

kernel.listen(onRpcControllerAccess, (event, logger: Logger) => {
    logger.log(`authenticating`);
    if (event.data.session.username === 'Admin')  {
       event.data.granted = true;
    }
});
```

- Added statistics object RpcStats which collects statistics about the kernel, traffic, connections, actions, and observables.

```typescript
const kernel = new RpcKernel();

kernel.stats.connections // currently active connections
kernel.stats.totalConnections // all handled connections so far

kernel.stats.actions
kernel.stats.incomingBytes
kernel.stats.outgoingBytes

kernel.stats.active.observables //how many active observables there are
kernel.stats.active.subscriptions //how many observable subscriptions there are
// and more
```

also each RpcKernelConnection has a `stats` object with the same data