### PR TITLE
fix(type-compiler) emit optional metadata for methods

### DIFF
--- a/packages/type-compiler/src/compiler.ts
+++ b/packages/type-compiler/src/compiler.ts
@@ -1778,6 +1778,10 @@ export class ReflectionTransformer implements CustomTransformer {
                                 ? ReflectionOp.method : ReflectionOp.function, program.findOrAddStackEntry(name),
                 );
 
+                if ((isMethodSignature(narrowed) || isMethodDeclaration(narrowed)) && narrowed.questionToken) {
+                    program.pushOp(ReflectionOp.optional);
+                }
+
                 if (isMethodDeclaration(narrowed)) {
                     if (hasModifier(narrowed, SyntaxKind.PrivateKeyword)) program.pushOp(ReflectionOp.private);
                     if (hasModifier(narrowed, SyntaxKind.ProtectedKeyword)) program.pushOp(ReflectionOp.protected);

--- a/packages/type/tests/compiler.spec.ts
+++ b/packages/type/tests/compiler.spec.ts
@@ -644,6 +644,30 @@ test('emit function types in objects', () => {
     } as Type);
 });
 
+test('emit optional for method signatures', () => {
+    const code = `
+    interface Wrap {
+        maybe?(item: string): any;
+    }
+    return typeOf<Wrap>();
+    `;
+    const js = transpile(code);
+    console.log('js', js);
+    const type = transpileAndReturn(code);
+    expectEqualType(type, {
+        kind: ReflectionKind.objectLiteral,
+        types: [
+            {
+                kind: ReflectionKind.methodSignature,
+                name: 'maybe',
+                optional: true,
+                parameters: [{ kind: ReflectionKind.parameter, name: 'item', type: { kind: ReflectionKind.string } }],
+                return: { kind: ReflectionKind.any }
+            }
+        ]
+    } as Type);
+});
+
 test('emit class extends types', () => {
     const code = `
         class ClassA<T> { item: T; }


### PR DESCRIPTION
### Summary of changes


* fix(type-compiler): generate optional metadata for method signatures and method declarations #647 



### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
