### PR TITLE
fix(framework): add missing BrokerKeyValue provider export

### DIFF
--- a/packages/framework/src/module.ts
+++ b/packages/framework/src/module.ts
@@ -146,6 +146,7 @@ export class FrameworkModule extends createModuleClass({
         BrokerLock,
         BrokerQueue,
         BrokerBus,
+        BrokerKeyValue,
         BrokerServer,
 
         FilesystemRegistry,


### PR DESCRIPTION
### Summary of changes


<!-- My summary here. -->
Adds missing export for BrokerKeyValue provider to be used in injection container

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
