### PR TITLE
fix(http): proper handling of encoded & multipart values, plus multipart JSON support

### DIFF
--- a/packages/http/src/module.config.ts
+++ b/packages/http/src/module.config.ts
@@ -1,4 +1,4 @@
-export interface HttpParserOptions {
+export interface FormidableOptions {
     /**
      * sets encoding for incoming form fields
      *
@@ -78,15 +78,16 @@ export interface HttpParserOptions {
     hashAlgorithm?: string | false | undefined;
 
     /**
-     * when you call the .parse method, the files argument (of the callback) will contain arrays of
-     * files for inputs which submit multiple files using the HTML5 multiple attribute. Also, the
-     * fields argument will contain arrays of values for fields that have names ending with '[]'
-     *
-     * @default false
+     * plugin imports from formidable package
      */
-    multiples?: boolean | undefined;
+    enabledPlugins?: any[] | undefined;
+}
 
-    enabledPlugins?: string[] | undefined;
+export interface HttpParserOptions extends FormidableOptions {
+    /**
+     * allow extracting JSON from a multipart/form-data request
+     */
+    multipartJsonKey?: string | undefined;
 }
 
 export class HttpConfig {

--- a/packages/http/tests/parser.spec.ts
+++ b/packages/http/tests/parser.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "@jest/globals";
+import { HttpConfig } from "../src/module.config";
+import { createHttpKernel } from "./utils";
+import { HttpRouterRegistry, UploadedFile } from "../src/router";
+import { HttpBody, HttpRequest } from "../src/model";
+import { json } from "stream/consumers";
+
+test('multipart posts', async () => {
+    const httpConfig = new HttpConfig();
+    httpConfig.parser.multipartJsonKey = 'json';
+
+    const httpKernel = createHttpKernel(
+        (registry: HttpRouterRegistry) => {
+            interface Input {
+                file: UploadedFile;
+                jsonA: string;
+                jsonB: number;
+                singleField: string;
+                multiField: string[];
+            }
+            registry.post('/', (body: HttpBody<Input>) => body);
+        },
+        [],
+        [],
+        [],
+        [],
+        httpConfig
+    );
+
+    const response = await httpKernel.request(HttpRequest.POST('/').multiPart([
+        { name: 'file', file: Buffer.from('the quick brown fox jumps over the lazy dog'), fileName: 'fox.txt' },
+        {
+            name: 'json',
+            value: JSON.stringify({
+                jsonA: 'someValue',
+                jsonB: 42
+            })
+        },
+        {
+            name: 'singleField',
+            value: 'singleValue',
+        },
+        {
+            name: 'multiField',
+            value: 'firstValue'
+        },
+        {
+            name: 'multiField',
+            value: 'secondValue'
+        }
+    ]));
+
+    expect(response.json).toMatchObject({
+        file: {
+            name: 'fox.txt',
+            size: 43,
+            path: expect.any(String),
+            type: 'application/octet-stream',
+        },
+        jsonA: 'someValue',
+        jsonB: 42,
+        singleField: 'singleValue',
+        multiField: ['firstValue', 'secondValue']
+    });
+});

--- a/packages/http/tests/utils.ts
+++ b/packages/http/tests/utils.ts
@@ -5,15 +5,17 @@ import { App, AppModule, MiddlewareFactory } from '@deepkit/app';
 import { EventListener } from '@deepkit/event';
 import { HttpModule } from '../src/module.js';
 import { HttpRouterRegistry } from '../src/router.js';
+import { HttpConfig } from '../src/module.config.js';
 
 export function createHttpKernel(
     controllers: (ClassType | { module: AppModule<any>, controller: ClassType })[] | ((registry: HttpRouterRegistry) => void) = [],
     providers: ProviderWithScope[] = [],
     listeners: (EventListener | ClassType)[] = [],
     middlewares: MiddlewareFactory[] = [],
-    modules: AppModule<any>[] = []
+    modules: AppModule<any>[] = [],
+    config?: HttpConfig
 ) {
-    const app = createHttpApp(controllers, providers, listeners, middlewares, modules);
+    const app = createHttpApp(controllers, providers, listeners, middlewares, modules, config);
 
     return app.get(HttpKernel);
 }
@@ -23,10 +25,11 @@ export function createHttpApp(
     providers: ProviderWithScope[] = [],
     listeners: (EventListener | ClassType)[] = [],
     middlewares: MiddlewareFactory[] = [],
-    modules: AppModule<any>[] = []
+    modules: AppModule<any>[] = [],
+    config: HttpConfig = new HttpConfig()
 ) {
     const imports: AppModule<any>[] = modules.slice(0);
-    imports.push(new HttpModule());
+    imports.push(new HttpModule().configure(config));
 
     if (isArray(controllers)) {
         for (const controller of controllers) {


### PR DESCRIPTION
### Summary of changes

Formidable 3.0 deprecated the `multiples` option and changed the functionality of urlencoded & multipart parsing to always output arrays (https://github.com/node-formidable/formidable/pull/730).

This PR automatically pulls up the value from single-element arrays, while leaving multi-element arrays as arrays, which fixes input validation for HTTP payloads when using urlencoded & multipart values (other payloads are unaffected).

Also adds an HttpParserConfig config (off by default) for enabling the extraction of JSON payloads alongside file uploads in multipart submissions:
```
const fd = new FormData();
fd.add('file', myFileInput.files[0]);
fd.add('json', '{"my": "other", "json": "payload"}');
```

Added multi-part parsing test, including single value, multi-value, JSON payload, and files.

### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [X] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
