### PR TITLE
feat(sql): support custom database field name filtering

### DIFF
--- a/packages/postgres/tests/postgres.spec.ts
+++ b/packages/postgres/tests/postgres.spec.ts
@@ -1,13 +1,8 @@
 import { expect, test } from '@jest/globals';
 import pg from 'pg';
-
-
-
 import { assertInstanceOf } from '@deepkit/core';
 import { DatabaseError, DatabaseInsertError, UniqueConstraintFailure } from '@deepkit/orm';
 import { AutoIncrement, DatabaseField, PrimaryKey, UUID, Unique, cast, entity, uuid } from '@deepkit/type';
-
-
 
 import { databaseFactory } from './factory.js';
 

--- a/packages/postgres/tests/postgres.spec.ts
+++ b/packages/postgres/tests/postgres.spec.ts
@@ -1,9 +1,16 @@
-import { AutoIncrement, cast, entity, PrimaryKey, Unique } from '@deepkit/type';
 import { expect, test } from '@jest/globals';
 import pg from 'pg';
-import { databaseFactory } from './factory.js';
-import { DatabaseError, DatabaseInsertError, UniqueConstraintFailure } from '@deepkit/orm';
+
+
+
 import { assertInstanceOf } from '@deepkit/core';
+import { DatabaseError, DatabaseInsertError, UniqueConstraintFailure } from '@deepkit/orm';
+import { AutoIncrement, DatabaseField, PrimaryKey, UUID, Unique, cast, entity, uuid } from '@deepkit/type';
+
+
+
+import { databaseFactory } from './factory.js';
+
 
 test('count', async () => {
     const pool = new pg.Pool({
@@ -229,5 +236,23 @@ test('unique constraint 1', async () => {
         const p = database.query(Model).filter({username: 'paul'}).patchOne({username: 'peter'});
         await expect(p).rejects.toThrow('Key (username)=(peter) already exists');
         await expect(p).rejects.toBeInstanceOf(UniqueConstraintFailure);
+    }
+});
+
+test('database field name with filter', async () => {
+    class User {
+        constructor(public id: UUID & PrimaryKey & DatabaseField<{ name: 'uuid' }>) {
+        }
+    }
+
+    const database = await databaseFactory([User]);
+
+    const user = new User(uuid());
+
+    await database.persist(user);
+
+    {
+        const dbUser = await database.query(User).filterField('id', user.id).findOne();
+        expect(dbUser.id).toEqual(user.id);
     }
 });

--- a/packages/sql/src/sql-builder.ts
+++ b/packages/sql/src/sql-builder.ts
@@ -125,7 +125,7 @@ export class SqlBuilder {
                 if (property.isDatabaseSkipped(model.adapterName)) continue;
                 if (model.isLazyLoaded(property.name)) continue;
 
-                this.sqlSelect.push(tableName + '.' + prepared.fieldMap[property.name].columnNameEscaped);
+                this.sqlSelect.push(tableName + '.' + prepared.fieldMap[property.name].columnNameEscaped + ' AS ' + this.platform.quoteIdentifier(property.name));
             }
         }
     }
@@ -402,6 +402,7 @@ export class SqlBuilder {
         for (const join of this.joins) {
             if (!join.join.query.model.sort) continue;
             const prepared = getPreparedEntity(this.adapter, join.join.query.classSchema);
+            // @ts-ignore
             for (const [name, sort] of Object.entries(join.join.query.model.sort)) {
                 order.push(`${join.join.as}.${prepared.fieldMap[name]?.columnNameEscaped || this.platform.quoteIdentifier(name)} ${sort}`);
             }


### PR DESCRIPTION
### Summary of changes
Added functionality to filter database fields by custom names via `DatabaseField` metadata. Updated tests for SQLite and Postgres to validate the new feature and ensured proper aliasing in SQL queries using the `AS` keyword.



<!-- My summary here. -->


### Relinquishment of Rights

Please mark following checkbox to confirm that you relinquish all rights of your changes:

- [x] I waive and relinquish all rights regarding this changes (including code, text, and images) to Deepkit UG (limited), Germany. This changes (including code, text, and images) are under MIT license without name attribution, copyright notice, and permission notice requirement.
